### PR TITLE
Fix for initial spike in vacuum graph

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ def config_com_ports(saved_com_ports):
     # Close the PyInstaller splash if running as bundled executable
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         try:
-            import pyi_splash # type: ignore[import]
+            import pyi_splash
             pyi_splash.close()
         except ImportError:
             pass


### PR DESCRIPTION
Initial spike on vacuum graph that would show up on dashboard startup was removed. Also, we will now use raw pressure sensor data for the pressure value if it is valid to avoid rounding.
![IMG_3335](https://github.com/user-attachments/assets/92d54145-4eb9-4d4e-818c-f82a23c22aea)
