### PR TITLE
Bugfix/graceful exit

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3,8 +3,6 @@ import sys
 import os
 import subsystem
 import tkinter as tk
-import threading
-import datetime
 from tkinter import ttk
 from tkinter import messagebox
 from utils import MessagesFrame, SetupScripts, LogLevel, MachineStatus

--- a/dashboard.py
+++ b/dashboard.py
@@ -106,15 +106,11 @@ class EBEAMSystemDashboard:
     def cleanup(self):
         """Closes all open com ports before quitting the application."""
 
-        self._dump_threads("cleanup start")
         print("Cleaning up com ports...")
         for name, subsystem in self.subsystems.items():
             if hasattr(subsystem, 'close_com_ports'):
-                self._log_cleanup_step(f"closing {name} ({subsystem.__class__.__name__})")
                 subsystem.close_com_ports()
-                self._log_cleanup_step(f"closed {name} ({subsystem.__class__.__name__})")
         print("Cleaned up com ports.")
-        self._dump_threads("after close_com_ports")
 
         '''Cancels all scheduled Dashboard updates before quitting the application.'''
         # First cancel updates in each subsystem
@@ -135,54 +131,7 @@ class EBEAMSystemDashboard:
         # Close logger and restore stdout while widgets still exist
         if hasattr(self, 'messages_frame') and hasattr(self.messages_frame, 'close'):
             self.messages_frame.close()
-        self._dump_threads("after cancel_updates and logger close")
 
-    def _dump_threads(self, label):
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        lines = [f"--- Thread dump: {label} @ {timestamp} ---"]
-        for thread in threading.enumerate():
-            lines.append(
-                f"Thread name={thread.name} "
-                f"ident={thread.ident} "
-                f"daemon={thread.daemon} "
-                f"alive={thread.is_alive()}"
-            )
-        payload = "\n".join(lines) + "\n"
-
-        try:
-            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
-            os.makedirs(log_dir, exist_ok=True)
-            dump_path = os.path.join(log_dir, "thread_dumps.txt")
-            with open(dump_path, "a", encoding="utf-8") as handle:
-                handle.write(payload)
-        except Exception:
-            pass
-
-        try:
-            sys.__stderr__.write(payload)
-            sys.__stderr__.flush()
-        except Exception:
-            pass
-
-    def _log_cleanup_step(self, message):
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        line = f"[{timestamp}] {message}\n"
-        try:
-            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
-            os.makedirs(log_dir, exist_ok=True)
-            dump_path = os.path.join(log_dir, "thread_dumps.txt")
-            with open(dump_path, "a", encoding="utf-8") as handle:
-                handle.write(line)
-        except Exception:
-            pass
-        try:
-            sys.__stderr__.write(line)
-            sys.__stderr__.flush()
-        except Exception:
-            pass
-            
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""
         self.main_pane = tk.PanedWindow(self.root, orient='vertical', sashrelief=tk.RAISED)

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,6 +3,7 @@ import sys
 import os
 import subsystem
 import tkinter as tk
+import threading
 from tkinter import ttk
 from tkinter import messagebox
 from utils import MessagesFrame, SetupScripts, LogLevel, MachineStatus
@@ -104,11 +105,13 @@ class EBEAMSystemDashboard:
     def cleanup(self):
         """Closes all open com ports before quitting the application."""
 
+        self._dump_threads("cleanup start")
         print("Cleaning up com ports...")
         for subsystem in self.subsystems.values():
             if hasattr(subsystem, 'close_com_ports'):
                 subsystem.close_com_ports()
         print("Cleaned up com ports.")
+        self._dump_threads("after close_com_ports")
 
         '''Cancels all scheduled Dashboard updates before quitting the application.'''
         # First cancel updates in each subsystem
@@ -126,8 +129,21 @@ class EBEAMSystemDashboard:
         # Now cancel machine status updates
         if hasattr(self.machine_status_frame, 'cancel_updates'):
             self.machine_status_frame.cancel_updates()
-        print("Dashboard upates cancelled.")
+        # Close logger and restore stdout while widgets still exist
+        if hasattr(self, 'messages_frame') and hasattr(self.messages_frame, 'close'):
+            self.messages_frame.close()
+        self._dump_threads("after cancel_updates and logger close")
 
+    def _dump_threads(self, label):
+        print(f"--- Thread dump: {label} ---")
+        for thread in threading.enumerate():
+            print(
+                f"Thread name={thread.name} "
+                f"ident={thread.ident} "
+                f"daemon={thread.daemon} "
+                f"alive={thread.is_alive()}"
+            )
+            
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""
         self.main_pane = tk.PanedWindow(self.root, orient='vertical', sashrelief=tk.RAISED)

--- a/dashboard.py
+++ b/dashboard.py
@@ -110,6 +110,13 @@ class EBEAMSystemDashboard:
                 subsystem.close_com_ports()
         print("Cleaned up com ports.")
 
+        '''Cancels all scheduled Dashboard updates before quitting the application.'''
+        print("Cancelling scheduled Dashboard updates...")
+        for subsystem in self.subsystems.values():
+            if hasattr(subsystem, 'cancel_updates'):
+                subsystem.cancel_updates()
+        print("Dashboard upates cancelled.")
+
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""
         self.main_pane = tk.PanedWindow(self.root, orient='vertical', sashrelief=tk.RAISED)

--- a/dashboard.py
+++ b/dashboard.py
@@ -111,10 +111,21 @@ class EBEAMSystemDashboard:
         print("Cleaned up com ports.")
 
         '''Cancels all scheduled Dashboard updates before quitting the application.'''
+        # First cancel updates in each subsystem
         print("Cancelling scheduled Dashboard updates...")
         for subsystem in self.subsystems.values():
             if hasattr(subsystem, 'cancel_updates'):
                 subsystem.cancel_updates()
+        # Now cancel com port checks
+        if self.ports_after_id:
+            try:
+                self.root.after_cancel(self.ports_after_id)
+                self.logger.debug("Cancelled scheduled com port checks.")
+            except Exception as e:
+                self.logger.debug("Failed to cancel scheduled com port checks.")
+        # Now cancel machine status updates
+        if hasattr(self.machine_status_frame, 'cancel_updates'):
+            self.machine_status_frame.cancel_updates()
         print("Dashboard upates cancelled.")
 
     def setup_main_pane(self):
@@ -473,7 +484,7 @@ class EBEAMSystemDashboard:
 
         finally:
             self.set_com_ports = current_ports
