### PR TITLE
Minimum features for cathode benchmarking - set voltage, config vars, temp graph

### DIFF
--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1461,6 +1461,8 @@ class CathodeHeatingSubsystem:
             # if not min(cathode_model.x_data) <= heater_current <= max(cathode_model.x_data):
             #     self.log(f"Heater current {heater_current:.3f} is out of range [{min(cathode_model.x_data):.3f}, {max(cathode_model.x_data):.3f}]", LogLevel.WARNING)
 
+
+            '''
             # # Set voltage and current on the power supply
             if self.power_supplies and len(self.power_supplies) > index:
                  voltage_set_success = self.power_supplies[index].set_voltage(3, voltage)
@@ -1472,11 +1474,11 @@ class CathodeHeatingSubsystem:
                 
             # Confirm the set values
                  set_voltage, set_current = self.power_supplies[index].get_settings(3)
-                 if set_voltage is not None: # and set_current is not None:    
+                 if set_voltage is not None: and set_current is not None:    
                     voltage_mismatch = abs(set_voltage - voltage) > 0.01  # 0.01V tolerance
             #         current_mismatch = abs(set_current - heater_current) > 0.01  # 0.01A tolerance
                     
-                    if voltage_mismatch: # or current_mismatch:
+                    if voltage_mismatch: or current_mismatch:
                          self.log(f"Mismatch in set values for Cathode {['A', 'B', 'C'][index]}:", LogLevel.WARNING)
                          if voltage_mismatch:
                             self.log(f"  Voltage - Intended: {voltage:.2f}V, Actual: {set_voltage:.2f}V", LogLevel.WARNING)
@@ -1490,6 +1492,32 @@ class CathodeHeatingSubsystem:
                      self.log(f"Failed to confirm set values for Cathode {['A', 'B', 'C'][index]}. No valid response received", LogLevel.ERROR)
                      return False
                 
+                 self.user_set_voltages[index] = voltage
+            '''
+
+
+            # # Set voltage on the power supply
+            if self.power_supplies and len(self.power_supplies) > index: # why does this?
+                 voltage_set_success = self.power_supplies[index].set_voltage(3, voltage) # IMPORTANT
+                 if not voltage_set_success:
+                    self.log(f"Unable to set voltage: {voltage} for Cathode {['A', 'B', 'C'][index]}", LogLevel.ERROR) 
+                    return False
+                
+                # Confirm the set values
+                 set_voltage, set_current = self.power_supplies[index].get_settings(3)
+                 if set_voltage is not None: # and set_current is not None:    
+                    voltage_mismatch = abs(set_voltage - voltage) > 0.01  # 0.01V tolerance
+                    
+                    if voltage_mismatch:
+                         self.log(f"Mismatch in set values for Cathode {['A', 'B', 'C'][index]}:", LogLevel.WARNING)
+                         if voltage_mismatch:
+                            self.log(f"  Voltage - Intended: {voltage:.2f}V, Actual: {set_voltage:.2f}V", LogLevel.WARNING)
+                         return False
+                    else:
+                        self.log(f"Values confirmed for Cathode {['A', 'B', 'C'][index]}: {set_voltage:.2f}V", LogLevel.INFO)
+                 else:
+                     self.log(f"Failed to confirm set values for Cathode {['A', 'B', 'C'][index]}. No valid response received", LogLevel.ERROR)
+                     return False
                  self.user_set_voltages[index] = voltage
 
             # Calculate dependent variables


### PR DESCRIPTION
Removes all instances of the interpolate function in cathode_heating.py while still accurately setting the voltages on the cathode power supplies individually. Included photo evidence of each power supply being set correctly within a margin or error. 

Other benchmark features including the config variables (OVP, OCP, Slew Rate), temperature graph, and actual voltage and heat monitoring were tested to be functioning correctly and not altered. 


CATHODE A
![cathode_a_console](https://github.com/user-attachments/assets/ef1013fb-22e4-4ee9-93a1-7d7805cda0d7)
![cathode_a_ps](https://github.com/user-attachments/assets/44fd6325-3fa4-43f6-9b86-1060d458b4c1)


CATHODE B
![cathode_b_console](https://github.com/user-attachments/assets/fea0e72a-6a75-49cb-8527-e5366c23bbc5)
![cathode_b_ps](https://github.com/user-attachments/assets/552d4787-42d9-4f2d-8a67-60d723bbd25d)


CATHODE C
![cathode_c_console](https://github.com/user-attachments/assets/6ced412b-28f0-4a7d-8c78-1f5cc42ff1fd)
![cathode_c_ps](https://github.com/user-attachments/assets/9cebe2b5-fd0e-4525-b5be-cb20c3ee0dbc)


