### PR TITLE
CCS current control: power supply 9104 driver cleanup 

### DIFF
--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -237,16 +237,16 @@ class PowerSupply9104:
                 # Set new voltage
                 for attempt in range(self.MAX_RETRIES):
                     try:
-                        if not self.set_voltage(preset, next_voltage):
+                       # Attempt to set voltage
+                        if self.set_voltage(preset, next_voltage):
+                            break # Success, exit retry loop
+                        else:
                             self.log(f"Attempt: {attempt} Failed to set voltage to {next_voltage:.2f}V.", LogLevel.ERROR)
-
                     except Exception as e:
                         self.log(f"Error during ramping step: {str(e)}. Aborting ramp.", LogLevel.ERROR)
-                        if callback:
-                            callback(False)
-                        return
-                    
-                if attempt > self.MAX_RETRIES:
+                        time.sleep(0.1) # brief pause before retry
+                else:
+                    # All retries failed
                     self.log(f"Failed to set voltage to {next_voltage:.2f}V. Aborting ramp", LogLevel.ERROR)
                     if callback:
                         callback(False)


### PR DESCRIPTION
Small fixes and hardening for the CCS power supply drivers (power_supply_9104.py). These should be merged prior to the implementation of tools to support current ramping. I recommend reviewing each change in order of commits.