-            self.root.after(500, self._check_ports)
+            self.ports_after_id = self.root.after(500, self._check_ports)
 
     def _update_com_ports(self, subsystem_str, port):
         """

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,6 +4,7 @@ import os
 import subsystem
 import tkinter as tk
 import threading
+import datetime
 from tkinter import ttk
 from tkinter import messagebox
 from utils import MessagesFrame, SetupScripts, LogLevel, MachineStatus
@@ -135,14 +136,32 @@ class EBEAMSystemDashboard:
         self._dump_threads("after cancel_updates and logger close")
 
     def _dump_threads(self, label):
-        print(f"--- Thread dump: {label} ---")
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        lines = [f"--- Thread dump: {label} @ {timestamp} ---"]
         for thread in threading.enumerate():
-            print(
+            lines.append(
                 f"Thread name={thread.name} "
                 f"ident={thread.ident} "
                 f"daemon={thread.daemon} "
                 f"alive={thread.is_alive()}"
             )
+        payload = "\n".join(lines) + "\n"
+
+        try:
+            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
+            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
+            os.makedirs(log_dir, exist_ok=True)
+            dump_path = os.path.join(log_dir, "thread_dumps.txt")
+            with open(dump_path, "a", encoding="utf-8") as handle:
+                handle.write(payload)
+        except Exception:
+            pass
+
+        try:
+            sys.__stderr__.write(payload)
+            sys.__stderr__.flush()
+        except Exception:
+            pass
             
     def setup_main_pane(self):
         """Initialize the main layout pane and its rows for subsystem organization."""

--- a/dashboard.py
+++ b/dashboard.py
@@ -108,9 +108,11 @@ class EBEAMSystemDashboard:
 
         self._dump_threads("cleanup start")
         print("Cleaning up com ports...")
-        for subsystem in self.subsystems.values():
+        for name, subsystem in self.subsystems.items():
             if hasattr(subsystem, 'close_com_ports'):
+                self._log_cleanup_step(f"closing {name} ({subsystem.__class__.__name__})")
                 subsystem.close_com_ports()
+                self._log_cleanup_step(f"closed {name} ({subsystem.__class__.__name__})")
         print("Cleaned up com ports.")
         self._dump_threads("after close_com_ports")
 
@@ -159,6 +161,24 @@ class EBEAMSystemDashboard:
 
         try:
             sys.__stderr__.write(payload)
+            sys.__stderr__.flush()
+        except Exception:
+            pass
+
+    def _log_cleanup_step(self, message):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"[{timestamp}] {message}\n"
+        try:
+            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
+            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
+            os.makedirs(log_dir, exist_ok=True)
+            dump_path = os.path.join(log_dir, "thread_dumps.txt")
+            with open(dump_path, "a", encoding="utf-8") as handle:
+                handle.write(line)
+        except Exception:
+            pass
+        try:
+            sys.__stderr__.write(line)
             sys.__stderr__.flush()
         except Exception:
             pass

--- a/dashboard.py
+++ b/dashboard.py
@@ -366,9 +366,6 @@ class EBEAMSystemDashboard:
             )
         }
 
-        # Updates machine status progress bar
-        self.machine_status_frame.update_status(self.machine_status_frame.MACHINE_STATUS)
-
     def create_messages_frame(self):
         """Create a scrollable frame for displaying system messages and errors."""
         self.messages_frame = MessagesFrame(self.rows[3], width = frames_config[-2][2], height = frames_config[-2][3], logger=self.logger)

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -346,7 +346,7 @@ class DP16ProcessMonitor:
             pass
 
         if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=3)
+            self._thread.join(timeout=0.3)
             if self._thread.is_alive():
                 self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         self._thread = None

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -332,9 +332,11 @@ class DP16ProcessMonitor:
 
     def disconnect(self):
         # Stop polling thread
-        # self._is_running = False
-        # if self._thread and self._thread.is_alive():
-        #     self._thread.join()
+        self._is_running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout = 2)
+            if self._thread.is_alive():
+                self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         
         # Close connection
         # with self.modbus_lock:

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -346,7 +346,7 @@ class DP16ProcessMonitor:
             pass
 
         if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=0.5)
+            self._thread.join(timeout=3)
             if self._thread.is_alive():
                 self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         self._thread = None

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -332,11 +332,11 @@ class DP16ProcessMonitor:
 
     def disconnect(self):
         # Stop polling thread
-        self._is_running = False
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout = 2)
-            if self._thread.is_alive():
-                self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
+        # self._is_running = False
+        # if self._thread and self._thread.is_alive():
+        #     self._thread.join(timeout = 2)
+        #     if self._thread.is_alive():
+        #         self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         
         # Close connection
         # with self.modbus_lock:

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -337,12 +337,20 @@ class DP16ProcessMonitor:
     def disconnect(self):
         # Stop polling thread
         self._is_running = False
+
+        # Close connection early to unblock any in-flight reads
+        try:
+            if self.client.is_socket_open():
+                self.client.close()
+        except Exception:
+            pass
+
         if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=2.0)
+            self._thread.join(timeout=0.5)
             if self._thread.is_alive():
                 self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         self._thread = None
-
+        
         # Close connection
         # with self.modbus_lock:
         if self.client.is_socket_open():

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -346,7 +346,7 @@ class DP16ProcessMonitor:
             pass
 
         if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=3)
+            self._thread.join(timeout=0.5)
             if self._thread.is_alive():
                 self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
         self._thread = None

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -187,6 +187,8 @@ class DP16ProcessMonitor:
         while self._is_running:
             current_time = time.time()
             try:
+                if not self._is_running:
+                    break
                 # Check if client is still connected
                 if not self.client.is_socket_open():
                     self.consecutive_connection_errors += 1
@@ -206,6 +208,8 @@ class DP16ProcessMonitor:
                 
                 # Poll each unit individually
                 for unit in sorted(self.unit_numbers):
+                    if not self._is_running:
+                        break
                     try:
                         self._poll_single_unit(unit) 
                         self.consecutive_connection_errors = 0  # Reset on successful poll
@@ -218,7 +222,7 @@ class DP16ProcessMonitor:
                             self.log(f"Error polling unit {unit}: {e}", LogLevel.ERROR)
                             self.last_critical_error_time = current_time
 
-                if self.consecutive_connection_errors == 0:
+                if self.consecutive_connection_errors == 0 and self._is_running:
                     time.sleep(self.BASE_DELAY)
                     
             except Exception as e:
@@ -332,12 +336,13 @@ class DP16ProcessMonitor:
 
     def disconnect(self):
         # Stop polling thread
-        # self._is_running = False
-        # if self._thread and self._thread.is_alive():
-        #     self._thread.join(timeout = 2)
-        #     if self._thread.is_alive():
-        #         self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
-        
+        self._is_running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+            if self._thread.is_alive():
+                self.log("Warning: Polling thread did not terminate in time", LogLevel.WARNING)
+        self._thread = None
+
         # Close connection
         # with self.modbus_lock:
         if self.client.is_socket_open():
@@ -345,6 +350,10 @@ class DP16ProcessMonitor:
             self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
         else:
             self.log("No active connection to DP16 Process Monitors", LogLevel.INFO)
+
+    def close(self):
+        """Compatibility alias used by subsystem shutdown paths."""
+        self.disconnect()
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -81,7 +81,11 @@ class E5CNModbus:
         """
         while not self.stop_event.is_set():
             try:
+                if self.stop_event.is_set():
+                    break
                 temperature = self.read_temperature(unit)
+                if self.stop_event.is_set():
+                    break
                 if temperature is not None:
                     with self.temperatures_lock:
                         self.temperatures[unit - 1] = temperature
@@ -101,19 +105,26 @@ class E5CNModbus:
         # Wait for threads to finish
         for thread in self.threads:
             thread.join(timeout=2.0)
-            self.log(f"Thread {thread.name} stopped", LogLevel.DEBUG)
+            if thread.is_alive():
+                self.log(f"Warning: Thread {thread.name} did not terminate in time", LogLevel.WARNING)
+            else:
+                self.log(f"Thread {thread.name} stopped", LogLevel.DEBUG)
             
         self.threads.clear()
         
         # Clean up the connection
-        with self.modbus_lock:
-            try:
-                if self.client.is_socket_open():
-                    self.client.close()
-                    self.log("Modbus connection closed", LogLevel.DEBUG)
-            except Exception as e:
-                self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
+        acquired = self.modbus_lock.acquire(timeout=1.0)
+        try:
+            if self.client.is_socket_open():
+                self.client.close()
+                self.log("Modbus connection closed", LogLevel.DEBUG)
+        except Exception as e:
+            self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
+        finally:
+            if acquired:
+                self.modbus_lock.release()
                 
+        self.connected = False
         self.is_initialized.clear()
 
     def connect(self):
@@ -157,7 +168,11 @@ class E5CNModbus:
         attempts = 3
         while attempts > 0:
             try:
+                if self.stop_event.is_set():
+                    return None
                 with self.modbus_lock:
+                    if self.stop_event.is_set():
+                        return None
                     if not self.client.is_socket_open():
                         try:
                             if self.client.connect():

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -84,8 +84,6 @@ class E5CNModbus:
                 if self.stop_event.is_set():
                     break
                 temperature = self.read_temperature(unit)
-                if self.stop_event.is_set():
-                    break
                 if temperature is not None:
                     with self.temperatures_lock:
                         self.temperatures[unit - 1] = temperature

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -7,7 +7,7 @@ class E5CNModbus:
     TEMPERATURE_ADDRESS = 0x0000  # Address for reading temperature, page 92
     UNIT_NUMBERS = [1, 2, 3]       # Unit numbers for each controller
 
-    def __init__(self, port, baudrate=9600, timeout=0.5, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
+    def __init__(self, port, baudrate=9600, timeout=1, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
         """
         Initialize the E5CNModbus instance with serial communication parameters and optional logging.
         
@@ -111,7 +111,7 @@ class E5CNModbus:
         
         # Wait for threads to finish
         for thread in self.threads:
-            thread.join(timeout=4)
+            thread.join(timeout=0.5)
             if thread.is_alive():
                 self.log(f"Warning: Thread {thread.name} did not terminate in time", LogLevel.WARNING)
             else:
@@ -173,13 +173,13 @@ class E5CNModbus:
 
     def read_temperature(self, unit):
         attempts = 3
-        while attempts > 0 and not self.stop_event.is_set():
+        while attempts > 0:
             try:
                 if self.stop_event.is_set():
                     return None
-                if self.stop_event.is_set():
-                    return None
                 with self.modbus_lock:
+                    if self.stop_event.is_set():
+                        return None
                     if not self.client.is_socket_open():
                         try:
                             if self.client.connect():

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -101,10 +101,17 @@ class E5CNModbus:
         """Stop all temperature reading threads and clean up connections."""
         self.log("Stopping temperature reading threads...", LogLevel.DEBUG)
         self.stop_event.set()
+
+        # Close connection early to unblock any in-flight reads
+        try:
+            if self.client.is_socket_open():
+                self.client.close()
+        except Exception:
+            pass
         
         # Wait for threads to finish
         for thread in self.threads:
-            thread.join(timeout=2.0)
+            thread.join(timeout=0.5)
             if thread.is_alive():
                 self.log(f"Warning: Thread {thread.name} did not terminate in time", LogLevel.WARNING)
             else:
@@ -113,7 +120,7 @@ class E5CNModbus:
         self.threads.clear()
         
         # Clean up the connection
-        acquired = self.modbus_lock.acquire(timeout=1.0)
+        acquired = self.modbus_lock.acquire(timeout=0.2)
         try:
             if self.client.is_socket_open():
                 self.client.close()

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -7,7 +7,7 @@ class E5CNModbus:
     TEMPERATURE_ADDRESS = 0x0000  # Address for reading temperature, page 92
     UNIT_NUMBERS = [1, 2, 3]       # Unit numbers for each controller
 
-    def __init__(self, port, baudrate=9600, timeout=1, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
+    def __init__(self, port, baudrate=9600, timeout=0.5, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
         """
         Initialize the E5CNModbus instance with serial communication parameters and optional logging.
         
@@ -111,7 +111,7 @@ class E5CNModbus:
         
         # Wait for threads to finish
         for thread in self.threads:
-            thread.join(timeout=0.5)
+            thread.join(timeout=4)
             if thread.is_alive():
                 self.log(f"Warning: Thread {thread.name} did not terminate in time", LogLevel.WARNING)
             else:
@@ -173,13 +173,13 @@ class E5CNModbus:
 
     def read_temperature(self, unit):
         attempts = 3
-        while attempts > 0:
+        while attempts > 0 and not self.stop_event.is_set():
             try:
                 if self.stop_event.is_set():
                     return None
+                if self.stop_event.is_set():
+                    return None
                 with self.modbus_lock:
-                    if self.stop_event.is_set():
-                        return None
                     if not self.client.is_socket_open():
                         try:
                             if self.client.connect():

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -109,7 +109,7 @@ class E5CNModbus:
         
         # Wait for threads to finish
         for thread in self.threads:
-            thread.join(timeout=4)
+            thread.join(timeout=0.3)
             if thread.is_alive():
                 self.log(f"Warning: Thread {thread.name} did not terminate in time", LogLevel.WARNING)
             else:

--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -146,6 +146,11 @@ class G9Driver:
 
             time.sleep(0.1)  # minimum sleep between successful reads
 
+    def stop_thread(self):
+        """Stops the communication thread"""
+        self._running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
 
     def get_interlock_status(self):
         """

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -736,7 +736,7 @@ class PowerSupply9104:
 
         # Wait for the ramping thread to finish
         if self.ramp_thread and self.ramp_thread.is_alive():
-            self.ramp_thread.join(timeout=2.0)
+            self.ramp_thread.join(timeout=0.5)
             if self.ramp_thread.is_alive():
                 self.log("Warning: Ramping thread did not terminate in time", LogLevel.WARNING)
             else:

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -736,8 +736,11 @@ class PowerSupply9104:
 
         # Wait for the ramping thread to finish
         if self.ramp_thread and self.ramp_thread.is_alive():
-            self.ramp_thread.join()
-            self.log("Ramping thread terminated.", LogLevel.INFO)
+            self.ramp_thread.join(timeout=2.0)
+            if self.ramp_thread.is_alive():
+                self.log("Warning: Ramping thread did not terminate in time", LogLevel.WARNING)
+            else:
+                self.log("Ramping thread terminated.", LogLevel.INFO)
 
         # Close the serial connection
         if self.ser and self.ser.is_open:

--- a/main.py
+++ b/main.py
@@ -59,6 +59,9 @@ def start_main_app(com_ports, logger=None):
             root.destroy()
         return "break"
     
+    """Esnure that quit_app is called when the window is closed, not just when Ctrl+Q is pressed."""
+    root.protocol("WM_DELETE_WINDOW", quit_app)
+    
     def toggle_fullscreen(event=None):
         nonlocal fullscreen
         fullscreen = not fullscreen

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
-import os
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
@@ -188,12 +187,6 @@ def start_main_app(com_ports, logger=None):
         root.destroy()
     except Exception:
         pass
-    # Force process termination to ensure the terminal regains control.
-    try:
-        os._exit(0)
-    except Exception:
-        # If os._exit fails for any reason, raise SystemExit as a fallback.
-        raise SystemExit(0)
 
 def config_com_ports(saved_com_ports, logger=None):
     """

--- a/main.py
+++ b/main.py
@@ -216,7 +216,6 @@ def config_com_ports(saved_com_ports, logger=None):
     config_root.title("Configure COM Ports")
 
     selections = {}
-    selected_ports = None
 
     main_frame = ttk.Frame(config_root, padding="20 20 20 20")
     main_frame.pack(side=tk.TOP, fill=tk.X)
@@ -248,7 +247,6 @@ def config_com_ports(saved_com_ports, logger=None):
         selections[subsystem] = selected_port
 
     def on_submit():
-        nonlocal selected_ports
         """
         Handler for the 'Submit' button. Checks if all subsystems have a port
         selected. If not, offers to fill those with dummy ports. If the user

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
 import os
-import datetime
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
@@ -52,40 +51,17 @@ def start_main_app(com_ports, logger=None):
     root.title("EBEAM System Dashboard")
     root.state('zoomed')
 
-    def _append_shutdown_log(message):
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        line = f"[{timestamp}] shutdown: {message}\n"
-        try:
-            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
-            os.makedirs(log_dir, exist_ok=True)
-            dump_path = os.path.join(log_dir, "thread_dumps.txt")
-            with open(dump_path, "a", encoding="utf-8") as handle:
-                handle.write(line)
-        except Exception:
-            pass
-        try:
-            sys.__stderr__.write(line)
-            sys.__stderr__.flush()
-        except Exception:
-            pass
-
     # Track fullscreen state
     fullscreen = False
   
     def quit_app(event=None):
-        _append_shutdown_log("quit_app invoked")
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
-            _append_shutdown_log("quit confirmed")
             app.cleanup()
-            _append_shutdown_log("cleanup returned, calling root.quit")
             try:
                 root.quit()
             except Exception:
                 pass
-            _append_shutdown_log("calling root.destroy")
             root.destroy()
-            _append_shutdown_log("root.destroy returned")
         return "break"
     
     """Esnure that quit_app is called when the window is closed, not just when Ctrl+Q is pressed."""
@@ -207,7 +183,6 @@ def start_main_app(com_ports, logger=None):
 
     app = EBEAMSystemDashboard(root, com_ports, logger=logger)
     root.mainloop()
-    _append_shutdown_log("mainloop exited")
     
     try:
         root.destroy()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import sys
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
+import os
+import datetime
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
@@ -50,13 +52,40 @@ def start_main_app(com_ports, logger=None):
     root.title("EBEAM System Dashboard")
     root.state('zoomed')
 
+    def _append_shutdown_log(message):
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        line = f"[{timestamp}] shutdown: {message}\n"
+        try:
+            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
+            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
+            os.makedirs(log_dir, exist_ok=True)
+            dump_path = os.path.join(log_dir, "thread_dumps.txt")
+            with open(dump_path, "a", encoding="utf-8") as handle:
+                handle.write(line)
+        except Exception:
+            pass
+        try:
+            sys.__stderr__.write(line)
+            sys.__stderr__.flush()
+        except Exception:
+            pass
+
     # Track fullscreen state
     fullscreen = False
   
     def quit_app(event=None):
+        _append_shutdown_log("quit_app invoked")
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
+            _append_shutdown_log("quit confirmed")
             app.cleanup()
+            _append_shutdown_log("cleanup returned, calling root.quit")
+            try:
+                root.quit()
+            except Exception:
+                pass
+            _append_shutdown_log("calling root.destroy")
             root.destroy()
+            _append_shutdown_log("root.destroy returned")
         return "break"
     
     """Esnure that quit_app is called when the window is closed, not just when Ctrl+Q is pressed."""
@@ -178,6 +207,7 @@ def start_main_app(com_ports, logger=None):
 
     app = EBEAMSystemDashboard(root, com_ports, logger=logger)
     root.mainloop()
+    _append_shutdown_log("mainloop exited")
 
 def config_com_ports(saved_com_ports, logger=None):
     """

--- a/main.py
+++ b/main.py
@@ -208,6 +208,17 @@ def start_main_app(com_ports, logger=None):
     app = EBEAMSystemDashboard(root, com_ports, logger=logger)
     root.mainloop()
     _append_shutdown_log("mainloop exited")
+    
+    try:
+        root.destroy()
+    except Exception:
+        pass
+    # Force process termination to ensure the terminal regains control.
+    try:
+        os._exit(0)
+    except Exception:
+        # If os._exit fails for any reason, raise SystemExit as a fallback.
+        raise SystemExit(0)
 
 def config_com_ports(saved_com_ports, logger=None):
     """
@@ -298,7 +309,8 @@ def config_com_ports(saved_com_ports, logger=None):
         save_com_ports(selected_ports, logger=logger)
         if logger is not None:
             logger.info(f"COM-port selection submitted: {selected_ports}")
-        config_root.quit()
+        config_root.destroy()
+        start_main_app(selected_ports, logger=logger)
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack(pady=20)
@@ -306,10 +318,6 @@ def config_com_ports(saved_com_ports, logger=None):
     config_root.bind('<Return>', lambda event: on_submit())
     config_root.mainloop()
     config_root.destroy()
-
-    if selected_ports:
-        start_main_app(selected_ports, logger=logger)
-
 
 if __name__ == "__main__":
     bootstrap_logger = Logger(text_widget=None, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)

--- a/main.py
+++ b/main.py
@@ -237,6 +237,7 @@ def config_com_ports(saved_com_ports, logger=None):
     config_root.title("Configure COM Ports")
 
     selections = {}
+    selected_ports = None
 
     main_frame = ttk.Frame(config_root, padding="20 20 20 20")
     main_frame.pack(side=tk.TOP, fill=tk.X)
@@ -268,6 +269,7 @@ def config_com_ports(saved_com_ports, logger=None):
         selections[subsystem] = selected_port
 
     def on_submit():
+        nonlocal selected_ports
         """
         Handler for the 'Submit' button. Checks if all subsystems have a port
         selected. If not, offers to fill those with dummy ports. If the user
@@ -296,16 +298,17 @@ def config_com_ports(saved_com_ports, logger=None):
         save_com_ports(selected_ports, logger=logger)
         if logger is not None:
             logger.info(f"COM-port selection submitted: {selected_ports}")
-        config_root.destroy()
-        
-        # Launch the main application
-        start_main_app(selected_ports, logger=logger)
+        config_root.quit()
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack(pady=20)
     
     config_root.bind('<Return>', lambda event: on_submit())
     config_root.mainloop()
+    config_root.destroy()
+
+    if selected_ports:
+        start_main_app(selected_ports, logger=logger)
 
 
 if __name__ == "__main__":

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2280,7 +2280,8 @@ class CathodeHeatingSubsystem:
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
-               # self.temperature_controller.stop_reading()
+                if hasattr(self.temperature_controller, 'stop_reading'):
+                    self.temperature_controller.stop_reading()
                 self.temperature_controller.disconnect()
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1345,7 +1345,16 @@ class CathodeHeatingSubsystem:
                 self.update_plot(i)
 
         # Schedule next update
-        self.parent.after(500, self.update_data)
+        self.after_id = self.parent.after(500, self.update_data)
+
+    def cancel_updates(self):
+        '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        if hasattr(self, 'after_id') and self.after_id:
+            try:
+                self.parent.after_cancel(self.after_id)
+                self.log('Canceled scheduled cathode heating display update.', LogLevel.DEBUG)
+            except Exception as e:
+                self.log('Failed to cancel scheduled cathode heating display update.', LogLevel.DEBUG)
 
     def update_plot(self, index):
         if len(self.time_data[index]) == 0:

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2267,21 +2267,51 @@ class CathodeHeatingSubsystem:
         """
         Disables all power supply outputs and closes serial connections upon quitting the application.
         """
+        def _shutdown_log(message: str):
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            line = f"[{timestamp}] cathode_heating shutdown: {message}\n"
+            try:
+                base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
+                log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
+                os.makedirs(log_dir, exist_ok=True)
+                dump_path = os.path.join(log_dir, "thread_dumps.txt")
+                with open(dump_path, "a", encoding="utf-8") as handle:
+                    handle.write(line)
+            except Exception:
+                pass
+            try:
+                sys.__stderr__.write(line)
+                sys.__stderr__.flush()
+            except Exception:
+                pass
+
+        _shutdown_log("enter close_com_ports")
         if hasattr(self, 'power_supplies') and self.power_supplies:
             for i, ps in enumerate(self.power_supplies):
                 try:
                     if hasattr(ps, 'disable_output') and ps.is_connected():
+                        _shutdown_log(f"disabling output for cathode {chr(65 + i)}")
                         self.log(f"Disabling output on cathode {chr(65 + i)} power supply", LogLevel.INFO)
                         ps.disable_output()
+                        _shutdown_log(f"disabled output for cathode {chr(65 + i)}")
                 except Exception as e:
                     self.log(f"Error disabling output on cathode {chr(65 + i)}: {e}", LogLevel.ERROR)
+                    _shutdown_log(f"error disabling output for cathode {chr(65 + i)}: {e}")
                 if hasattr(ps, 'close'):
+                    _shutdown_log(f"closing power supply for cathode {chr(65 + i)}")
                     ps.close()
+                    _shutdown_log(f"closed power supply for cathode {chr(65 + i)}")
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
                 if hasattr(self.temperature_controller, 'stop_reading'):
+                    _shutdown_log("stopping temperature controller threads")
                     self.temperature_controller.stop_reading()
+                    _shutdown_log("stopped temperature controller threads")
+                _shutdown_log("disconnecting temperature controller")
                 self.temperature_controller.disconnect()
+                _shutdown_log("disconnected temperature controller")
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)
+                _shutdown_log(f"error cleaning up temperature controller: {e}")
+        _shutdown_log("exit close_com_ports")

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2267,51 +2267,21 @@ class CathodeHeatingSubsystem:
         """
         Disables all power supply outputs and closes serial connections upon quitting the application.
         """
-        def _shutdown_log(message: str):
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            line = f"[{timestamp}] cathode_heating shutdown: {message}\n"
-            try:
-                base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-                log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
-                os.makedirs(log_dir, exist_ok=True)
-                dump_path = os.path.join(log_dir, "thread_dumps.txt")
-                with open(dump_path, "a", encoding="utf-8") as handle:
-                    handle.write(line)
-            except Exception:
-                pass
-            try:
-                sys.__stderr__.write(line)
-                sys.__stderr__.flush()
-            except Exception:
-                pass
-
-        _shutdown_log("enter close_com_ports")
         if hasattr(self, 'power_supplies') and self.power_supplies:
             for i, ps in enumerate(self.power_supplies):
                 try:
                     if hasattr(ps, 'disable_output') and ps.is_connected():
-                        _shutdown_log(f"disabling output for cathode {chr(65 + i)}")
                         self.log(f"Disabling output on cathode {chr(65 + i)} power supply", LogLevel.INFO)
                         ps.disable_output()
-                        _shutdown_log(f"disabled output for cathode {chr(65 + i)}")
                 except Exception as e:
                     self.log(f"Error disabling output on cathode {chr(65 + i)}: {e}", LogLevel.ERROR)
-                    _shutdown_log(f"error disabling output for cathode {chr(65 + i)}: {e}")
                 if hasattr(ps, 'close'):
-                    _shutdown_log(f"closing power supply for cathode {chr(65 + i)}")
                     ps.close()
-                    _shutdown_log(f"closed power supply for cathode {chr(65 + i)}")
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
                 if hasattr(self.temperature_controller, 'stop_reading'):
-                    _shutdown_log("stopping temperature controller threads")
                     self.temperature_controller.stop_reading()
-                    _shutdown_log("stopped temperature controller threads")
-                _shutdown_log("disconnecting temperature controller")
                 self.temperature_controller.disconnect()
-                _shutdown_log("disconnected temperature controller")
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)
-                _shutdown_log(f"error cleaning up temperature controller: {e}")
-        _shutdown_log("exit close_com_ports")

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -346,7 +346,16 @@ class InterlocksSubsystem:
         finally:
             # Schedule next update
             if self.driver:
-                self.parent.after(self.update_interval, self.update_data)
+                self.after_id = self.parent.after(self.update_interval, self.update_data)
+    
+    def cancel_updates(self):
+        '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        if hasattr(self, 'after_id') and self.after_id:
+            try:
+                self.parent.after_cancel(self.after_id)
+                self.log('Canceled scheduled interlock status update.', LogLevel.DEBUG)
+            except Exception as e:
+                self.log('Failed to cancel scheduled interlock status update.', LogLevel.DEBUG)
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -368,6 +368,7 @@ class InterlocksSubsystem:
         """
         Closes the serial port connection upon quitting the application.
         """
+        self.driver.stop_thread()
         if self.driver and hasattr(self.driver, 'ser'):
             if self.driver.ser and self.driver.ser.is_open:
                 self.driver.ser.close()

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -368,8 +368,9 @@ class InterlocksSubsystem:
         """
         Closes the serial port connection upon quitting the application.
         """
-        self.driver.stop_thread()
-        if self.driver and hasattr(self.driver, 'ser'):
+        if hasattr(self, 'driver') and self.driver:
+            self.driver.stop_thread()
+        if hasattr(self, 'driver') and self.driver and hasattr(self.driver, 'ser'):
             if self.driver.ser and self.driver.ser.is_open:
                 self.driver.ser.close()
                 self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -49,6 +49,7 @@ class InterlocksSubsystem:
         self.update_interval = 500  # Default update interval (ms)
         self.max_interval = 5000   # Maximum update interval (ms)
         self._last_status = None
+        self._after_ids = set()
         self.setup_gui()
 
         try:
@@ -68,7 +69,7 @@ class InterlocksSubsystem:
             self.log(f"Failed to initialize G9 driver: {str(e)}", LogLevel.WARNING)
             self._set_all_indicators('red')
         
-        self.parent.after(self.update_interval, self.update_data)
+        self._schedule_update()
 
     def update_com_port(self, com_port):
         """
@@ -269,7 +270,6 @@ class InterlocksSubsystem:
                         self.log("No data available from G9", LogLevel.CRITICAL)
                         self.last_error_time = current_time
                         self._adjust_update_interval(success=False)
-                        self.parent.after(self.update_interval, self.update_data)
                         return
                 
                 sitsf_bits, sitdf_bits, g9_active, unit_status, input_terms, output_terms, debug_data = status
@@ -346,16 +346,32 @@ class InterlocksSubsystem:
         finally:
             # Schedule next update
             if self.driver:
-                self.after_id = self.parent.after(self.update_interval, self.update_data)
+                self._schedule_update()
     
     def cancel_updates(self):
         '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
-        if hasattr(self, 'after_id') and self.after_id:
-            try:
-                self.parent.after_cancel(self.after_id)
-                self.log('Canceled scheduled interlock status update.', LogLevel.DEBUG)
-            except Exception as e:
-                self.log('Failed to cancel scheduled interlock status update.', LogLevel.DEBUG)
+        if hasattr(self, '_after_ids') and self._after_ids:
+            for after_id in list(self._after_ids):
+                try:
+                    self.parent.after_cancel(after_id)
+                except Exception:
+                    pass
+            self._after_ids.clear()
+            self.log('Canceled scheduled interlock status update.', LogLevel.DEBUG)
+
+    def _schedule_update(self):
+        """Schedule the next update and track the callback id for cancellation."""
+        id_holder = {}
+
+        def _callback():
+            after_id = id_holder.get('id')
+            if after_id:
+                self._after_ids.discard(after_id)
+            self.update_data()
+
+        after_id = self.parent.after(self.update_interval, _callback)
+        id_holder['id'] = after_id
+        self._after_ids.add(after_id)
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/subsystem/oil_system/oil_system.py
+++ b/subsystem/oil_system/oil_system.py
@@ -48,6 +48,17 @@ class OilSubsystem:
         self.pressure_label.config(text=f"{self.pressure:.1f} PSI")
         self.flow_label.config(text=f"{self.flow_rate:.1f} GPM")
         self.pumpStat.config(text=f"{self.pump_status}")
-        self.parent.after(200, self.update_display)  
+        self.after_id = self.parent.after(200, self.update_display)  
+
+    def cancel_updates(self):
+        '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        if hasattr(self, 'after_id') and self.after_id:
+            try:
+                self.parent.after_cancel(self.after_id)
+                if self.logger:
+                    self.logger.debug('Canceled scheduled oil system display update.')
+            except Exception as e:
+                if self.logger:
+                    self.logger.debug('Failed to cancel scheduled oil system display update.')
 
 

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -302,9 +302,18 @@ class ProcessMonitorSubsystem:
                 self.last_error_time = current_time
                 
         finally:
-            # Schedule next update
+            # Schedule next update, store after_id for cancellation if needed.
             if self.monitor:
-                self.parent.after(self.update_interval, self.update_temperatures)
+                self.after_id = self.parent.after(self.update_interval, self.update_temperatures)
+
+    def cancel_updates(self):
+        '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        if hasattr(self, 'after_id') and self.after_id:
+            try:
+                self.parent.after_cancel(self.after_id)
+                self.log('Canceled scheduled temperature update.', LogLevel.DEBUG)
+            except Exception as e:
+                self.log('Failed to cancel scheduled temperature update.', LogLevel.DEBUG)
 
     def _set_all_temps_error(self):
         """Set all temperature bars to error state"""

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -495,6 +495,11 @@ class VTRXSubsystem:
 
     def stop_serial_thread(self):
         self.stop_event.set()
+        try:
+            if self.ser and self.ser.is_open:
+                self.ser.close()
+        except Exception:
+            pass
         if self.process_after_id:
             try:
                 self.parent.after_cancel(self.process_after_id)
@@ -502,7 +507,7 @@ class VTRXSubsystem:
                 pass
             self.process_after_id = None
         if hasattr(self, 'serial_thread') and self.serial_thread.is_alive():
-            self.serial_thread.join(timeout=2.0)
+            self.serial_thread.join(timeout=0.5)
             if self.serial_thread.is_alive():
                 self.log("Warning: VTRX serial thread did not terminate in time", LogLevel.WARNING)
     

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -65,6 +65,7 @@ class VTRXSubsystem:
         self.stop_event = threading.Event()
         self.last_data_received_time = time.time()
         self.last_gui_update_time = time.time()
+        self.process_after_id = None
 
         self.setup_serial()
         self.setup_gui()
@@ -176,6 +177,8 @@ class VTRXSubsystem:
 
         After processing all items, reschedules itself to run again after 500 ms.
         """
+        if self.stop_event.is_set():
+            return
         try:
             while True:
                 data = self.data_queue.get_nowait()
@@ -186,7 +189,8 @@ class VTRXSubsystem:
         except queue.Empty:
             pass
         finally:
-            self.parent.after(500, self.process_queue)
+            if not self.stop_event.is_set():
+                self.process_after_id = self.parent.after(500, self.process_queue)
 
     def update_gui_with_error_state(self):
         """
@@ -487,12 +491,20 @@ class VTRXSubsystem:
         self.stop_event.clear()
         self.serial_thread = threading.Thread(target=self.read_serial, daemon=True)
         self.serial_thread.start()
-        self.parent.after(100, self.process_queue)
+        self.process_after_id = self.parent.after(100, self.process_queue)
 
     def stop_serial_thread(self):
         self.stop_event.set()
+        if self.process_after_id:
+            try:
+                self.parent.after_cancel(self.process_after_id)
+            except Exception:
+                pass
+            self.process_after_id = None
         if hasattr(self, 'serial_thread') and self.serial_thread.is_alive():
-            self.serial_thread.join()
+            self.serial_thread.join(timeout=2.0)
+            if self.serial_thread.is_alive():
+                self.log("Warning: VTRX serial thread did not terminate in time", LogLevel.WARNING)
     
     def update_time_window(self, seconds):
         current_time = datetime.datetime.now()
@@ -557,4 +569,13 @@ class VTRXSubsystem:
             self.log(f"Closed serial port {self.serial_port}", LogLevel.INFO)
         else:
             self.log(f"{self.serial_port} port already closed", LogLevel.INFO)
+
+    def cancel_updates(self):
+        if self.process_after_id:
+            try:
+                self.parent.after_cancel(self.process_after_id)
+                self.log("Canceled scheduled VTRX queue processing.", LogLevel.DEBUG)
+            except Exception:
+                self.log("Failed to cancel scheduled VTRX queue processing.", LogLevel.DEBUG)
+            self.process_after_id = None
           

--- a/utils.py
+++ b/utils.py
@@ -26,6 +26,8 @@ class Logger:
 
     def __init__(self, text_widget, file_log_level = LogLevel.VERBOSE, log_level=LogLevel.INFO, log_to_file=False):
         self.text_widget = text_widget
+        # Only updated from the main thread: indicates the text widget is attached and safe to call
+        self._widget_attached = False
         self.file_log_level = file_log_level
         self.log_level = log_level
         self.log_to_file = log_to_file
@@ -63,25 +65,25 @@ class Logger:
         if log_to_file:
             self.setup_log_file()
             self.setup_wm_logfile()
-        self._start_gui_pump()
+        # Start GUI pump only if a widget was provided at construction and we're on the main thread.
+        if self.text_widget and threading.current_thread() is threading.main_thread():
+            if hasattr(self.text_widget, "after"):
+                self._widget_attached = True
+                self._start_gui_pump()
 
     def _get_dashboard_base_path(self):
         return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
 
     def _widget_alive(self):
-        if self.text_widget is None:
-            return False
-        if not hasattr(self.text_widget, "winfo_exists"):
-            return True
-        try:
-            return bool(self.text_widget.winfo_exists())
-        except tk.TclError:
-            return False
+        # Do NOT invoke any tkinter methods from background threads (e.g., winfo_exists).
+        # This flag is only set/cleared from the main thread (see attach_text_widget and close()).
+        return bool(self.text_widget) and bool(self._widget_attached)
 
     def _start_gui_pump(self):
-        if self._closed or not self._widget_alive():
+        # Only start pumping when the widget is attached and supports `after`.
+        if self._closed or not self._widget_attached:
             return
-        if not hasattr(self.text_widget, "after"):
+        if self.text_widget is None or not hasattr(self.text_widget, "after"):
             return
         if self._pump_after_id is None:
             try:
@@ -92,7 +94,7 @@ class Logger:
                 self._pump_after_id = None
 
     def _pump_queue(self):
-        if self._closed or not self._widget_alive():
+        if self._closed or not self._widget_attached:
             self._pump_after_id = None
             return
         try:
@@ -102,8 +104,8 @@ class Logger:
         except queue.Empty:
             pass
         finally:
-            if not self._closed and self._widget_alive():
-                if not hasattr(self.text_widget, "after"):
+            if not self._closed and self._widget_attached:
+                if self.text_widget is None or not hasattr(self.text_widget, "after"):
                     self._pump_after_id = None
                     return
                 try:
@@ -114,7 +116,8 @@ class Logger:
                     self._pump_after_id = None
 
     def _write_to_text_widget(self, formatted_message, tag="log"):
-        if not self._widget_alive():
+        # Expect this to be called from the main thread via the pump; guard with the attached flag.
+        if not (self.text_widget and self._widget_attached):
             return
         try:
             self.text_widget.insert(tk.END, formatted_message, (tag,))
@@ -128,20 +131,35 @@ class Logger:
     def _enqueue_gui_write(self, message, tag="log"):
         if self._closed:
             return
-        if self.text_widget is None:
-            self._pending_widget_messages.append((message, tag))
+
+        # Always enqueue into the thread-safe queue.
+        try:
+            self._gui_queue.put((message, tag))
+        except Exception:
+            # If queue put fails for some reason, fall back to pending buffer.
+            try:
+                self._pending_widget_messages.append((message, tag))
+            except Exception:
+                pass
             return
-        if not hasattr(self.text_widget, "after"):
-            self._write_to_text_widget(message, tag)
+
+        # If widget is not attached yet or doesn't support `after`, buffer until attach.
+        if not self._widget_attached or self.text_widget is None or not hasattr(self.text_widget, "after"):
+            try:
+                self._pending_widget_messages.append((message, tag))
+            except Exception:
+                pass
             return
-        if not self._widget_alive():
-            self._pending_widget_messages.append((message, tag))
-            return
-        self._gui_queue.put((message, tag))
-        self._start_gui_pump()
+
+        # Only call into tkinter (start the pump) from the main thread.
+        if threading.current_thread() is threading.main_thread():
+            self._start_gui_pump()
 
     def attach_text_widget(self, text_widget):
+        # Called from the main thread to attach a tkinter Text widget.
         self.text_widget = text_widget
+        # Mark attached (only set from main thread)
+        self._widget_attached = True
         if not hasattr(self.text_widget, "after"):
             while self._pending_widget_messages:
                 message, tag = self._pending_widget_messages.popleft()
@@ -150,6 +168,7 @@ class Logger:
         while self._pending_widget_messages:
             message, tag = self._pending_widget_messages.popleft()
             self._gui_queue.put((message, tag))
+        # Safe to start pump because this is called on the main thread.
         self._start_gui_pump()
 
     def write_raw(self, message, tag="stdout"):
@@ -291,12 +310,17 @@ class Logger:
 
     def close(self):
         self._closed = True
-        if self._pump_after_id is not None and self._widget_alive():
-            try:
-                self.text_widget.after_cancel(self._pump_after_id)
-            except tk.TclError:
-                pass
+        # Try to cancel scheduled after() only from the main thread to avoid Tk calls from background threads.
+        if self._pump_after_id is not None:
+            if threading.current_thread() is threading.main_thread() and self._widget_attached and self.text_widget and hasattr(self.text_widget, "after"):
+                try:
+                    self.text_widget.after_cancel(self._pump_after_id)
+                except tk.TclError:
+                    pass
+            # clear pump id regardless; the pump checks _closed and will stop if running
             self._pump_after_id = None
+        # mark widget detached
+        self._widget_attached = False
         if self.log_file:
             try:
                 with self._file_lock:

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,8 @@ import os
 import tkinter as tk
 from tkinter import messagebox, ttk, filedialog
 import datetime
+import threading
+import queue
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import enum
@@ -34,6 +36,12 @@ class Logger:
         self.log_filepath = None
         self.webMonitor_log_filepath = None
         self._pending_widget_messages = deque(maxlen=self.STARTUP_BUFFER_MAX)
+        self._gui_queue = queue.Queue()
+        self._pump_after_id = None
+        self._pump_interval_ms = 100
+        self._closed = False
+        self._log_tag_configured = False
+        self._file_lock = threading.RLock()
         self.dict_logger = {
             "pressure": None,
             "safetyOutputDataFlags": None,
@@ -55,55 +63,116 @@ class Logger:
         if log_to_file:
             self.setup_log_file()
             self.setup_wm_logfile()
+        self._start_gui_pump()
 
     def _get_dashboard_base_path(self):
         return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
 
-    def _write_to_text_widget(self, formatted_message):
+    def _widget_alive(self):
         if self.text_widget is None:
+            return False
+        try:
+            return bool(self.text_widget.winfo_exists())
+        except tk.TclError:
+            return False
+
+    def _start_gui_pump(self):
+        if self._closed or not self._widget_alive():
             return
-        self.text_widget.insert(tk.END, formatted_message, ("log",))
-        self.text_widget.tag_config("log", font=("Helvetica", 9))
-        self.text_widget.see(tk.END)
+        if self._pump_after_id is None:
+            try:
+                self._pump_after_id = self.text_widget.after(
+                    self._pump_interval_ms, self._pump_queue
+                )
+            except tk.TclError:
+                self._pump_after_id = None
+
+    def _pump_queue(self):
+        if self._closed or not self._widget_alive():
+            self._pump_after_id = None
+            return
+        try:
+            while True:
+                message, tag = self._gui_queue.get_nowait()
+                self._write_to_text_widget(message, tag)
+        except queue.Empty:
+            pass
+        finally:
+            if not self._closed and self._widget_alive():
+                try:
+                    self._pump_after_id = self.text_widget.after(
+                        self._pump_interval_ms, self._pump_queue
+                    )
+                except tk.TclError:
+                    self._pump_after_id = None
+
+    def _write_to_text_widget(self, formatted_message, tag="log"):
+        if not self._widget_alive():
+            return
+        try:
+            self.text_widget.insert(tk.END, formatted_message, (tag,))
+            if tag == "log" and not self._log_tag_configured:
+                self.text_widget.tag_config("log", font=("Helvetica", 9))
+                self._log_tag_configured = True
+            self.text_widget.see(tk.END)
+        except tk.TclError:
+            pass
+
+    def _enqueue_gui_write(self, message, tag="log"):
+        if self._closed:
+            return
+        if not self._widget_alive():
+            self._pending_widget_messages.append((message, tag))
+            return
+        self._gui_queue.put((message, tag))
+        self._start_gui_pump()
 
     def attach_text_widget(self, text_widget):
         self.text_widget = text_widget
         while self._pending_widget_messages:
-            self._write_to_text_widget(self._pending_widget_messages.popleft())
+            message, tag = self._pending_widget_messages.popleft()
+            self._gui_queue.put((message, tag))
+        self._start_gui_pump()
+
+    def write_raw(self, message, tag="stdout"):
+        """Write a raw message (no formatting) to the text widget safely."""
+        self._enqueue_gui_write(message, tag=tag)
 
     def setup_log_file(self):
         """Setup a new log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
         try:
-            log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Logs")
-            os.makedirs(log_dir, exist_ok=True)
-            
-            # Create the log file with the old naming pattern
-            log_file_name = f"log_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
-            # close the existing log file at intervals of 8 hours and create a new one
-            if self.log_file != None:
-                self.log_file.close()
+            with self._file_lock:
+                log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Logs")
+                os.makedirs(log_dir, exist_ok=True)
+                
+                # Create the log file with the old naming pattern
+                log_file_name = f"log_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
+                # close the existing log file at intervals of 8 hours and create a new one
+                if self.log_file != None:
+                    self.log_file.close()
 
-            self.log_filepath = os.path.join(log_dir, log_file_name)
-            self.log_file = open(self.log_filepath, 'w')
-            self.log_start_time = datetime.datetime.now()
-            self.info(f"Log file created at {self.log_filepath}")
+                self.log_filepath = os.path.join(log_dir, log_file_name)
+                self.log_file = open(self.log_filepath, 'w')
+                self.log_start_time = datetime.datetime.now()
+            print(f"Log file created at {self.log_filepath}")
         except Exception as e:
             print(f"Error creating log file: {str(e)}")
 
     def setup_wm_logfile(self):
         """Setup a new web monitor log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
         try:
-            wm_log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-WMLogs")
-            os.makedirs(wm_log_dir, exist_ok=True)
-            
-            # Create the web monitor log file with the old naming pattern
-            webMonitor_log_file_name = f"webMonitor_log.txt"
-            if self.webMonitor_log_file != None:
-                self.webMonitor_log_file.close()
-            self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
-            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
-            self.webMonitor_log_start_time = datetime.datetime.now()
-            self.info(f"WebMonitor log file created at {self.webMonitor_log_filepath}")
+            with self._file_lock:
+                wm_log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-WMLogs")
+                os.makedirs(wm_log_dir, exist_ok=True)
+                
+                # Create the web monitor log file with the old naming pattern
+                webMonitor_log_file_name = f"webMonitor_log.txt"
+                if self.webMonitor_log_file != None:
+                    self.webMonitor_log_file.close()
+                self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
+                self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
+                self.webMonitor_log_start_time = datetime.datetime.now()
+            print(f"WebMonitor log file created at {self.webMonitor_log_filepath}")
         except Exception as e:
             print(f"Error creating web monitor log file: {str(e)}")
 
@@ -113,24 +182,25 @@ class Logger:
         formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
         if level >= self.log_level:
             if self.text_widget is not None:
-                self._write_to_text_widget(formatted_message)
+                self._enqueue_gui_write(formatted_message, tag="log")
             else:
-                self._pending_widget_messages.append(formatted_message)
+                self._pending_widget_messages.append((formatted_message, "log"))
         # return early if file logging is disabled
         if not self.log_to_file:
             return
         # write to log file if enabled
         if self.log_to_file and level >= self.file_log_level:
-            now = datetime.datetime.now()
-            # close the log file at intervals of 8 hours and create a new one
-            if self.log_start_time == None or (now - self.log_start_time).total_seconds() > 8*60*60:
-                self.setup_log_file()
-            if self.log_file is None:
-                return
             try:
-                file_formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
-                self.log_file.write(file_formatted_message)
-                self.log_file.flush()
+                with self._file_lock:
+                    now = datetime.datetime.now()
+                    # close the log file at intervals of 8 hours and create a new one
+                    if self.log_start_time == None or (now - self.log_start_time).total_seconds() > 8*60*60:
+                        self.setup_log_file()
+                    if self.log_file is None:
+                        return
+                    file_formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
+                    self.log_file.write(file_formatted_message)
+                    self.log_file.flush()
             except Exception as e:
                 print(f"Error writing to log file: {str(e)}")   
     def update_field(self, field, value):
@@ -150,21 +220,21 @@ class Logger:
         if not self.log_to_file:
                 return
         try:
-            now = datetime.datetime.now()
-            # overwrite logs on the same webMonitor file every hour
-            if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
-                if self.webMonitor_log_file:
-                    self.webMonitor_log_file.close()
-                self.setup_wm_logfile()
-            if self.webMonitor_log_file is None:
-                return
-            entry = {
-                "timestamp": now.strftime("%Y-%m-%d %H:%M:%S"),
-                "status": update_dict
-            }
-            self.webMonitor_log_file.write(json.dumps(entry) + "\n")
-            self.webMonitor_log_file.flush()
-
+            with self._file_lock:
+                now = datetime.datetime.now()
+                # overwrite logs on the same webMonitor file every hour
+                if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
+                    if self.webMonitor_log_file:
+                        self.webMonitor_log_file.close()
+                    self.setup_wm_logfile()
+                if self.webMonitor_log_file is None:
+                    return
+                entry = {
+                    "timestamp": now.strftime("%Y-%m-%d %H:%M:%S"),
+                    "status": update_dict
+                }
+                self.webMonitor_log_file.write(json.dumps(entry) + "\n")
+                self.webMonitor_log_file.flush()
         except Exception as e:
             print(f"Error writing web monitor updates: {e}")
 
@@ -188,16 +258,25 @@ class Logger:
         self.log_level = level
 
     def close(self):
+        self._closed = True
+        if self._pump_after_id is not None and self._widget_alive():
+            try:
+                self.text_widget.after_cancel(self._pump_after_id)
+            except tk.TclError:
+                pass
+            self._pump_after_id = None
         if self.log_file:
             try:
-                self.log_file.close()
-                self.log_file = None
+                with self._file_lock:
+                    self.log_file.close()
+                    self.log_file = None
             except Exception as e:
                 print(f"Error closing log file {str(e)}")
         if self.webMonitor_log_file:
             try:
-                self.webMonitor_log_file.close()
-                self.webMonitor_log_file = None
+                with self._file_lock:
+                    self.webMonitor_log_file.close()
+                    self.webMonitor_log_file = None
             except Exception as e:
                 print(f"Error closing web monitor log file {str(e)}")
 
@@ -260,12 +339,20 @@ class MessagesFrame:
         self.logger.info("Messages pane attached to logger")
 
         # Redirect stdout to the text widget
-        sys.stdout = TextRedirector(self.text_widget, "stdout")
+        sys.stdout = TextRedirector(self.text_widget, "stdout", logger=self.logger)
 
     def write(self, msg):
         """ Write message to the text widget and trim if necessary. """
-        self.text_widget.insert(tk.END, msg)
-        self.trim_text()
+        if self.logger:
+            self.logger.write_raw(msg, tag="stdout")
+            if threading.current_thread() is threading.main_thread():
+                self.trim_text()
+            return
+        try:
+            self.text_widget.insert(tk.END, msg)
+            self.trim_text()
+        except tk.TclError:
+            pass
 
     def toggle_file_logging(self):
         if self.file_logging_enabled:
@@ -384,13 +471,21 @@ class MessagesFrame:
             self.text_widget.delete('1.0', tk.END)
 
 class TextRedirector:
-    def __init__(self, widget, tag="stdout"):
+    def __init__(self, widget, tag="stdout", logger=None):
         self.widget = widget
         self.tag = tag
+        self.logger = logger
 
     def write(self, msg):
-        self.widget.insert(tk.END, msg, (self.tag,))
-        self.widget.see(tk.END)  # Scroll to the end
+        if self.logger:
+            self.logger.write_raw(msg, tag=self.tag)
+            return
+        try:
+            if self.widget.winfo_exists():
+                self.widget.insert(tk.END, msg, (self.tag,))
+                self.widget.see(tk.END)  # Scroll to the end
+        except tk.TclError:
+            pass
 
     def flush(self):
         pass  # Needed for compatibility

--- a/utils.py
+++ b/utils.py
@@ -582,7 +582,12 @@ class MachineStatus():
         
         self._previous_status = status_dict.copy()
 
-        self.parent.after(self.update_interval, self.update_status)  # Schedule the next update
+        self.after_id = self.parent.after(self.update_interval, self.update_status)  # Schedule the next update
+
+    def cancel_updates(self):
+        '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        if hasattr(self, 'after_id') and self.after_id:
+            self.parent.after_cancel(self.after_id)
 
     def update_labels(self, status_dict):
             for name, is_active in status_dict.items():

--- a/utils.py
+++ b/utils.py
@@ -26,8 +26,6 @@ class Logger:
 
     def __init__(self, text_widget, file_log_level = LogLevel.VERBOSE, log_level=LogLevel.INFO, log_to_file=False):
         self.text_widget = text_widget
-        # Only updated from the main thread: indicates the text widget is attached and safe to call
-        self._widget_attached = False
         self.file_log_level = file_log_level
         self.log_level = log_level
         self.log_to_file = log_to_file
@@ -65,25 +63,25 @@ class Logger:
         if log_to_file:
             self.setup_log_file()
             self.setup_wm_logfile()
-        # Start GUI pump only if a widget was provided at construction and we're on the main thread.
-        if self.text_widget and threading.current_thread() is threading.main_thread():
-            if hasattr(self.text_widget, "after"):
-                self._widget_attached = True
-                self._start_gui_pump()
+        self._start_gui_pump()
 
     def _get_dashboard_base_path(self):
         return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
 
     def _widget_alive(self):
-        # Do NOT invoke any tkinter methods from background threads (e.g., winfo_exists).
-        # This flag is only set/cleared from the main thread (see attach_text_widget and close()).
-        return bool(self.text_widget) and bool(self._widget_attached)
+        if self.text_widget is None:
+            return False
+        if not hasattr(self.text_widget, "winfo_exists"):
+            return True
+        try:
+            return bool(self.text_widget.winfo_exists())
+        except tk.TclError:
+            return False
 
     def _start_gui_pump(self):
-        # Only start pumping when the widget is attached and supports `after`.
-        if self._closed or not self._widget_attached:
+        if self._closed or not self._widget_alive():
             return
-        if self.text_widget is None or not hasattr(self.text_widget, "after"):
+        if not hasattr(self.text_widget, "after"):
             return
         if self._pump_after_id is None:
             try:
@@ -94,7 +92,7 @@ class Logger:
                 self._pump_after_id = None
 
     def _pump_queue(self):
-        if self._closed or not self._widget_attached:
+        if self._closed or not self._widget_alive():
             self._pump_after_id = None
             return
         try:
@@ -104,8 +102,8 @@ class Logger:
         except queue.Empty:
             pass
         finally:
-            if not self._closed and self._widget_attached:
-                if self.text_widget is None or not hasattr(self.text_widget, "after"):
+            if not self._closed and self._widget_alive():
+                if not hasattr(self.text_widget, "after"):
                     self._pump_after_id = None
                     return
                 try:
@@ -116,8 +114,7 @@ class Logger:
                     self._pump_after_id = None
 
     def _write_to_text_widget(self, formatted_message, tag="log"):
-        # Expect this to be called from the main thread via the pump; guard with the attached flag.
-        if not (self.text_widget and self._widget_attached):
+        if not self._widget_alive():
             return
         try:
             self.text_widget.insert(tk.END, formatted_message, (tag,))
@@ -131,35 +128,20 @@ class Logger:
     def _enqueue_gui_write(self, message, tag="log"):
         if self._closed:
             return
-
-        # Always enqueue into the thread-safe queue.
-        try:
-            self._gui_queue.put((message, tag))
-        except Exception:
-            # If queue put fails for some reason, fall back to pending buffer.
-            try:
-                self._pending_widget_messages.append((message, tag))
-            except Exception:
-                pass
+        if self.text_widget is None:
+            self._pending_widget_messages.append((message, tag))
             return
-
-        # If widget is not attached yet or doesn't support `after`, buffer until attach.
-        if not self._widget_attached or self.text_widget is None or not hasattr(self.text_widget, "after"):
-            try:
-                self._pending_widget_messages.append((message, tag))
-            except Exception:
-                pass
+        if not hasattr(self.text_widget, "after"):
+            self._write_to_text_widget(message, tag)
             return
-
-        # Only call into tkinter (start the pump) from the main thread.
-        if threading.current_thread() is threading.main_thread():
-            self._start_gui_pump()
+        if not self._widget_alive():
+            self._pending_widget_messages.append((message, tag))
+            return
+        self._gui_queue.put((message, tag))
+        self._start_gui_pump()
 
     def attach_text_widget(self, text_widget):
-        # Called from the main thread to attach a tkinter Text widget.
         self.text_widget = text_widget
-        # Mark attached (only set from main thread)
-        self._widget_attached = True
         if not hasattr(self.text_widget, "after"):
             while self._pending_widget_messages:
                 message, tag = self._pending_widget_messages.popleft()
@@ -168,7 +150,6 @@ class Logger:
         while self._pending_widget_messages:
             message, tag = self._pending_widget_messages.popleft()
             self._gui_queue.put((message, tag))
-        # Safe to start pump because this is called on the main thread.
         self._start_gui_pump()
 
     def write_raw(self, message, tag="stdout"):
@@ -310,17 +291,12 @@ class Logger:
 
     def close(self):
         self._closed = True
-        # Try to cancel scheduled after() only from the main thread to avoid Tk calls from background threads.
-        if self._pump_after_id is not None:
-            if threading.current_thread() is threading.main_thread() and self._widget_attached and self.text_widget and hasattr(self.text_widget, "after"):
-                try:
-                    self.text_widget.after_cancel(self._pump_after_id)
-                except tk.TclError:
-                    pass
-            # clear pump id regardless; the pump checks _closed and will stop if running
+        if self._pump_after_id is not None and self._widget_alive():
+            try:
+                self.text_widget.after_cancel(self._pump_after_id)
+            except tk.TclError:
+                pass
             self._pump_after_id = None
-        # mark widget detached
-        self._widget_attached = False
         if self.log_file:
             try:
                 with self._file_lock:

--- a/utils.py
+++ b/utils.py
@@ -71,6 +71,8 @@ class Logger:
     def _widget_alive(self):
         if self.text_widget is None:
             return False
+        if not hasattr(self.text_widget, "winfo_exists"):
+            return True
         try:
             return bool(self.text_widget.winfo_exists())
         except tk.TclError:
@@ -78,6 +80,8 @@ class Logger:
 
     def _start_gui_pump(self):
         if self._closed or not self._widget_alive():
+            return
+        if not hasattr(self.text_widget, "after"):
             return
         if self._pump_after_id is None:
             try:
@@ -99,6 +103,9 @@ class Logger:
             pass
         finally:
             if not self._closed and self._widget_alive():
+                if not hasattr(self.text_widget, "after"):
+                    self._pump_after_id = None
+                    return
                 try:
                     self._pump_after_id = self.text_widget.after(
                         self._pump_interval_ms, self._pump_queue
@@ -111,7 +118,7 @@ class Logger:
             return
         try:
             self.text_widget.insert(tk.END, formatted_message, (tag,))
-            if tag == "log" and not self._log_tag_configured:
+            if tag == "log" and not self._log_tag_configured and hasattr(self.text_widget, "tag_config"):
                 self.text_widget.tag_config("log", font=("Helvetica", 9))
                 self._log_tag_configured = True
             self.text_widget.see(tk.END)
@@ -121,6 +128,12 @@ class Logger:
     def _enqueue_gui_write(self, message, tag="log"):
         if self._closed:
             return
+        if self.text_widget is None:
+            self._pending_widget_messages.append((message, tag))
+            return
+        if not hasattr(self.text_widget, "after"):
+            self._write_to_text_widget(message, tag)
+            return
         if not self._widget_alive():
             self._pending_widget_messages.append((message, tag))
             return
@@ -129,6 +142,11 @@ class Logger:
 
     def attach_text_widget(self, text_widget):
         self.text_widget = text_widget
+        if not hasattr(self.text_widget, "after"):
+            while self._pending_widget_messages:
+                message, tag = self._pending_widget_messages.popleft()
+                self._write_to_text_widget(message, tag)
+            return
         while self._pending_widget_messages:
             message, tag = self._pending_widget_messages.popleft()
             self._gui_queue.put((message, tag))
@@ -154,7 +172,7 @@ class Logger:
                 self.log_filepath = os.path.join(log_dir, log_file_name)
                 self.log_file = open(self.log_filepath, 'w')
                 self.log_start_time = datetime.datetime.now()
-            print(f"Log file created at {self.log_filepath}")
+                self._write_startup_notice("Log file created at", self.log_filepath)
         except Exception as e:
             print(f"Error creating log file: {str(e)}")
 
@@ -172,12 +190,14 @@ class Logger:
                 self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
                 self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
                 self.webMonitor_log_start_time = datetime.datetime.now()
-            print(f"WebMonitor log file created at {self.webMonitor_log_filepath}")
+                self._write_startup_notice("WebMonitor log file created at", self.webMonitor_log_filepath)
         except Exception as e:
             print(f"Error creating web monitor log file: {str(e)}")
 
     def log(self, msg, level=LogLevel.INFO):
         """ Log a message to the text widget and optionally to local file """
+        if self._closed:
+            return
         timestamp = datetime.datetime.now().strftime("%H:%M:%S")
         formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
         if level >= self.log_level:
@@ -216,6 +236,8 @@ class Logger:
         else:
             raise KeyError(f"'{field}' is not a valid key in status dict.")
     def log_dict_update(self, update_dict):
+        if self._closed:
+                return
         # return early if file logging is disabled
         if not self.log_to_file:
                 return
@@ -237,6 +259,16 @@ class Logger:
                 self.webMonitor_log_file.flush()
         except Exception as e:
             print(f"Error writing web monitor updates: {e}")
+
+    def _write_startup_notice(self, prefix, path):
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+        message = f"{prefix} {path}"
+        line = f"[{timestamp}] - INFO: {message}\n"
+        if self.log_file:
+            self.log_file.write(line)
+            self.log_file.flush()
+        if LogLevel.INFO >= self.log_level:
+            self._enqueue_gui_write(line, tag="log")
 
 
     def debug(self, message):
@@ -339,6 +371,7 @@ class MessagesFrame:
         self.logger.info("Messages pane attached to logger")
 
         # Redirect stdout to the text widget
+        self._original_stdout = sys.stdout
         sys.stdout = TextRedirector(self.text_widget, "stdout", logger=self.logger)
 
     def write(self, msg):
@@ -469,6 +502,13 @@ class MessagesFrame:
         ''' Show a confirmation dialog before clearing the text widget '''
         if messagebox.askokcancel("Clear Messages", "Do you really want to clear all messages?"):
             self.text_widget.delete('1.0', tk.END)
+
+    def close(self):
+        if getattr(self, "_original_stdout", None) is not None:
+            sys.stdout = self._original_stdout
+            self._original_stdout = None
+        if self.logger:
+            self.logger.close()
 
 class TextRedirector:
     def __init__(self, widget, tag="stdout", logger=None):


### PR DESCRIPTION
<h3>Graceful Exit</h3>
This is a small bugfix that stops the Tkinter from attempting to update Dashboard components after the Dashboard has been quit by the user. The result is that the console will not print these error messages upon closing the Dashboard. Additionally, quit behavior is modified to always display the "are you sure?" prompt.<br><br>
I added calls to Tkinter's cancel_after() function that cancels scheduled updates. This works because the subsystem that schedules an update task stores a reference (in the form of a unique id) of that task. Then when the user quits the app, the main loop calls the function cancel_updates() on all subsystems that implement that function.<br><br>

**The main changes you will see are:**

1. Storing of after_ids which enable tracking and canceling scheduled updates

2. Implementation of cancel_updates() in individual subsystems

3. Now, on pressing the 'X' in the top right corner of the Dashboard app, a pop-up window will appear with the message: "Do you   want to quit?" This behavior is added to be consistent with when the user presses Ctrl+Q, so that we have one singular "quit the application" event. Having this singular event allows the same cleanup functionalities to always run when we close the Dashboard.


>[!NOTE]
>The PMON polling thread is still not closed correctly, resulting in one error message still being printed on Dashboard exit (after about 5 seconds). This was intentional; the code had been written to cleanly close this thread but then commented out, implying that it might break some functionality. This bug does not have any other effects on the Dashboard.