### PR TITLE
feat: Add EBEAM hardware simulator with virtual serial ports and GUI

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -126,6 +126,25 @@ class EBEAMSystemDashboard:
             foreground=[("disabled", MD_TEXT_DIM)],
         )
         style.configure(
+            "TCombobox",
+            fieldbackground=MD_CARD,
+            background=MD_CARD_BORDER,
+            foreground=MD_TEXT,
+            arrowcolor=MD_TEXT,
+            bordercolor=MD_CARD_BORDER,
+            lightcolor=MD_CARD_BORDER,
+            darkcolor=MD_CARD_BORDER,
+            insertcolor=MD_TEXT,
+            padding=(6, 4),
+        )
+        style.map(
+            "TCombobox",
+            fieldbackground=[("readonly", MD_CARD), ("focus", MD_CARD)],
+            background=[("readonly", MD_CARD_BORDER), ("active", MD_PRIMARY_HOVER)],
+            foreground=[("readonly", MD_TEXT), ("disabled", MD_TEXT_DIM)],
+            arrowcolor=[("active", "#FFFFFF"), ("readonly", MD_TEXT)],
+        )
+        style.configure(
             "MD.TCombobox",
             fieldbackground=MD_CARD,
             background=MD_CARD_BORDER,
@@ -144,6 +163,26 @@ class EBEAMSystemDashboard:
             foreground=[("readonly", MD_TEXT), ("disabled", MD_TEXT_DIM)],
             arrowcolor=[("active", "#FFFFFF"), ("readonly", MD_TEXT)],
         )
+        style.configure(
+            "TEntry",
+            fieldbackground=MD_CARD,
+            background=MD_CARD,
+            foreground=MD_TEXT,
+            bordercolor=MD_CARD_BORDER,
+            lightcolor=MD_CARD_BORDER,
+            darkcolor=MD_CARD_BORDER,
+            insertcolor=MD_TEXT,
+            padding=(6, 4),
+        )
+        style.map(
+            "TEntry",
+            fieldbackground=[("disabled", MD_BG), ("focus", MD_CARD)],
+            foreground=[("disabled", MD_TEXT_DIM)],
+            bordercolor=[("focus", MD_PRIMARY), ("!focus", MD_CARD_BORDER)],
+            lightcolor=[("focus", MD_PRIMARY), ("!focus", MD_CARD_BORDER)],
+            darkcolor=[("focus", MD_PRIMARY), ("!focus", MD_CARD_BORDER)],
+        )
+        style.configure("MD.TEntry", fieldbackground=MD_CARD, background=MD_CARD, foreground=MD_TEXT)
         style.configure("Switch.TCheckbutton", background=MD_BG, foreground=MD_TEXT, padding=(8, 4))
         style.map(
             "Switch.TCheckbutton",
@@ -157,6 +196,16 @@ class EBEAMSystemDashboard:
         self.root.option_add('*TCombobox*Listbox*Foreground', MD_TEXT)
         self.root.option_add('*TCombobox*Listbox*selectBackground', MD_PRIMARY)
         self.root.option_add('*TCombobox*Listbox*selectForeground', '#FFFFFF')
+        self.root.option_add('*Entry*Background', MD_CARD)
+        self.root.option_add('*Entry*Foreground', MD_TEXT)
+        self.root.option_add('*Entry*insertBackground', MD_TEXT)
+        self.root.option_add('*Entry*selectBackground', MD_PRIMARY)
+        self.root.option_add('*Entry*selectForeground', '#FFFFFF')
+        self.root.option_add('*Text*Background', MD_CARD)
+        self.root.option_add('*Text*Foreground', MD_TEXT)
+        self.root.option_add('*Text*insertBackground', MD_TEXT)
+        self.root.option_add('*Text*selectBackground', MD_PRIMARY)
+        self.root.option_add('*Text*selectForeground', '#FFFFFF')
 
         self.set_com_ports = set(serial.tools.list_ports.comports())
         

--- a/dashboard.py
+++ b/dashboard.py
@@ -29,27 +29,45 @@ def resource_path(relative_path):
         base_path = os.path.abspath(".")
     return os.path.join(base_path, relative_path)
 
+# Material Design Dark Theme Palette
+MD_BG           = "#1E1E2E"    # surface
+MD_CARD         = "#2A2A3C"    # card
+MD_CARD_BORDER  = "#3A3A4C"
+MD_PRIMARY      = "#7C4DFF"    # deep purple accent
+MD_PRIMARY_HOVER= "#6A3FE0"
+MD_TEXT         = "#E0E0E0"
+MD_TEXT_DIM     = "#9E9E9E"
+MD_SUCCESS      = "#00C853"
+MD_SUCCESS_HOVER= "#00B248"
+MD_DANGER       = "#B71C1C"
+MD_DANGER_HOVER = "#9A1717"
+
 frames_config = [
     # Row 0
-    ("Interlocks", 0, 1920, 30),
+    ("Interlocks", 0, 1920.0, 30.0),
     
     # Row 1
-    ("Oil System", 1, 520, 120),
-    ("Beam Energy", 1, 1400, 120),
+    ("Oil System", 1, 520.0, 120.0),
+    ("Beam Energy", 1, 1400.0, 120.0),
     
     # Row 2
-    ("Vacuum System", 2, 550, 410),
-    ("Beam Pulse", 2, 1020, 410),
-    ("Main Control", 2, 350, 410),
+    ("Vacuum System", 2, 550.0, 410.0),
+    ("Beam Pulse", 2, 1020.0, 410.0),
+    ("Main Control", 2, 350.0, 410.0),
     
     # Row 4
-    ("Process Monitor", 3, 280, 465),
-    ("Cathode Heating", 3, 1200, 465),
-    ("Messages Frame", 3, 440, 465),
+    ("Process Monitor", 3, 280.0, 465.0),
+    ("Cathode Heating", 3, 1200.0, 465.0),
+    ("Messages Frame", 3, 440.0, 465.0),
 
     # Row 5
-    ("Machine Status", 4, 1920, 35)
+    ("Machine Status", 4, 1920.0, 35.0)
 ]
+
+DEFAULT_WINDOW_WIDTH = 1920.0
+DEFAULT_WINDOW_HEIGHT = 1080.0
+MIN_LAYOUT_WIDTH = 1200
+MIN_LAYOUT_HEIGHT = 675
 
 class EBEAMSystemDashboard:
     """
@@ -77,6 +95,68 @@ class EBEAMSystemDashboard:
         self.root = root
         self.com_ports = com_ports
         self.root.title("EBEAM Control System Dashboard")
+        self.root.configure(bg=MD_BG)
+
+        # Configure Material Dark Style
+        style = ttk.Style()
+        if "clam" in style.theme_names():
+            style.theme_use("clam")
+        
+        style.configure(".", background=MD_BG, foreground=MD_TEXT)
+        style.configure("TFrame", background=MD_BG)
+        style.configure("Card.TFrame", background=MD_CARD)
+        style.configure("TLabel", background=MD_BG, foreground=MD_TEXT)
+        style.configure("Card.TLabel", background=MD_CARD, foreground=MD_TEXT)
+        style.configure("TButton", background=MD_CARD_BORDER, foreground=MD_TEXT, borderwidth=0, focusthickness=0, padding=(10, 6))
+        style.map(
+            "TButton",
+            background=[("active", MD_PRIMARY_HOVER), ("pressed", MD_PRIMARY)],
+            foreground=[("disabled", MD_TEXT_DIM)],
+        )
+        style.configure("Primary.TButton", background=MD_PRIMARY, foreground="#FFFFFF", borderwidth=0, focusthickness=0, padding=(10, 6))
+        style.map(
+            "Primary.TButton",
+            background=[("active", MD_PRIMARY_HOVER), ("pressed", MD_PRIMARY)],
+            foreground=[("disabled", MD_TEXT_DIM)],
+        )
+        style.configure("Danger.TButton", background=MD_DANGER, foreground="#FFFFFF", borderwidth=0, focusthickness=0, padding=(10, 6))
+        style.map(
+            "Danger.TButton",
+            background=[("active", MD_DANGER_HOVER), ("pressed", MD_DANGER)],
+            foreground=[("disabled", MD_TEXT_DIM)],
+        )
+        style.configure(
+            "MD.TCombobox",
+            fieldbackground=MD_CARD,
+            background=MD_CARD_BORDER,
+            foreground=MD_TEXT,
+            arrowcolor=MD_TEXT,
+            bordercolor=MD_CARD_BORDER,
+            lightcolor=MD_CARD_BORDER,
+            darkcolor=MD_CARD_BORDER,
+            insertcolor=MD_TEXT,
+            padding=(6, 4),
+        )
+        style.map(
+            "MD.TCombobox",
+            fieldbackground=[("readonly", MD_CARD), ("focus", MD_CARD)],
+            background=[("readonly", MD_CARD_BORDER), ("active", MD_PRIMARY_HOVER)],
+            foreground=[("readonly", MD_TEXT), ("disabled", MD_TEXT_DIM)],
+            arrowcolor=[("active", "#FFFFFF"), ("readonly", MD_TEXT)],
+        )
+        style.configure("Switch.TCheckbutton", background=MD_BG, foreground=MD_TEXT, padding=(8, 4))
+        style.map(
+            "Switch.TCheckbutton",
+            background=[("selected", MD_SUCCESS), ("active", MD_PRIMARY_HOVER)],
+            foreground=[("selected", "#FFFFFF"), ("disabled", MD_TEXT_DIM)],
+        )
+        style.configure("TNotebook", background=MD_BG, borderwidth=0)
+        style.configure("TNotebook.Tab", background=MD_CARD, foreground=MD_TEXT_DIM, padding=(10, 5))
+        style.map("TNotebook.Tab", background=[("selected", MD_PRIMARY)], foreground=[("selected", "#FFFFFF")])
+        self.root.option_add('*TCombobox*Listbox*Background', MD_CARD)
+        self.root.option_add('*TCombobox*Listbox*Foreground', MD_TEXT)
+        self.root.option_add('*TCombobox*Listbox*selectBackground', MD_PRIMARY)
+        self.root.option_add('*TCombobox*Listbox*selectForeground', '#FFFFFF')
 
         self.set_com_ports = set(serial.tools.list_ports.comports())
         
@@ -125,7 +205,7 @@ class EBEAMSystemDashboard:
 
         # Bind adaptive resize AFTER all frames are created so that
         # Configure events fired during construction are ignored.
-        self.root.bind('<Configure>', self._on_window_resize)
+        self.root.bind('<Configure>', self._on_window_resize, add='+')
 
     def cleanup(self):
         """Closes all open com ports before quitting the application."""
@@ -138,7 +218,7 @@ class EBEAMSystemDashboard:
 
     def setup_main_pane(self):
         """Initialize the main container for absolute layout using place()."""
-        self.main_pane = tk.Frame(self.root)
+        self.main_pane = tk.Frame(self.root, bg=MD_BG)
         self.main_pane.grid(row=0, column=0, sticky='nsew')
         self.root.grid_columnconfigure(0, weight=1)
         self.root.grid_rowconfigure(0, weight=1)
@@ -147,20 +227,26 @@ class EBEAMSystemDashboard:
         self._sashes = []  # list of dicts with widgets and placement meta
         self._grips = []   # bottom resize grips per frame
 
-        # Adaptive layout: compute design reference dimensions from frames_config.
-        # _last_w/_last_h start at 0 (sentinel = "not yet seen a real window size").
-        # On the first <Configure> event with a real size we scale from the design
-        # reference to the actual window; subsequent events scale incrementally.
-        _row_heights = {}
-        _row_widths = {}
-        for _, row, w, h in frames_config:
-            _row_heights[row] = max(_row_heights.get(row, 0), h or 0)
-            _row_widths[row] = _row_widths.get(row, 0) + (w or 0)
-        self._design_w = max(_row_widths.values()) if _row_widths else 1920
-        self._design_h = sum(_row_heights.values()) if _row_heights else 1060
+        # Adaptive layout baseline:
+        # - _base_frames_config keeps the proportions to scale from.
+        # - _design_w/_design_h defines the baseline window size.
+        # Scaling always uses this baseline (non-cumulative) to avoid drift.
+        self._base_frames_config = [
+            (title, row, float(w), float(h)) for title, row, w, h in frames_config
+        ]
+        self._design_w = DEFAULT_WINDOW_WIDTH
+        self._design_h = DEFAULT_WINDOW_HEIGHT
         self._last_w = 0   # 0 = not yet initialised
         self._last_h = 0
         self._resize_pending = None  # after() id for debounced reflow
+
+    def _refresh_resize_baseline(self):
+        """Use current frame dimensions and current window size as the new resize baseline."""
+        self._base_frames_config = [
+            (title, row, float(w), float(h)) for title, row, w, h in frames_config
+        ]
+        self._design_w = max(1.0, float(self.root.winfo_width()))
+        self._design_h = max(1.0, float(self.root.winfo_height()))
 
     def _compute_row_layout(self):
         """Return structures for layout: row_max_heights, sorted_rows, row_to_y, row_x_offsets."""
@@ -178,29 +264,30 @@ class EBEAMSystemDashboard:
         return row_max_heights, sorted_rows, row_to_y, row_x_offsets
 
     def _on_window_resize(self, event):
-        """Handle window <Configure> events and scale frames proportionally."""
+        """Handle window <Configure> events and scale frames proportionally from a fixed baseline."""
         if event.widget is not self.root:
             return
-        new_w = self.root.winfo_width()
-        new_h = self.root.winfo_height()
+        new_w = event.width
+        new_h = event.height
         # Skip spurious pre-render events where Tk reports the window as tiny.
         if new_w < 50 or new_h < 50:
             return
+        # Ignore transient tiny geometries during drag/restore; prevents sudden collapse
+        # of all panels to their minimum clamp sizes.
+        if new_w < MIN_LAYOUT_WIDTH or new_h < MIN_LAYOUT_HEIGHT:
+            return
         if new_w == self._last_w and new_h == self._last_h:
             return
-        # Determine the reference to scale FROM:
-        # - First real event  → scale from original design reference
-        # - Subsequent events → scale incrementally from previous size
-        ref_w = self._design_w if self._last_w == 0 else self._last_w
-        ref_h = self._design_h if self._last_h == 0 else self._last_h
-        if ref_w > 0 and ref_h > 0:
-            scale_x = new_w / ref_w
-            scale_y = new_h / ref_h
-            for i, (title, row, w, h) in enumerate(frames_config):
+        if self._design_w > 0 and self._design_h > 0:
+            scale_x = new_w / self._design_w
+            scale_y = new_h / self._design_h
+            for i, (title, row, _w, _h) in enumerate(frames_config):
+                _, _, base_w, base_h = self._base_frames_config[i]
                 frames_config[i] = (
-                    title, row,
-                    max(80, int(w * scale_x)),
-                    max(10, int(h * scale_y)),
+                    title,
+                    row,
+                    max(80.0, base_w * scale_x),
+                    max(10.0, base_h * scale_y),
                 )
         self._last_w = new_w
         self._last_h = new_h
@@ -239,7 +326,7 @@ class EBEAMSystemDashboard:
             x = row_x_offsets.get(row, 0)
             y = row_to_y.get(row, 0)
             if frame and width > 0 and height > 0:
-                frame.place(x=x, y=y, width=width, height=height)
+                frame.place(x=int(x), y=int(y), width=int(width), height=int(height))
             # Always advance offset, even for spacer/non-rendered entries
             row_x_offsets[row] = x + (width or 0)
 
@@ -255,9 +342,9 @@ class EBEAMSystemDashboard:
                 x += left_w
                 if sash_h <= 0:
                     continue  # skip zero-height sashes (would crash X11)
-                sash = tk.Frame(self.main_pane, cursor='sb_h_double_arrow', bg='#CCCCCC')
+                sash = tk.Frame(self.main_pane, cursor='sb_h_double_arrow', bg=MD_BG)
                 sash_w = 5
-                sash.place(x=x - sash_w // 2, y=y, width=sash_w, height=sash_h)
+                sash.place(x=int(x - sash_w // 2), y=int(y), width=sash_w, height=int(sash_h))
                 self._attach_sash_handlers(sash, row, idx)
                 self._sashes.append({'widget': sash, 'row': row, 'index': idx})
 
@@ -278,11 +365,11 @@ class EBEAMSystemDashboard:
                 if t2 == title:
                     break
                 x += w2
-            grip = tk.Frame(self.main_pane, cursor='sb_v_double_arrow', bg='#CCCCCC')
+            grip = tk.Frame(self.main_pane, cursor='sb_v_double_arrow', bg=MD_BG)
             grip_h = 5
             if width <= 0 or height <= 0:
                 continue  # skip zero-dimension grips (would crash X11)
-            grip.place(x=x, y=y + height - grip_h // 2, width=width, height=grip_h)
+            grip.place(x=int(x), y=int(y + height - grip_h // 2), width=int(width), height=grip_h)
             self._attach_grip_handlers(grip, row, title)
             self._grips.append({'widget': grip, 'row': row, 'title': title})
 
@@ -319,7 +406,7 @@ class EBEAMSystemDashboard:
         left_title, _r, left_w, left_h = frames_config[left_i]
         right_title, _r2, right_w, right_h = frames_config[right_i]
         # Apply delta with clamps
-        min_w = 80
+        min_w = 80.0
         new_left = max(min_w, left_w + dx)
         delta = new_left - left_w
         new_right = max(min_w, right_w - delta)
@@ -328,8 +415,8 @@ class EBEAMSystemDashboard:
             delta = right_w - min_w
             new_left = left_w + delta
             new_right = min_w
-        frames_config[left_i] = (left_title, row, new_left, left_h)
-        frames_config[right_i] = (right_title, row, new_right, right_h)
+        frames_config[left_i] = (left_title, row, float(new_left), left_h)
+        frames_config[right_i] = (right_title, row, float(new_right), right_h)
 
         # Keep merged column width in sync across rows
         if left_title in ("Beam Pulse", "Beam Steering/Pulse", "Beam Pulse Spacer"):
@@ -337,23 +424,25 @@ class EBEAMSystemDashboard:
         if right_title in ("Beam Pulse", "Beam Steering/Pulse", "Beam Pulse Spacer"):
             self._sync_merged_column_width(new_right)
 
+        self._refresh_resize_baseline()
         self._reflow_all()
 
     def _sync_merged_column_width(self, new_width):
         """Ensure the merged middle column keeps the same width in all rows."""
         for i, (t, r, w, h) in enumerate(frames_config):
             if t in ("Beam Pulse", "Beam Steering/Pulse", "Beam Pulse Spacer"):
-                frames_config[i] = (t, r, int(new_width), h)
+                frames_config[i] = (t, r, float(new_width), h)
 
     def _resize_vertical(self, row, title, dy):
         # Change height of a single frame in the row, row stack height follows max of row
-        min_h = 10
+        min_h = 10.0
         # Find the target frame index
         for i, (t, r, w, h) in enumerate(frames_config):
             if r == row and t == title:
                 new_h = max(min_h, h + dy)
-                frames_config[i] = (t, r, w, int(new_h))
+                frames_config[i] = (t, r, w, float(new_h))
                 break
+        self._refresh_resize_baseline()
         self._reflow_all()
 
     def create_frames(self):
@@ -366,10 +455,10 @@ class EBEAMSystemDashboard:
                 continue
 
             if width and height and title:
-                frame = tk.Frame(self.main_pane, borderwidth=1, relief="solid", width=width, height=height)
+                frame = tk.Frame(self.main_pane, bg=MD_CARD, highlightbackground=MD_CARD_BORDER, highlightthickness=1, width=int(width), height=int(height))
                 frame.pack_propagate(False)
             else:
-                frame = tk.Frame(self.main_pane, borderwidth=1, relief="solid")
+                frame = tk.Frame(self.main_pane, bg=MD_CARD, highlightbackground=MD_CARD_BORDER, highlightthickness=1)
 
             # Skip adding title for certain frames
             if title not in ["Interlocks", "Machine Status", "Messages Frame"]:
@@ -407,10 +496,16 @@ class EBEAMSystemDashboard:
         beams_off_button = tk.Button(
             main_frame,
             text="BEAMS E-STOP",
-            bg="red",
+            bg=MD_DANGER,
             fg="white",
-            font=("Helvetica",14,"bold"),
-            command=self.handle_beams_off
+            font=("Segoe UI",14,"bold"),
+            command=self.handle_beams_off,
+            relief="flat",
+            activebackground=MD_DANGER_HOVER,
+            activeforeground="#FFFFFF",
+            disabledforeground=MD_TEXT_DIM,
+            bd=0,
+            cursor="hand2"
         )
         beams_off_button.pack(side="bottom", fill="x", padx=10, pady=(4, 8))
 
@@ -425,11 +520,11 @@ class EBEAMSystemDashboard:
         # --- Manual-tab panel: Beam ON/OFF + CH Enable/Disable buttons --
         # Stored as self.bp_manual_panel so the beam_pulse subsystem can swap
         # it in/out when the Beam Pulse notebook tab changes.
-        self.bp_manual_panel = tk.Frame(main_frame)
+        self.bp_manual_panel = tk.Frame(main_frame, bg=MD_BG)
         self.bp_manual_panel.pack(side="top", fill="x", padx=10, pady=(10, 0))
 
         # Beam ON/OFF row — saved so the tab-change handler can show/hide it
-        self.beam_on_off_frame = tk.Frame(self.bp_manual_panel)
+        self.beam_on_off_frame = tk.Frame(self.bp_manual_panel, bg=MD_BG)
         self.beam_on_off_frame.pack(side="top", fill="x")
         buttons_frame = self.beam_on_off_frame
         for i in range(3):
@@ -441,17 +536,23 @@ class EBEAMSystemDashboard:
             btn = tk.Button(
                 buttons_frame,
                 text=beam_name,
-                bg="gray",
-                fg="white",
-                font=("Helvetica", 10, "bold"),
+                bg=MD_CARD_BORDER,
+                fg=MD_TEXT,
+                font=("Segoe UI", 10, "bold"),
                 state="disabled",  # disabled until armed AND channel enabled
-                command=lambda idx=i: self.toggle_individual_beam_with_status(idx)
+                command=lambda idx=i: self.toggle_individual_beam_with_status(idx),
+                relief="flat",
+                activebackground=MD_PRIMARY_HOVER,
+                activeforeground="#FFFFFF",
+                disabledforeground=MD_TEXT_DIM,
+                bd=0,
+                cursor="hand2"
             )
             btn.grid(row=0, column=i, sticky="ew", padx=2)
             self.beam_toggle_buttons.append(btn)
 
         # CH Enable/Disable row
-        enable_toggle_frame = tk.Frame(self.bp_manual_panel)
+        enable_toggle_frame = tk.Frame(self.bp_manual_panel, bg=MD_BG)
         enable_toggle_frame.pack(side="top", fill="x", pady=(4, 0))
         for i in range(3):
             enable_toggle_frame.grid_columnconfigure(i, weight=1, uniform="button")
@@ -461,17 +562,23 @@ class EBEAMSystemDashboard:
             btn = tk.Button(
                 enable_toggle_frame,
                 text=f"CH{i+1}: Disabled",
-                bg="#888888",
-                fg="white",
-                font=("Helvetica", 9),
+                bg=MD_CARD_BORDER,
+                fg=MD_TEXT,
+                font=("Segoe UI", 9),
                 state="disabled",  # Initially disabled until armed
-                command=lambda idx=i: self._toggle_channel_enable(idx)
+                command=lambda idx=i: self._toggle_channel_enable(idx),
+                relief="flat",
+                activebackground=MD_PRIMARY_HOVER,
+                activeforeground="#FFFFFF",
+                disabledforeground=MD_TEXT_DIM,
+                bd=0,
+                cursor="hand2"
             )
             btn.grid(row=0, column=i, sticky="ew", padx=2)
             self.enable_toggle_buttons.append(btn)
 
         # Add beams armed toggle
-        beams_armed_control_frame = tk.Frame(main_frame)
+        beams_armed_control_frame = tk.Frame(main_frame, bg=MD_BG)
         beams_armed_control_frame.pack(side="bottom", fill="x", padx=10, pady=(8, 4))
         
         beams_armed_label_frame = ttk.Frame(beams_armed_control_frame)
@@ -485,16 +592,23 @@ class EBEAMSystemDashboard:
                 command=self.handle_arm_beams,
                 relief=tk.FLAT,
                 bd=0,
-                bg="white"
+                bg=MD_BG,
+                activebackground=MD_BG
             )
         else:
             self.beams_ready_button = tk.Button(
                 beams_armed_control_frame,
                 text="ARM BEAMS",
-                bg="sky blue",
+                bg=MD_PRIMARY,
                 fg="white",
-                font=("Helvetica",16,"bold"),
-                command=self.handle_arm_beams
+                font=("Segoe UI",16,"bold"),
+                command=self.handle_arm_beams,
+                relief="flat",
+                activebackground=MD_PRIMARY_HOVER,
+                activeforeground="#FFFFFF",
+                disabledforeground=MD_TEXT_DIM,
+                bd=0,
+                cursor="hand2"
             )
         self.beams_ready_button.pack()
 
@@ -510,7 +624,8 @@ class EBEAMSystemDashboard:
         ttk.Button(
             save_layout_frame,
             text="Save Layout",
-            command=self.save_current_pane_state
+            command=self.save_current_pane_state,
+            style="Primary.TButton"
         ).pack(side=tk.LEFT, padx=5)
 
         # 3. Post Processor button
@@ -524,7 +639,7 @@ class EBEAMSystemDashboard:
             config_frame,
             text="Press F1 for keyboard shortcuts",
             font=("Helvetica", 8, "italic"),
-            foreground="gray"
+            foreground=MD_TEXT_DIM
         )
         help_label.pack(side=tk.BOTTOM, anchor='se', padx=5, pady=(10, 5))
 
@@ -579,8 +694,10 @@ class EBEAMSystemDashboard:
             frame: Frame to add title to
             title: Title text to display
         """
-        label = tk.Label(frame, text=title, font=("Helvetica", 10, "bold"))
-        label.pack(pady=0, fill=tk.X)
+        label = tk.Label(frame, text=title, font=("Segoe UI", 12, "bold"), bg=MD_CARD, fg=MD_PRIMARY)
+        label.pack(pady=(5, 0), padx=10, anchor="w")
+        sep = ttk.Separator(frame, orient="horizontal")
+        sep.pack(fill="x", pady=(4, 8), padx=10)
 
     # saves data to file when button is pressed
     def save_current_pane_state(self):
@@ -596,7 +713,7 @@ class EBEAMSystemDashboard:
             if title in savedData and savedData[title]:
                 dims = savedData[title]
                 if isinstance(dims, (list, tuple)) and len(dims) >= 2:
-                    frames_config[i] = (title, frames_config[i][1], dims[0], dims[1])
+                    frames_config[i] = (title, frames_config[i][1], float(dims[0]), float(dims[1]))
 
     def create_log_level_dropdown(self, parent_frame):
         log_level_frame = ttk.Frame(parent_frame)
@@ -610,7 +727,8 @@ class EBEAMSystemDashboard:
             textvariable=self.log_level_var, 
             values=log_levels, 
             state="readonly", 
-            width=15
+            width=15,
+            style="MD.TCombobox"
         )
         log_level_dropdown.pack(side=tk.LEFT, padx=(5, 0))
         
@@ -644,7 +762,7 @@ class EBEAMSystemDashboard:
                     else:
                         self.beams_ready_button.config(
                             text="ARM BEAMS",
-                            bg="sky blue"
+                            bg=MD_PRIMARY
                         )
                     # Disable beam toggle buttons, enable toggle buttons and reset states
                     self.update_beam_toggle_states(enabled=False, reset=True)
@@ -662,7 +780,7 @@ class EBEAMSystemDashboard:
                     else:
                         self.beams_ready_button.config(
                             text="BEAMS ARMED",
-                            bg="navy"  # Darker shade of blue
+                            bg=MD_PRIMARY_HOVER
                         )
                     # Enable beam toggle buttons and enable toggle buttons
                     self.update_beam_toggle_states(enabled=True)
@@ -705,7 +823,7 @@ class EBEAMSystemDashboard:
                         else:
                             self.beams_ready_button.config(
                                 text="ARM BEAMS",
-                                bg="sky blue"
+                                bg=MD_PRIMARY
                             )
                         # Disable beam toggle buttons, enable toggle buttons and reset states
                         self.update_beam_toggle_states(enabled=False, reset=True)
@@ -744,9 +862,9 @@ class EBEAMSystemDashboard:
                 if ch_index < len(self.enable_toggle_buttons):
                     btn = self.enable_toggle_buttons[ch_index]
                     if new_enabled:
-                        btn.config(bg="#2e7d32", text=f"CH{ch_index+1}: Enabled")   # dark green
+                        btn.config(bg=MD_SUCCESS, text=f"CH{ch_index+1}: Enabled")
                     else:
-                        btn.config(bg="#888888", text=f"CH{ch_index+1}: Disabled")  # gray
+                        btn.config(bg=MD_CARD_BORDER, text=f"CH{ch_index+1}: Disabled")
                 # Enable/disable the beam ON/OFF button to match channel enable state
                 if ch_index < len(self.beam_toggle_buttons):
                     self.beam_toggle_buttons[ch_index].config(
@@ -757,7 +875,7 @@ class EBEAMSystemDashboard:
                     beam_names = ["A", "B", "C"]
                     if ch_index < len(self.beam_toggle_buttons):
                         self.beam_toggle_buttons[ch_index].config(
-                            bg="gray", text=f"Beam {beam_names[ch_index]} OFF")
+                            bg=MD_CARD_BORDER, text=f"Beam {beam_names[ch_index]} OFF")
             else:
                 self.logger.warning("BCON driver not available for enable toggle")
         except Exception as e:
@@ -784,13 +902,13 @@ class EBEAMSystemDashboard:
             if current_status:
                 # Currently ON -> turn OFF
                 beam_pulse.send_channel_off(beam_index)
-                btn.config(bg="gray", text=f"Beam {beam_names[beam_index]} OFF")
+                btn.config(bg=MD_CARD_BORDER, text=f"Beam {beam_names[beam_index]} OFF")
                 self.logger.info(f"Beam {beam_names[beam_index]} turned OFF")
             else:
                 # Currently OFF -> send channel config to BCON
                 ok = beam_pulse.send_channel_config(beam_index)
                 if ok:
-                    btn.config(bg="green", text=f"Beam {beam_names[beam_index]} ON")
+                    btn.config(bg=MD_SUCCESS, text=f"Beam {beam_names[beam_index]} ON")
                     self.logger.info(f"Beam {beam_names[beam_index]} config sent to BCON")
                 else:
                     self.logger.error(f"Failed to send Beam {beam_names[beam_index]} config")
@@ -840,7 +958,7 @@ class EBEAMSystemDashboard:
                     
                     # Update button appearance
                     btn = self.beam_toggle_buttons[beam_index]
-                    btn.config(bg="gray", text=f"Beam {beam_names[beam_index]} OFF")
+                    btn.config(bg=MD_CARD_BORDER, text=f"Beam {beam_names[beam_index]} OFF")
                     
                     self.logger.info(f"Beam {beam_names[beam_index]} automatically turned OFF after pulse duration")
                     
@@ -858,7 +976,7 @@ class EBEAMSystemDashboard:
             if status:
                 # Beam turned ON - update button display
                 if beam_index < len(self.beam_toggle_buttons):
-                    self.beam_toggle_buttons[beam_index].config(bg="green", text=f"Beam {beam_names[beam_index]} ON")
+                    self.beam_toggle_buttons[beam_index].config(bg=MD_SUCCESS, text=f"Beam {beam_names[beam_index]} ON")
                 
                 if duration > 0:
                     self.logger.info(f"Beam {beam_names[beam_index]} pulsed for {duration}ms")
@@ -869,7 +987,7 @@ class EBEAMSystemDashboard:
             else:
                 # Beam turned OFF - update button display
                 if beam_index < len(self.beam_toggle_buttons):
-                    self.beam_toggle_buttons[beam_index].config(bg="gray", text=f"Beam {beam_names[beam_index]} OFF")
+                    self.beam_toggle_buttons[beam_index].config(bg=MD_CARD_BORDER, text=f"Beam {beam_names[beam_index]} OFF")
                 
         except Exception as e:
             self.logger.error(f"Error in beam pulse callback for beam {beam_index}: {str(e)}")
@@ -890,14 +1008,14 @@ class EBEAMSystemDashboard:
         is_running = (mode_code != 0) and (remaining > 0 or mode_code == MODE_DC)
         try:
             if is_running:
-                btn.config(bg="green", text=f"Beam {beam_names[ch]} ON")
+                btn.config(bg=MD_SUCCESS, text=f"Beam {beam_names[ch]} ON")
                 if 'Beam Pulse' in self.subsystems and self.subsystems['Beam Pulse'] is not None:
                     self.subsystems['Beam Pulse'].beam_on_status[ch] = True
             else:
                 # Only reset to gray when the button is currently green
                 # (avoids overwriting a manually-initiated OFF state)
-                if str(btn.cget('bg')) == 'green':
-                    btn.config(bg="gray", text=f"Beam {beam_names[ch]} OFF")
+                if str(btn.cget('bg')) == MD_SUCCESS:
+                    btn.config(bg=MD_CARD_BORDER, text=f"Beam {beam_names[ch]} OFF")
                     if 'Beam Pulse' in self.subsystems and self.subsystems['Beam Pulse'] is not None:
                         self.subsystems['Beam Pulse'].beam_on_status[ch] = False
         except Exception:
@@ -921,13 +1039,13 @@ class EBEAMSystemDashboard:
                     )
                     btn.config(state="normal" if ch_enabled else "disabled")
                     if reset:
-                        btn.config(bg="gray", text=f"Beam {beam_names[i]} OFF")
+                        btn.config(bg=MD_CARD_BORDER, text=f"Beam {beam_names[i]} OFF")
                         if 'Beam Pulse' in self.subsystems and self.subsystems['Beam Pulse'] is not None:
                             beam_pulse = self.subsystems['Beam Pulse']
                             if hasattr(beam_pulse, 'set_beam_status'):
                                 beam_pulse.set_beam_status(i, False)
                 else:
-                    btn.config(state="disabled", bg="gray", text=f"Beam {beam_names[i]} OFF")
+                    btn.config(state="disabled", bg=MD_CARD_BORDER, text=f"Beam {beam_names[i]} OFF")
                     if reset:
                         if 'Beam Pulse' in self.subsystems and self.subsystems['Beam Pulse'] is not None:
                             beam_pulse = self.subsystems['Beam Pulse']
@@ -950,7 +1068,7 @@ class EBEAMSystemDashboard:
                     # Keep current Enabled/Disabled appearance; don't forcibly reset visual
                 else:
                     # Disarmed — force all to Disabled appearance and reset tracking
-                    btn.config(state="disabled", bg="#888888", text=f"CH{i+1}: Disabled")
+                    btn.config(state="disabled", bg=MD_CARD_BORDER, text=f"CH{i+1}: Disabled")
                     if hasattr(self, '_ch_enable_states') and i < len(self._ch_enable_states):
                         self._ch_enable_states[i] = False
         except Exception as e:
@@ -1148,6 +1266,7 @@ class EBEAMSystemDashboard:
             port_var = tk.StringVar(value=self.com_ports.get(subsystem, ''))
             self.port_selections[subsystem] = port_var
             dropdown = ttk.Combobox(frame, textvariable=port_var)
+            dropdown.configure(style="MD.TCombobox", state="readonly")
             dropdown.pack(side=tk.RIGHT)
             self.port_dropdowns[subsystem] = dropdown
 
@@ -1159,10 +1278,11 @@ class EBEAMSystemDashboard:
             port_var = tk.StringVar(value=self.com_ports.get('Beam Pulse', ''))
             self.port_selections['Beam Pulse'] = port_var
             dropdown = ttk.Combobox(frame, textvariable=port_var)
+            dropdown.configure(style="MD.TCombobox", state="readonly")
             dropdown.pack(side=tk.RIGHT)
             self.port_dropdowns['Beam Pulse'] = dropdown
 
-        ttk.Button(self.com_port_menu, text="Apply", command=self.apply_com_port_changes).pack(pady=5)
+        ttk.Button(self.com_port_menu, text="Apply", command=self.apply_com_port_changes, style="Primary.TButton").pack(pady=5)
 
     def toggle_com_port_menu(self):
         if self.com_port_menu.winfo_viewable():

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import os
+import platform
 import subsystem
 import tkinter as tk
 from tkinter import ttk
@@ -68,6 +69,20 @@ DEFAULT_WINDOW_WIDTH = 1920.0
 DEFAULT_WINDOW_HEIGHT = 1080.0
 MIN_LAYOUT_WIDTH = 1200
 MIN_LAYOUT_HEIGHT = 675
+
+PLATFORM_SYSTEM = platform.system().lower()
+IS_WINDOWS = PLATFORM_SYSTEM == "windows"
+IS_LINUX = PLATFORM_SYSTEM == "linux"
+
+
+def list_serial_ports_by_os():
+    """Return available serial ports filtered for the current OS."""
+    ports = [port.device for port in serial.tools.list_ports.comports() if port.device]
+    if IS_WINDOWS:
+        ports = [port for port in ports if port.upper().startswith("COM")]
+    elif IS_LINUX:
+        ports = [port for port in ports if port.startswith("/dev/tty")]
+    return sorted(set(ports))
 
 class EBEAMSystemDashboard:
     """
@@ -721,7 +736,7 @@ class EBEAMSystemDashboard:
             post_processor_path = os.path.join(base_path, 'scripts/post-process/post_process_gui.py')
 
             # Launch the post-processor script
-            if sys.platform.startswith('win'):
+            if IS_WINDOWS:
                 # On Windows, use pythonw to avoid console window
                 subprocess.Popen([sys.executable, post_processor_path], 
                             creationflags=subprocess.CREATE_NO_WINDOW)
@@ -1344,7 +1359,7 @@ class EBEAMSystemDashboard:
 
     def update_available_ports(self):
         """Scan for available COM ports and update dropdown menus."""
-        available_ports = [port.device for port in serial.tools.list_ports.comports()]
+        available_ports = list_serial_ports_by_os()
         for dropdown in self.port_dropdowns.values():
             current_value = dropdown.get()
             dropdown['values'] = available_ports

--- a/dashboard.py
+++ b/dashboard.py
@@ -123,6 +123,10 @@ class EBEAMSystemDashboard:
 
         self._check_ports()
 
+        # Bind adaptive resize AFTER all frames are created so that
+        # Configure events fired during construction are ignored.
+        self.root.bind('<Configure>', self._on_window_resize)
+
     def cleanup(self):
         """Closes all open com ports before quitting the application."""
 
@@ -143,6 +147,21 @@ class EBEAMSystemDashboard:
         self._sashes = []  # list of dicts with widgets and placement meta
         self._grips = []   # bottom resize grips per frame
 
+        # Adaptive layout: compute design reference dimensions from frames_config.
+        # _last_w/_last_h start at 0 (sentinel = "not yet seen a real window size").
+        # On the first <Configure> event with a real size we scale from the design
+        # reference to the actual window; subsequent events scale incrementally.
+        _row_heights = {}
+        _row_widths = {}
+        for _, row, w, h in frames_config:
+            _row_heights[row] = max(_row_heights.get(row, 0), h or 0)
+            _row_widths[row] = _row_widths.get(row, 0) + (w or 0)
+        self._design_w = max(_row_widths.values()) if _row_widths else 1920
+        self._design_h = sum(_row_heights.values()) if _row_heights else 1060
+        self._last_w = 0   # 0 = not yet initialised
+        self._last_h = 0
+        self._resize_pending = None  # after() id for debounced reflow
+
     def _compute_row_layout(self):
         """Return structures for layout: row_max_heights, sorted_rows, row_to_y, row_x_offsets."""
         row_max_heights = {}
@@ -157,6 +176,43 @@ class EBEAMSystemDashboard:
         # initial x offsets per row
         row_x_offsets = {r: 0 for r in sorted_rows}
         return row_max_heights, sorted_rows, row_to_y, row_x_offsets
+
+    def _on_window_resize(self, event):
+        """Handle window <Configure> events and scale frames proportionally."""
+        if event.widget is not self.root:
+            return
+        new_w = self.root.winfo_width()
+        new_h = self.root.winfo_height()
+        # Skip spurious pre-render events where Tk reports the window as tiny.
+        if new_w < 50 or new_h < 50:
+            return
+        if new_w == self._last_w and new_h == self._last_h:
+            return
+        # Determine the reference to scale FROM:
+        # - First real event  → scale from original design reference
+        # - Subsequent events → scale incrementally from previous size
+        ref_w = self._design_w if self._last_w == 0 else self._last_w
+        ref_h = self._design_h if self._last_h == 0 else self._last_h
+        if ref_w > 0 and ref_h > 0:
+            scale_x = new_w / ref_w
+            scale_y = new_h / ref_h
+            for i, (title, row, w, h) in enumerate(frames_config):
+                frames_config[i] = (
+                    title, row,
+                    max(80, int(w * scale_x)),
+                    max(10, int(h * scale_y)),
+                )
+        self._last_w = new_w
+        self._last_h = new_h
+        # Debounce: wait 50 ms after the last resize event before reflowing.
+        if self._resize_pending is not None:
+            self.root.after_cancel(self._resize_pending)
+        self._resize_pending = self.root.after(50, self._do_resize_reflow)
+
+    def _do_resize_reflow(self):
+        """Perform the actual reflow after the debounce period."""
+        self._resize_pending = None
+        self._reflow_all()
 
     def _reflow_all(self):
         """Re-place frames, sashes and grips after a resize change."""
@@ -182,7 +238,7 @@ class EBEAMSystemDashboard:
             frame = self.frames.get(title)
             x = row_x_offsets.get(row, 0)
             y = row_to_y.get(row, 0)
-            if frame:
+            if frame and width > 0 and height > 0:
                 frame.place(x=x, y=y, width=width, height=height)
             # Always advance offset, even for spacer/non-rendered entries
             row_x_offsets[row] = x + (width or 0)
@@ -192,13 +248,16 @@ class EBEAMSystemDashboard:
             # Recalculate X running sum for sash positions
             x = 0
             y = row_to_y[row]
+            sash_h = row_max_heights.get(row, 0)
             for idx in range(len(members) - 1):
                 left_title, left_w, left_h = members[idx]
                 right_title, right_w, right_h = members[idx + 1]
                 x += left_w
+                if sash_h <= 0:
+                    continue  # skip zero-height sashes (would crash X11)
                 sash = tk.Frame(self.main_pane, cursor='sb_h_double_arrow', bg='#CCCCCC')
                 sash_w = 5
-                sash.place(x=x - sash_w // 2, y=y, width=sash_w, height=row_max_heights[row])
+                sash.place(x=x - sash_w // 2, y=y, width=sash_w, height=sash_h)
                 self._attach_sash_handlers(sash, row, idx)
                 self._sashes.append({'widget': sash, 'row': row, 'index': idx})
 
@@ -221,6 +280,8 @@ class EBEAMSystemDashboard:
                 x += w2
             grip = tk.Frame(self.main_pane, cursor='sb_v_double_arrow', bg='#CCCCCC')
             grip_h = 5
+            if width <= 0 or height <= 0:
+                continue  # skip zero-dimension grips (would crash X11)
             grip.place(x=x, y=y + height - grip_h // 2, width=width, height=grip_h)
             self._attach_grip_handlers(grip, row, title)
             self._grips.append({'widget': grip, 'row': row, 'title': title})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,3 +77,10 @@ All notable changes to the EBEAM Dashboard project are documented here.
     - New `reset_interlock()` API clears the forced-off latch and re-evaluates interlock state from upstream input.
     - Added `Reset` button in the BCON simulator card.
     - `Reset` is enabled only while interlock is latched forced-off; normal state keeps it disabled.
+
+  - **Cross-platform simulator serial backend (Linux + Windows)** (`simulator/virtual_serial.py`, `simulator/run_simulator.py`)  
+    Refactored virtual serial layer to support Windows in addition to Linux:
+    - Linux/macOS: existing PTY master/slave backend retained.
+    - Windows: COM null-modem backend using paired ports (e.g. com0com `CNCAx`/`CNCBx`).
+    - Windows mapping sources: `EBEAM_SIM_PORT_MAP_FILE`, `EBEAM_SIM_PORT_MAP`, or automatic com0com pair detection.
+    - Added friendly startup error messaging in launcher when Windows COM mapping is missing/misconfigured.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to the EBEAM Dashboard project are documented here.
 
 ### Fixed
 
+- **UI Layout Glitches on Resize** (`dashboard.py`)  
+  Fixed subpanel arrangement issues and UI glitches during window resizing and moving. Transitioned the adaptive layout engine to use floating-point math for all width/height calculations, preventing cumulative integer truncation/rounding errors.
+
+- **Window restore size after maximize/fullscreen drag-out** (`main.py`)  
+  Enforced a deterministic restore geometry of `1920x1080` when leaving fullscreen/maximized state (keyboard toggle or window-manager drag/restore). Added a `<Configure>` transition guard so maximize → normal always snaps back to the target restore size.
+
+- **Dashboard restore behavior and proportional panel scaling refinement** (`main.py`, `dashboard.py`)  
+  Revised restore/resize behavior for consistency and stability:
+  - Exiting fullscreen/maximized on the dashboard now consistently restores to `1920x1080` across keyboard and window-manager transitions.
+  - Subpanel resizing now scales from a stable baseline instead of cumulative step-scaling, preserving layout proportions during repeated resize/drag operations.
+  - Manual sash/grip panel adjustments are incorporated into the next resize baseline so user-adjusted proportions remain consistent on subsequent window resizes.
+
+- **Main-screen drag-collapse prevention** (`dashboard.py`, `main.py`)  
+  Fixed an issue where entering the dashboard main screen and dragging/restoring the window could shrink the entire layout to near-minimum size:
+  - Added minimum dashboard window size (`1200x675`) in the main app window.
+  - Updated resize handling to use event geometry and ignore transient tiny `<Configure>` sizes during drag/restore transitions.
+  - Prevented accidental global subpanel down-scaling caused by short-lived window-manager geometry glitches.
+
+- **Tk integer argument crash in log panel sizing** (`utils.py`)  
+  Fixed `_tkinter.TclError: expected integer but got "44.0"` by coercing `tk.Text` character `width` / `height` inputs to safe integers when frame dimensions are float-scaled.
+
 - **Linux compatibility — window maximize** (`main.py`)  
   Replaced `root.state('zoomed')` (Windows-only) with `root.attributes('-zoomed', True)` in `start_main_app()` and `toggle_maximize()`. The previous call raised `_tkinter.TclError: bad argument "zoomed"` on Linux/X11.
 
@@ -25,6 +46,15 @@ All notable changes to the EBEAM Dashboard project are documented here.
   Background polling threads (e.g. `poll_all_units` in `DP16_process_monitor`) continued to call `MessagesFrame.log()` after the Tk window was destroyed on quit, raising `TclError: invalid command name`. Wrapped the `text_widget.insert()` / `see()` calls in `try/except tk.TclError`; messages that arrive after window destruction fall back to `print()`.
 
 ### Added
+
+- **Material Dark Theme** (`dashboard.py`, `utils.py`, `subsystem/*`)  
+  Applied a consistent Material Design Dark theme across the entire dashboard and all subsystems. Replaced hardcoded colors with a unified palette (`MD_BG`, `MD_CARD`, `MD_PRIMARY`, `MD_TEXT`, etc.) for backgrounds, text, buttons, and plots.
+
+- **Material control variants for interactive UI elements** (`dashboard.py`, `main.py`)  
+  Extended the dark theme with refined control styling for actions and selectors:
+  - Added themed button variants (`Primary`, `Danger`) with hover/pressed states and consistent padding.
+  - Added styled option selectors (`ttk.Combobox`) including dark dropdown list colors and focused/readonly states.
+  - Updated beam/channel toggle controls and COM-port/config controls for consistent Material interaction feedback.
 
 - **Adaptive / responsive UI** (`dashboard.py`)  
   The dashboard layout now scales proportionally whenever the window is resized or un-maximised:
@@ -84,3 +114,22 @@ All notable changes to the EBEAM Dashboard project are documented here.
     - Windows: COM null-modem backend using paired ports (e.g. com0com `CNCAx`/`CNCBx`).
     - Windows mapping sources: `EBEAM_SIM_PORT_MAP_FILE`, `EBEAM_SIM_PORT_MAP`, or automatic com0com pair detection.
     - Added friendly startup error messaging in launcher when Windows COM mapping is missing/misconfigured.
+
+  - **CCS-410 PSU simulator command/state fidelity improvements** (`simulator/instruments.py`)  
+    Refined `PowerSupply9104Sim` command handling to better match dashboard driver/manual usage:
+    - Added stateful handling for `SETD`, `SETM`, `SABC`, `GDLT`/`SDLT`, and `GSWT`/`SSWT`.
+    - Expanded `GALL` to return a structured aggregate status payload rather than a generic ack.
+    - Preset selection now synchronizes active setpoints (`voltage_set`, `current_set`) with selected preset values.
+
+  - **E5CN simulator PV register encoding refinement** (`simulator/instruments.py`)  
+    Updated `E5CNModbusSim` PV register behavior for better controller realism:
+    - Keeps project-compatible read path (`addr=0x0000`, `count>=2`, PV in `regs[1]`).
+    - Encodes PV at 0.1°C resolution using signed 16-bit (two’s complement) representation, improving sub-zero temperature fidelity.
+
+  - **G9SP simulator manual-aligned protocol/status refinement** (`simulator/instruments.py`)  
+    Refined `G9DriverSim` based on the G9SP operator manual response format and status model:
+    - Added explicit normal response control bytes (`End code=0x0000`, `Service code=0xCB`) and command-format error response (`LL=0x06`).
+    - Added request validation (fixed header/footer and checksum) before generating a normal response.
+    - Implemented manual-aligned status fields: terminal status flags (`SITSF`/`SOTSF`) now represent self-diagnosis health (`1=normal, 0=error`) independent of ON/OFF data flags.
+    - Implemented Safety Input/Output terminal error-cause nibbles (`SITEC`/`SOTEC`) from simulator state.
+    - Added Unit Status bit mapping (normal/output power/safety I/O/function block), Configuration ID, and Unit Conduction Time fields.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to the EBEAM Dashboard project are documented here.
+
+---
+
+## [Unreleased] - 2026-02-26
+
+### Fixed
+
+- **Linux compatibility — window maximize** (`main.py`)  
+  Replaced `root.state('zoomed')` (Windows-only) with `root.attributes('-zoomed', True)` in `start_main_app()` and `toggle_maximize()`. The previous call raised `_tkinter.TclError: bad argument "zoomed"` on Linux/X11.
+
+- **Dependencies — pandas Python 3.13 compatibility** (`requirements.txt`)  
+  Changed `pandas==2.1.3` to `pandas>=2.2.0`. Version 2.1.3 fails to build from source on Python 3.13 due to a Cython/`_PyLong_AsByteArray` API incompatibility introduced in CPython 3.13.
+
+- **Adaptive UI crash — X11 `BadValue (0x0)` on startup** (`dashboard.py`)  
+  Before the root window was fully rendered, `winfo_width()` returned `1`. The resize handler used this as the scaling baseline, producing explosive scale factors (e.g. `1920 / 1 = 1920×`) that corrupted all frame dimensions to values that caused X11 `X_CreatePixmap` to fail with `BadValue`. Fixed by:
+  - Storing the design reference dimensions (`_design_w`, `_design_h`) from `frames_config` separately in `setup_main_pane()`.
+  - Using `_last_w = 0` / `_last_h = 0` as a "not yet initialised" sentinel; the first real resize event now scales from the design reference rather than a garbage value.
+  - Skipping `<Configure>` events where `winfo_width() < 50` (pre-render noise from Tk).
+  - Adding `width > 0 and height > 0` guards before every `place()` call (frames, sashes, grips) so zero-dimension pixmaps are never passed to X11.
+
+- **Thread teardown error — log widget destroyed** (`utils.py`)  
+  Background polling threads (e.g. `poll_all_units` in `DP16_process_monitor`) continued to call `MessagesFrame.log()` after the Tk window was destroyed on quit, raising `TclError: invalid command name`. Wrapped the `text_widget.insert()` / `see()` calls in `try/except tk.TclError`; messages that arrive after window destruction fall back to `print()`.
+
+### Added
+
+- **Adaptive / responsive UI** (`dashboard.py`)  
+  The dashboard layout now scales proportionally whenever the window is resized or un-maximised:
+  - `_on_window_resize(event)` — bound to `root <Configure>` after all frames are created (avoids spurious construction events). Computes `scale_x` / `scale_y` from the previous window size, updates every entry in `frames_config`, and schedules a debounced reflow.
+  - `_do_resize_reflow()` — fires 50 ms after the last resize event to avoid reflowing on every pixel of a drag operation.
+  - Existing manual sash (horizontal) and grip (vertical) drag-resize continue to work; the resize handler scales from whatever dimensions the user last set.
+  - The `<Configure>` binding is registered at the end of `__init__()`, after `create_frames()` and `create_subsystems()`, so construction-time Configure events do not trigger premature scaling.
+
+- **Hardware simulator** (`simulator/`)  
+  A full virtual-hardware simulator that lets the dashboard run without any physical equipment. Located in the `simulator/` folder:
+
+  - **`virtual_serial.py`** — `PortManager` creates Linux PTY pairs (`/dev/pts/XX`) for each subsystem. The slave path is given to the dashboard as a real serial port; the master fd is used by instrument threads.
+  - **`instruments.py`** — One simulator class per instrument protocol:
+    | Simulator | Protocol | What it emulates |
+    |-----------|----------|------------------|
+    | `VTRXSimulator` | Read-only ASCII stream, 1 Hz | Vacuum pressure + 8 switch bits |
+    | `PowerSupply9104Sim` | ASCII cmd/response (×3 instances) | Cathode heater PSU (GETD, VOLT, CURR, SOUT, …) |
+    | `E5CNModbusSim` | Modbus RTU 8E2, slaves 1–3 | Omron E5CN temperature controllers |
+    | `G9DriverSim` | Raw binary 199-byte packets | G9SP safety interlocks (13 inputs) |
+    | `DP16ProcessMonitorSim` | Modbus RTU 8N1, slaves 1–5 | DP16PT RTD process monitors (IEEE 754 float) |
+    | `BCONDriverSim` | Modbus RTU, 160 registers | BCON beam pulse controller (arm, mode, enable, etc.) |
+  - **`sim_gui.py`** — Material Design dark-themed Tkinter GUI with card-based layout. Each instrument gets a live-updating card showing its current state. Operator controls include interlock toggles, pressure slider, temperature sliders, and channel inspection.
+  - **`run_simulator.py`** — Entry point / launcher:
+    - `python -m simulator.run_simulator` — opens the simulator GUI only  
+    - `python -m simulator.run_simulator --dashboard` — writes virtual port mapping to `usr/usr_data/com_ports.json` and auto-launches the dashboard as a child process  
+    - `--print-ports` — prints the JSON port map and exits  
+    - On exit: stops all simulator threads, closes PTY pairs, terminates the dashboard child.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,3 +52,28 @@ All notable changes to the EBEAM Dashboard project are documented here.
     - `python -m simulator.run_simulator --dashboard` — writes virtual port mapping to `usr/usr_data/com_ports.json` and auto-launches the dashboard as a child process  
     - `--print-ports` — prints the JSON port map and exits  
     - On exit: stops all simulator threads, closes PTY pairs, terminates the dashboard child.
+
+  ### Updated
+
+  - **Interlocks simulator protocol fidelity** (`simulator/instruments.py`)  
+    Refined `G9DriverSim` to match the real G9 driver parsing rules:
+    - Response header bytes now follow expected format (`0x40 0x00 0x00 0xC3`).
+    - Unit status at offset 73 is set to `0x0100` for normal operation.
+    - `SITDF` / `SITSF` bits are packed in the same bit order used by `G9Driver._extract_flags(...)`.
+    - `SOTDF` / `SOTSF` bit-4 now drives the `g9_active` signal consumed by the interlocks subsystem.
+
+  - **Cross-subsystem safety linkage (G9SP → BCON)** (`simulator/run_simulator.py`)  
+    Added a live callback link so BCON interlock health follows the simulated G9 interlock chain state. Interlock faults injected in the G9 simulator now propagate immediately into BCON safety state.
+
+  - **BCON interlock force-off behavior (one-way fault injection)** (`simulator/instruments.py`, `simulator/sim_gui.py`)  
+    The BCON GUI control is now one-way:
+    - Replaced interlock toggle with `Force OFF`.
+    - Once pressed, interlock is latched forced-off (`interlock_forced_off=True`) and cannot be restored via the UI toggle path.
+    - BCON interlock evaluation now respects forced-off latch first, then upstream interlock input.
+    - UI reflects latched state by disabling the button and showing `FORCED OFF`.
+
+  - **BCON interlock reset control** (`simulator/instruments.py`, `simulator/sim_gui.py`)  
+    Added an explicit reset path for simulator operations:
+    - New `reset_interlock()` API clears the forced-off latch and re-evaluates interlock state from upstream input.
+    - Added `Reset` button in the BCON simulator card.
+    - `Reset` is enabled only while interlock is latched forced-off; normal state keeps it disabled.

--- a/instrumentctl/BCON/bcon_driver.py
+++ b/instrumentctl/BCON/bcon_driver.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import copy
 import inspect
 import logging
+import platform
 import queue
 import threading
 import time
@@ -127,15 +128,24 @@ def scan_serial_ports() -> List[str]:
     """Return a list of available serial ports, with Arduino-like ports first."""
     if list_ports is None:
         return []
+    is_windows = platform.system().lower() == "windows"
+    is_linux = platform.system().lower() == "linux"
     ports = list_ports.comports()
     preferred, others = [], []
     for p in ports:
+        device = getattr(p, "device", None)
+        if not device:
+            continue
+        if is_windows and not str(device).upper().startswith("COM"):
+            continue
+        if is_linux and not str(device).startswith("/dev/tty"):
+            continue
         desc = (getattr(p, "description", "") or "").lower()
         hwid = (getattr(p, "hwid", "") or "").lower()
         if any(tok in desc for tok in ("arduino", "usb serial", "ch340", "cp210")) or "vid:pid=2341" in hwid:
-            preferred.append(p.device)
+            preferred.append(device)
         else:
-            others.append(p.device)
+            others.append(device)
     return preferred + others
 
 

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from threading import Lock
+from threading import Lock, RLock
 import struct
 import math
 from utils import LogLevel
@@ -14,6 +14,10 @@ class DP16ProcessMonitor:
     PROCESS_VALUE_REG = 0x210   # Page 8: CNPt Series Programming User's Guide Modbus Interface
     RDGCNF_REG = 0x248          # Page 9: CNPt Series Programming User's Guide Modbus Interface
     STATUS_REG = 0x240          # Page 9: CNPt Series Programming User's Guide Modbus Interface
+
+    # Alternate map from iSeries Modbus table (manual section 6.7)
+    PROCESS_VALUE_REG_ALT = 39
+    RDGCNF_REG_ALT = 8
 
     STATUS_RUNNING = 0x0006
 
@@ -34,23 +38,45 @@ class DP16ProcessMonitor:
     DISCONNECTED = -1
     SENSOR_ERROR = -2
 
-    def __init__(self, port, unit_numbers=(1,2,3,4,5), baudrate=9600, logger=None):
+    def __init__(
+        self,
+        port,
+        unit_numbers=(1, 2, 3, 4, 5, 6),
+        baudrate=9600,
+        bytesize=8,
+        parity='N',
+        stopbits=1,
+        timeout=0.25,
+        prefer_manual_map=True,
+        auto_detect_serial_profile=True,
+        logger=None,
+    ):
         """ Initialize Modbus settings """
+        self.port = port
+        self.baudrate = baudrate
+        self.bytesize = bytesize
+        self.parity = parity
+        self.stopbits = stopbits
+        self.timeout = timeout
+        self.auto_detect_serial_profile = auto_detect_serial_profile
+
         self.client = ModbusClient(
-            port=port,
-            baudrate=baudrate,
-            bytesize=8,
-            parity='N',
-            stopbits=1,
-            timeout=0.2
+            port=self.port,
+            baudrate=self.baudrate,
+            bytesize=self.bytesize,
+            parity=self.parity,
+            stopbits=self.stopbits,
+            timeout=self.timeout
         )
+        self.prefer_manual_map = prefer_manual_map
         self.unit_numbers = set(unit_numbers)
-        self.modbus_lock = Lock()
+        self.modbus_lock = RLock()
         self.logger = logger
 
         self.temperature_readings = {unit: None for unit in unit_numbers}
         self.consecutive_error_counts = {unit: 0 for unit in self.unit_numbers}
         self.last_good_readings = {unit: None for unit in self.unit_numbers}
+        self.unit_map_mode = {unit: None for unit in self.unit_numbers}  # 'float_map' or 'int_map'
         self.consecutive_connection_errors = 0
 
         self._is_running = True
@@ -62,12 +88,150 @@ class DP16ProcessMonitor:
         self._thread = threading.Thread(target=self.poll_all_units, daemon=True)
         self._thread.start()
 
+    def _set_serial_profile_locked(self, bytesize: int, parity: str, stopbits: int):
+        """Rebuild serial client with a new framing profile. Caller must hold modbus_lock."""
+        try:
+            if self.client.is_socket_open():
+                self.client.close()
+        except Exception:
+            pass
+
+        self.bytesize = bytesize
+        self.parity = parity
+        self.stopbits = stopbits
+        self.client = ModbusClient(
+            port=self.port,
+            baudrate=self.baudrate,
+            bytesize=self.bytesize,
+            parity=self.parity,
+            stopbits=self.stopbits,
+            timeout=self.timeout,
+        )
+
+    def _probe_working_units_locked(self):
+        """Probe all configured units and return set of working unit ids. Caller must hold modbus_lock."""
+        working_units = set()
+        for unit in self.unit_numbers:
+            try:
+                map_mode = self._probe_unit_map_locked(unit)
+                if map_mode:
+                    working_units.add(unit)
+                    self.unit_map_mode[unit] = map_mode
+                    continue
+                self.log(f"DP16 Unit {unit} not responding", LogLevel.WARNING)
+            except ModbusIOException:
+                self.log(f"DP16 Unit {unit} not responding", LogLevel.WARNING)
+            finally:
+                time.sleep(self.INTER_REQUEST_DELAY)
+        return working_units
+
+    @staticmethod
+    def _to_signed_16(value: int) -> int:
+        return value - 0x10000 if value >= 0x8000 else value
+
+    @staticmethod
+    def _rdgcnf_multiplier(rdgcnf: int) -> float:
+        decimal_code = (rdgcnf >> 5) & 0x07
+        if decimal_code == 1:
+            return 1.0
+        if decimal_code == 2:
+            return 10.0
+        if decimal_code == 3:
+            return 100.0
+        if decimal_code == 4:
+            return 1000.0
+        return 1.0
+
+    def _probe_unit_map_locked(self, unit: int):
+        """Probe unit register map. Caller must hold modbus_lock."""
+        if self.prefer_manual_map:
+            try:
+                rdgcnf_resp = self._read_holding_registers_locked(
+                    address=self.RDGCNF_REG_ALT,
+                    count=1,
+                    slave=unit
+                )
+                pv_resp = self._read_holding_registers_locked(
+                    address=self.PROCESS_VALUE_REG_ALT,
+                    count=1,
+                    slave=unit
+                )
+                rdgcnf = rdgcnf_resp.registers[0]
+                counts = self._to_signed_16(pv_resp.registers[0])
+                multiplier = self._rdgcnf_multiplier(rdgcnf)
+                value = counts / multiplier if multiplier else float(counts)
+                if self.MIN_TEMP <= value <= self.MAX_TEMP:
+                    self.log(
+                        f"DP16 Unit {unit} responded on manual map (reg39/reg8): {value:.2f}C",
+                        LogLevel.VERBOSE
+                    )
+                return 'int_map'
+            except ModbusIOException:
+                pass
+
+        try:
+            status = self._read_holding_registers_locked(
+                address=self.STATUS_REG,
+                count=1,
+                slave=unit
+            )
+            self.log(
+                f"DP16 Unit {unit} responded on float map with status: {status.registers[0]}",
+                LogLevel.VERBOSE
+            )
+            return 'float_map'
+        except ModbusIOException:
+            pass
+
+        try:
+            rdgcnf_resp = self._read_holding_registers_locked(
+                address=self.RDGCNF_REG_ALT,
+                count=1,
+                slave=unit
+            )
+            pv_resp = self._read_holding_registers_locked(
+                address=self.PROCESS_VALUE_REG_ALT,
+                count=1,
+                slave=unit
+            )
+            rdgcnf = rdgcnf_resp.registers[0]
+            counts = self._to_signed_16(pv_resp.registers[0])
+            multiplier = self._rdgcnf_multiplier(rdgcnf)
+            value = counts / multiplier if multiplier else float(counts)
+            if self.MIN_TEMP <= value <= self.MAX_TEMP:
+                self.log(
+                    f"DP16 Unit {unit} responded on int map (reg39/reg8): {value:.2f}C",
+                    LogLevel.VERBOSE
+                )
+            else:
+                self.log(
+                    f"DP16 Unit {unit} int-map probe returned out-of-range value {value:.2f}C; continuing",
+                    LogLevel.DEBUG
+                )
+            return 'int_map'
+        except ModbusIOException:
+            return None
+
     def _read_holding_registers_locked(self, address: int, count: int, slave: int):
-        """Read holding registers with retry. Caller must hold modbus_lock."""
+        """Read register(s) with retry. Caller must hold modbus_lock.
+
+        Manual states 03/04 are valid for reads, so we try 03 first then 04.
+        """
         last_exception = None
         for attempt in range(self.REQUEST_RETRIES + 1):
             try:
                 response = self.client.read_holding_registers(
+                    address=address,
+                    count=count,
+                    slave=slave
+                )
+                if response and not response.isError() and len(response.registers) >= count:
+                    return response
+            except Exception as exc:
+                last_exception = exc
+
+            try:
+                response = self.client.read_input_registers(
                     address=address,
                     count=count,
                     slave=slave
@@ -122,38 +286,36 @@ class DP16ProcessMonitor:
                 if self.client.is_socket_open():
                     self.log("Reusing existing PMON Modbus connection", LogLevel.DEBUG)
                     return True
-                
-                self.log(f"Attempting to connect on port {self.client}", LogLevel.DEBUG)
-                if not self.client.connect():
-                    return False
-                
-                # Check if any unit responds
-                working_units = set()
-                for unit in self.unit_numbers:
-                    try:
-                        status = self._read_holding_registers_locked(
-                            address=self.STATUS_REG,
-                            count=1,
-                            slave=unit
-                        )
-                        working_units.add(unit)
-                        self.log(
-                            f"DP16 Unit {unit} responded with status: {status.registers[0]}", 
-                            LogLevel.VERBOSE
-                        )
-                    except ModbusIOException:
-                        self.log(f"DP16 Unit {unit} not responding", LogLevel.WARNING)
-                    finally:
-                        time.sleep(self.INTER_REQUEST_DELAY)
 
-                if working_units:
-                    self.consecutive_connection_errors = 0
+                current_profile = (self.bytesize, self.parity, self.stopbits)
+                candidate_profiles = [current_profile]
+                if self.auto_detect_serial_profile:
+                    for profile in ((8, 'N', 1), (8, 'E', 1), (8, 'O', 1), (7, 'E', 1), (7, 'O', 1)):
+                        if profile not in candidate_profiles:
+                            candidate_profiles.append(profile)
+
+                for bytesize, parity, stopbits in candidate_profiles:
+                    if (bytesize, parity, stopbits) != (self.bytesize, self.parity, self.stopbits):
+                        self._set_serial_profile_locked(bytesize, parity, stopbits)
+
                     self.log(
-                        f"Connected to {len(working_units)}/{len(self.unit_numbers)} DP16 units", 
-                        LogLevel.INFO
+                        f"Attempting PMON connect on {self.port} @ {self.baudrate},{bytesize}{parity}{stopbits}",
+                        LogLevel.DEBUG
                     )
-                    return True
-                self.client.close()
+                    if not self.client.connect():
+                        continue
+
+                    working_units = self._probe_working_units_locked()
+                    if working_units:
+                        self.consecutive_connection_errors = 0
+                        self.log(
+                            f"Connected to {len(working_units)}/{len(self.unit_numbers)} DP16 units using {bytesize}{parity}{stopbits}",
+                            LogLevel.INFO
+                        )
+                        return True
+
+                    self.client.close()
+
                 return False
 
             except ModbusIOException as e:
@@ -170,19 +332,35 @@ class DP16ProcessMonitor:
         """
         try:
             with self.modbus_lock:
-                response = self._read_holding_registers_locked(
-                    address=self.RDGCNF_REG,
-                    count=1,
-                    slave=unit
-                )
-                time.sleep(self.INTER_REQUEST_DELAY)
-                return response.registers[0]
+                return self._get_reading_config_locked(unit)
         except ModbusIOException as e:
             self.log(f"Modbus IO error reading config for DP16 unit {unit}: {e}", LogLevel.WARNING)
             return None
         except Exception as e:
             self.log(f"Error reading config: {e}", LogLevel.ERROR)
             return None
+
+    def _get_reading_config_locked(self, unit):
+        """Read RDGCNF while caller holds modbus_lock."""
+        if self.unit_map_mode.get(unit) == 'int_map' or self.prefer_manual_map:
+            try:
+                response = self._read_holding_registers_locked(
+                    address=self.RDGCNF_REG_ALT,
+                    count=1,
+                    slave=unit
+                )
+                time.sleep(self.INTER_REQUEST_DELAY)
+                return response.registers[0]
+            except ModbusIOException:
+                pass
+
+        response = self._read_holding_registers_locked(
+            address=self.RDGCNF_REG,
+            count=1,
+            slave=unit
+        )
+        time.sleep(self.INTER_REQUEST_DELAY)
+        return response.registers[0]
 
     def _set_config(self, unit):
         """
@@ -202,20 +380,19 @@ class DP16ProcessMonitor:
         try:
             with self.modbus_lock:
                 self.log(f"Setting RDGCNF_REG for unit {unit}", LogLevel.DEBUG)
-                # First write: Set decimal format
-                self._write_register_locked(
-                    address=self.RDGCNF_REG,
-                    value=0x002, # e.g. "FFF.F"
-                    slave=unit
-                )
-                    
-                # Second write: Update STATUS_REG
-                self.log(f"Setting STATUS_REG for unit {unit}", LogLevel.DEBUG)
-                self._write_register_locked(
-                    address=self.STATUS_REG,
-                    value=self.STATUS_RUNNING,
-                    slave=unit
-                )
+                # Manual register 8: default 0x4A (Decimal point 2, °F bit=0, filter=4)
+                if self.unit_map_mode.get(unit) == 'int_map' or self.prefer_manual_map:
+                    self._write_register_locked(
+                        address=self.RDGCNF_REG_ALT,
+                        value=0x004A,
+                        slave=unit
+                    )
+                else:
+                    self._write_register_locked(
+                        address=self.RDGCNF_REG,
+                        value=0x004A,
+                        slave=unit
+                    )
                 time.sleep(self.INTER_REQUEST_DELAY)
                 
                 self.log(f"Configuration successful for DP16 unit {unit}", LogLevel.INFO)
@@ -284,30 +461,47 @@ class DP16ProcessMonitor:
             return
 
         with self.modbus_lock:
-            # Read status first
-            status = self._read_holding_registers_locked(
-                address=self.STATUS_REG,
-                count=1,
-                slave=unit
-            )
+            map_mode = self.unit_map_mode.get(unit)
+            if map_mode is None:
+                map_mode = self._probe_unit_map_locked(unit)
+                self.unit_map_mode[unit] = map_mode
+                if map_mode is None:
+                    raise ModbusIOException("Unable to determine DP16 register map")
 
-            # Warn if not in expected running state
-            if status.registers[0] != self.STATUS_RUNNING:
-                self.log(
-                    f"DP16 Unit {unit} status {status.registers[0]} differs from expected {self.STATUS_RUNNING}", 
-                    LogLevel.WARNING
+            if map_mode == 'float_map':
+                try:
+                    status = self._read_holding_registers_locked(
+                        address=self.STATUS_REG,
+                        count=1,
+                        slave=unit
+                    )
+                    if status.registers[0] != self.STATUS_RUNNING:
+                        self.log(
+                            f"DP16 Unit {unit} status {status.registers[0]} differs from expected {self.STATUS_RUNNING}",
+                            LogLevel.WARNING
+                        )
+                except ModbusIOException:
+                    self.log(f"DP16 Unit {unit} status read skipped; continuing with PV read", LogLevel.DEBUG)
+
+                response = self._read_holding_registers_locked(
+                    address=self.PROCESS_VALUE_REG,
+                    count=2,
+                    slave=unit
                 )
+                raw_float = struct.pack('>HH', response.registers[0], response.registers[1])
+                value = struct.unpack('>f', raw_float)[0]
+            else:
+                rdgcnf = self._get_reading_config_locked(unit)
+                if rdgcnf is None:
+                    raise ModbusIOException("RDGCNF read failed on int map")
 
-            # Read temperature
-            response = self._read_holding_registers_locked(
-                address=self.PROCESS_VALUE_REG,
-                count=2,
-                slave=unit
-            )
-
-            # Process response
-            raw_float = struct.pack('>HH', response.registers[0], response.registers[1])
-            value = struct.unpack('>f', raw_float)[0]
+                response = self._read_holding_registers_locked(
+                    address=self.PROCESS_VALUE_REG_ALT,
+                    count=1,
+                    slave=unit
+                )
+                counts = self._to_signed_16(response.registers[0])
+                value = counts / self._rdgcnf_multiplier(rdgcnf)
 
             # In-line validation
             if not math.isfinite(value):

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -2,6 +2,7 @@ import time
 import threading
 from threading import Lock
 import struct
+import math
 from utils import LogLevel
 from pymodbus.client import ModbusSerialClient as ModbusClient
 from pymodbus.exceptions import ModbusIOException
@@ -23,6 +24,8 @@ class DP16ProcessMonitor:
     # Polling delay
     BASE_DELAY = 0.1    # [seconds]
     MAX_DELAY = 5       # [seconds]
+    INTER_REQUEST_DELAY = 0.03
+    REQUEST_RETRIES = 2
 
     ERROR_THRESHOLD = 5
     ERROR_LOG_INTERVAL = 10 # [seconds]
@@ -58,6 +61,54 @@ class DP16ProcessMonitor:
         # Start single background polling thread after successful connection and configuration
         self._thread = threading.Thread(target=self.poll_all_units, daemon=True)
         self._thread.start()
+
+    def _read_holding_registers_locked(self, address: int, count: int, slave: int):
+        """Read holding registers with retry. Caller must hold modbus_lock."""
+        last_exception = None
+        for attempt in range(self.REQUEST_RETRIES + 1):
+            try:
+                response = self.client.read_holding_registers(
+                    address=address,
+                    count=count,
+                    slave=slave
+                )
+                if response and not response.isError() and len(response.registers) >= count:
+                    return response
+            except Exception as exc:
+                last_exception = exc
+
+            if attempt < self.REQUEST_RETRIES:
+                time.sleep(self.INTER_REQUEST_DELAY)
+
+        if last_exception:
+            raise ModbusIOException(str(last_exception))
+        raise ModbusIOException(
+            f"Read failed for slave={slave}, address=0x{address:03X}, count={count}"
+        )
+
+    def _write_register_locked(self, address: int, value: int, slave: int):
+        """Write single register with retry. Caller must hold modbus_lock."""
+        last_exception = None
+        for attempt in range(self.REQUEST_RETRIES + 1):
+            try:
+                response = self.client.write_register(
+                    address=address,
+                    value=value,
+                    slave=slave
+                )
+                if response and not response.isError():
+                    return response
+            except Exception as exc:
+                last_exception = exc
+
+            if attempt < self.REQUEST_RETRIES:
+                time.sleep(self.INTER_REQUEST_DELAY)
+
+        if last_exception:
+            raise ModbusIOException(str(last_exception))
+        raise ModbusIOException(
+            f"Write failed for slave={slave}, address=0x{address:03X}, value={value}"
+        )
     
     def connect(self):
         """
@@ -79,28 +130,30 @@ class DP16ProcessMonitor:
                 # Check if any unit responds
                 working_units = set()
                 for unit in self.unit_numbers:
-                    status = self.client.read_holding_registers(
-                        address=self.STATUS_REG,
-                        count=1,
-                        slave=unit
-                    )
-                    if not status.isError():
+                    try:
+                        status = self._read_holding_registers_locked(
+                            address=self.STATUS_REG,
+                            count=1,
+                            slave=unit
+                        )
                         working_units.add(unit)
                         self.log(
                             f"DP16 Unit {unit} responded with status: {status.registers[0]}", 
                             LogLevel.VERBOSE
                         )
-                    else:
+                    except ModbusIOException:
                         self.log(f"DP16 Unit {unit} not responding", LogLevel.WARNING)
-                        # with self.response_lock:
-                        #     self.temperature_readings[unit] = self.DISCONNECTED
+                    finally:
+                        time.sleep(self.INTER_REQUEST_DELAY)
 
                 if working_units:
+                    self.consecutive_connection_errors = 0
                     self.log(
                         f"Connected to {len(working_units)}/{len(self.unit_numbers)} DP16 units", 
                         LogLevel.INFO
                     )
                     return True
+                self.client.close()
                 return False
 
             except ModbusIOException as e:
@@ -117,17 +170,16 @@ class DP16ProcessMonitor:
         """
         try:
             with self.modbus_lock:
-                response = self.client.read_holding_registers(
+                response = self._read_holding_registers_locked(
                     address=self.RDGCNF_REG,
                     count=1,
                     slave=unit
                 )
-                time.sleep(0.1)
-                if not response.isError():
-                    return response.registers[0]
-                return None
+                time.sleep(self.INTER_REQUEST_DELAY)
+                return response.registers[0]
         except ModbusIOException as e:
             self.log(f"Modbus IO error reading config for DP16 unit {unit}: {e}", LogLevel.WARNING)
+            return None
         except Exception as e:
             self.log(f"Error reading config: {e}", LogLevel.ERROR)
             return None
@@ -151,26 +203,20 @@ class DP16ProcessMonitor:
             with self.modbus_lock:
                 self.log(f"Setting RDGCNF_REG for unit {unit}", LogLevel.DEBUG)
                 # First write: Set decimal format
-                response1 = self.client.write_register(
+                self._write_register_locked(
                     address=self.RDGCNF_REG,
                     value=0x002, # e.g. "FFF.F"
                     slave=unit
                 )
-                if response1.isError():
-                    self.log(f"Failed to write RDGCNF_REG for DP16 unit {unit}. Response:{response1}", LogLevel.ERROR)
-                    return False # Exit early if the first write fails
                     
                 # Second write: Update STATUS_REG
                 self.log(f"Setting STATUS_REG for unit {unit}", LogLevel.DEBUG)
-                response2 = self.client.write_register(
+                self._write_register_locked(
                     address=self.STATUS_REG,
                     value=self.STATUS_RUNNING,
                     slave=unit
                 )
-                time.sleep(0.1)
-                if response2.isError():
-                    self.log(f"Failed to write STATUS_REG for DP16 unit {unit}: Response:{response2}", LogLevel.ERROR)
-                    return False # Exit if second write fails
+                time.sleep(self.INTER_REQUEST_DELAY)
                 
                 self.log(f"Configuration successful for DP16 unit {unit}", LogLevel.INFO)
                 return True
@@ -201,7 +247,11 @@ class DP16ProcessMonitor:
                         if current_time - self.last_critical_error_time >= self.ERROR_LOG_INTERVAL:
                             self.log("Failed to reconnect to PMON", LogLevel.ERROR)
                             self.last_critical_error_time = current_time
-                        time.sleep(1)  # Delay before next attempt
+                        sleep_time = min(
+                            self.MAX_DELAY,
+                            max(self.BASE_DELAY, self.BASE_DELAY * (2 ** min(self.consecutive_connection_errors, 5)))
+                        )
+                        time.sleep(sleep_time)
                         continue
                 
                 # Poll each unit individually
@@ -209,8 +259,8 @@ class DP16ProcessMonitor:
                     try:
                         self._poll_single_unit(unit) 
                         self.consecutive_connection_errors = 0  # Reset on successful poll
-                        time.sleep(0.1)
-                    except ModbusIOException as e:
+                        time.sleep(self.INTER_REQUEST_DELAY)
+                    except Exception as e:
                         self._handle_poll_error(unit, e)
                         
                         # Rate limited error logging
@@ -234,19 +284,12 @@ class DP16ProcessMonitor:
             return
 
         with self.modbus_lock:
-            # Clear any stale data
-            if hasattr(self.client, 'serial'):
-                self.client.serial.reset_input_buffer()
-
             # Read status first
-            status = self.client.read_holding_registers(
+            status = self._read_holding_registers_locked(
                 address=self.STATUS_REG,
                 count=1,
                 slave=unit
             )
-            if status.isError():
-                self.consecutive_error_counts[unit] += 1
-                raise ModbusIOException("Status read failed")
 
             # Warn if not in expected running state
             if status.registers[0] != self.STATUS_RUNNING:
@@ -256,21 +299,19 @@ class DP16ProcessMonitor:
                 )
 
             # Read temperature
-            response = self.client.read_holding_registers(
+            response = self._read_holding_registers_locked(
                 address=self.PROCESS_VALUE_REG,
                 count=2,
                 slave=unit
             )
-            if response.isError():
-                raise ModbusIOException("Temperature read failed")
 
             # Process response
             raw_float = struct.pack('>HH', response.registers[0], response.registers[1])
             value = struct.unpack('>f', raw_float)[0]
 
             # In-line validation
-            if abs(value) < 0.001:
-                raise ValueError("Zero reading indicates communication error")
+            if not math.isfinite(value):
+                raise ValueError(f"Non-finite reading: {value}")
             if not (self.MIN_TEMP <= value <= self.MAX_TEMP):
                 raise ValueError(f"Temperature out of range: {value}")
 
@@ -331,18 +372,16 @@ class DP16ProcessMonitor:
             return dict(self.temperature_readings)
 
     def disconnect(self):
-        # Stop polling thread
-        # self._is_running = False
-        # if self._thread and self._thread.is_alive():
-        #     self._thread.join()
-        
-        # Close connection
-        # with self.modbus_lock:
-        if self.client.is_socket_open():
-            self.client.close()
-            self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
-        else:
-            self.log("No active connection to DP16 Process Monitors", LogLevel.INFO)
+        self._is_running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+
+        with self.modbus_lock:
+            if self.client.is_socket_open():
+                self.client.close()
+                self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
+            else:
+                self.log("No active connection to DP16 Process Monitors", LogLevel.INFO)
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""

--- a/log_export_2026-02-27_13-50-47.txt
+++ b/log_export_2026-02-27_13-50-47.txt
@@ -1,0 +1,5887 @@
+[13:49:30] - INFO: Serial connection established on /dev/pts/25
+[13:49:31] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:31] - INFO: Serial connection established on /dev/pts/30
+[13:49:31] - INFO: G9 driver initialized
+[13:49:31] - DEBUG: Initializing E5CNModbus with port: /dev/pts/29
+[13:49:31] - ERROR: Failed to connect to the E5CN Modbus device.
+[13:49:31] - ERROR: Cannot start reading temperatures - connection failed
+[13:49:31] - ERROR: Failed to start temperature controllers at /dev/pts/29
+[13:49:31] - INFO: Serial connection established on /dev/pts/26
+[13:49:31] - DEBUG: Raw command sent: SABC3
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SABC3
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - DEBUG: Raw response received: OK
+[13:49:31] - INFO: Set preset mode for CathodeA PS to 3 (normal mode).
+[13:49:31] - DEBUG: Raw command sent: GABC
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GABC
+[13:49:31] - DEBUG: Response: 3OK
+[13:49:31] - DEBUG: Raw response received: 3OK
+[13:49:31] - INFO: Current preset selection: 3
+[13:49:31] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeA PS. Response: 3
+[13:49:31] - DEBUG: Setting OVP for cathode CathodeA PS to: 1.00
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOVP0100
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OVP for cathode CathodeA PS to 1.00V
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOVP
+[13:49:31] - DEBUG: Response: 0100OK
+[13:49:31] - INFO: OVP value: 1.00
+[13:49:31] - INFO: OVP setting confirmed for cathode CathodeA PS: 1.00V
+[13:49:31] - DEBUG: Setting OCP for cathode CathodeA PS to: 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOCP0900
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OCP for cathode CathodeA PS to 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOCP
+[13:49:31] - DEBUG: Response: 0900OK
+[13:49:31] - DEBUG: OCP value: 9.00A
+[13:49:31] - INFO: OCP setting confirmed for cathode CathodeA PS: 9.00A
+[13:49:31] - INFO: Initialized CathodeA PS on port /dev/pts/26
+[13:49:31] - INFO: Serial connection established on /dev/pts/27
+[13:49:31] - DEBUG: Raw command sent: SABC3
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SABC3
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - DEBUG: Raw response received: OK
+[13:49:31] - INFO: Set preset mode for CathodeB PS to 3 (normal mode).
+[13:49:31] - DEBUG: Raw command sent: GABC
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GABC
+[13:49:31] - DEBUG: Response: 3OK
+[13:49:31] - DEBUG: Raw response received: 3OK
+[13:49:31] - INFO: Current preset selection: 3
+[13:49:31] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeB PS. Response: 3
+[13:49:31] - DEBUG: Setting OVP for cathode CathodeB PS to: 1.00
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOVP0100
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OVP for cathode CathodeB PS to 1.00V
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOVP
+[13:49:31] - DEBUG: Response: 0100OK
+[13:49:31] - INFO: OVP value: 1.00
+[13:49:31] - INFO: OVP setting confirmed for cathode CathodeB PS: 1.00V
+[13:49:31] - DEBUG: Setting OCP for cathode CathodeB PS to: 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOCP0900
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OCP for cathode CathodeB PS to 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOCP
+[13:49:31] - DEBUG: Response: 0900OK
+[13:49:31] - DEBUG: OCP value: 9.00A
+[13:49:31] - INFO: OCP setting confirmed for cathode CathodeB PS: 9.00A
+[13:49:31] - INFO: Initialized CathodeB PS on port /dev/pts/27
+[13:49:31] - INFO: Serial connection established on /dev/pts/28
+[13:49:31] - DEBUG: Raw command sent: SABC3
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SABC3
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - DEBUG: Raw response received: OK
+[13:49:31] - INFO: Set preset mode for CathodeC PS to 3 (normal mode).
+[13:49:31] - DEBUG: Raw command sent: GABC
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GABC
+[13:49:31] - DEBUG: Response: 3OK
+[13:49:31] - DEBUG: Raw response received: 3OK
+[13:49:31] - INFO: Current preset selection: 3
+[13:49:31] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeC PS. Response: 3
+[13:49:31] - DEBUG: Setting OVP for cathode CathodeC PS to: 1.00
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOVP0100
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OVP for cathode CathodeC PS to 1.00V
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOVP
+[13:49:31] - DEBUG: Response: 0100OK
+[13:49:31] - INFO: OVP value: 1.00
+[13:49:31] - INFO: OVP setting confirmed for cathode CathodeC PS: 1.00V
+[13:49:31] - DEBUG: Setting OCP for cathode CathodeC PS to: 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: SOCP0900
+[13:49:31] - DEBUG: Response: OK
+[13:49:31] - INFO: Set OCP for cathode CathodeC PS to 9.00A
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GOCP
+[13:49:31] - DEBUG: Response: 0900OK
+[13:49:31] - DEBUG: OCP value: 9.00A
+[13:49:31] - INFO: OCP setting confirmed for cathode CathodeC PS: 9.00A
+[13:49:31] - INFO: Initialized CathodeC PS on port /dev/pts/28
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:31] - DEBUG: No connection to CCS temperature controller 1
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:31] - DEBUG: No connection to CCS temperature controller 2
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Sent command:GETD
+[13:49:31] - DEBUG: Flushing serial input buffer
+[13:49:31] - DEBUG: Sending command: GETD
+[13:49:31] - DEBUG: Response: 000000000OK
+[13:49:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:31] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:31] - DEBUG: No connection to CCS temperature controller 3
+[13:49:31] - INFO: checking com ports
+[13:49:31] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:31] - WARNING: No interlock information is here; Queue is Empty
+[13:49:31] - CRITICAL: No data available from G9
+[13:49:31] - DEBUG: Dashboard beam callback registered
+[13:49:31] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:49:31] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:32] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:32] - INFO: Connecting to BCON on /dev/pts/32…
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:32] - DEBUG: No connection to CCS temperature controller 1
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:32] - DEBUG: No connection to CCS temperature controller 2
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:32] - DEBUG: No connection to CCS temperature controller 3
+[13:49:32] - INFO: checking com ports
+[13:49:32] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:32] - DEBUG: VTRX States: 11010101
+[13:49:32] - DEBUG: GUI updated with pressure: 4.52E-06 mbar
+[13:49:32] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:32] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:32] - INFO: Interlock E-STOP Int: red -> green
+[13:49:32] - INFO: Interlock E-STOP Ext: red -> green
+[13:49:32] - INFO: Interlock Door: red -> green
+[13:49:32] - INFO: Interlock Vacuum Power: red -> green
+[13:49:32] - INFO: Interlock Vacuum Pressure: red -> green
+[13:49:32] - INFO: Interlock High Oil: red -> green
+[13:49:32] - INFO: Interlock Low Oil: red -> green
+[13:49:32] - INFO: Interlock Water: red -> green
+[13:49:32] - INFO: Interlock All Interlocks: red -> green
+[13:49:32] - INFO: Interlock G9SP Active: red -> green
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:32] - DEBUG: No connection to CCS temperature controller 1
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:32] - DEBUG: No connection to CCS temperature controller 2
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:32] - DEBUG: Response: 000000000OK
+[13:49:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:32] - DEBUG: Sent command:GETD
+[13:49:32] - DEBUG: Flushing serial input buffer
+[13:49:32] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:33] - DEBUG: No connection to CCS temperature controller 3
+[13:49:33] - INFO: checking com ports
+[13:49:33] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:33] - DEBUG: VTRX States: 11010101
+[13:49:33] - DEBUG: GUI updated with pressure: 4.49E-06 mbar
+[13:49:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:33] - WARNING: DP16 Unit 1 not responding
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:33] - DEBUG: No connection to CCS temperature controller 1
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:33] - DEBUG: No connection to CCS temperature controller 2
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Sent command:GETD
+[13:49:33] - DEBUG: Flushing serial input buffer
+[13:49:33] - DEBUG: Sending command: GETD
+[13:49:33] - DEBUG: Response: 000000000OK
+[13:49:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:33] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:33] - DEBUG: No connection to CCS temperature controller 3
+[13:49:33] - INFO: checking com ports
+[13:49:33] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 1
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 2
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 3
+[13:49:34] - INFO: checking com ports
+[13:49:34] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:34] - INFO: BCON connected on /dev/pts/32
+[13:49:34] - DEBUG: VTRX States: 11010101
+[13:49:34] - DEBUG: GUI updated with pressure: 4.55E-06 mbar
+[13:49:34] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:34] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 1
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 2
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Sent command:GETD
+[13:49:34] - DEBUG: Flushing serial input buffer
+[13:49:34] - DEBUG: Sending command: GETD
+[13:49:34] - DEBUG: Response: 000000000OK
+[13:49:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:34] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:34] - DEBUG: No connection to CCS temperature controller 3
+[13:49:34] - WARNING: DP16 Unit 2 not responding
+[13:49:34] - INFO: checking com ports
+[13:49:34] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:34] - DEBUG: VTRX States: 11010101
+[13:49:34] - DEBUG: GUI updated with pressure: 4.52E-06 mbar
+[13:49:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:35] - DEBUG: No connection to CCS temperature controller 1
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:35] - DEBUG: No connection to CCS temperature controller 2
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:35] - DEBUG: No connection to CCS temperature controller 3
+[13:49:35] - INFO: checking com ports
+[13:49:35] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:35] - DEBUG: No connection to CCS temperature controller 1
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:35] - DEBUG: Response: 000000000OK
+[13:49:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:35] - DEBUG: No connection to CCS temperature controller 2
+[13:49:35] - DEBUG: Sent command:GETD
+[13:49:35] - DEBUG: Flushing serial input buffer
+[13:49:35] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:36] - DEBUG: No connection to CCS temperature controller 3
+[13:49:36] - INFO: checking com ports
+[13:49:36] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:36] - DEBUG: VTRX States: 11010101
+[13:49:36] - DEBUG: GUI updated with pressure: 4.72E-06 mbar
+[13:49:36] - WARNING: DP16 Unit 3 not responding
+[13:49:36] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:36] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:36] - DEBUG: No connection to CCS temperature controller 1
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:36] - DEBUG: No connection to CCS temperature controller 2
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Sent command:GETD
+[13:49:36] - DEBUG: Flushing serial input buffer
+[13:49:36] - DEBUG: Sending command: GETD
+[13:49:36] - DEBUG: Response: 000000000OK
+[13:49:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:36] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:36] - DEBUG: No connection to CCS temperature controller 3
+[13:49:36] - INFO: checking com ports
+[13:49:36] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:36] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:36] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 1
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 2
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 3
+[13:49:37] - INFO: checking com ports
+[13:49:37] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:37] - DEBUG: VTRX States: 11010101
+[13:49:37] - DEBUG: GUI updated with pressure: 4.66E-06 mbar
+[13:49:37] - WARNING: DP16 Unit 4 not responding
+[13:49:37] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:37] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 1
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 2
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Sent command:GETD
+[13:49:37] - DEBUG: Flushing serial input buffer
+[13:49:37] - DEBUG: Sending command: GETD
+[13:49:37] - DEBUG: Response: 000000000OK
+[13:49:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:37] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:37] - DEBUG: No connection to CCS temperature controller 3
+[13:49:37] - INFO: checking com ports
+[13:49:37] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:37] - DEBUG: VTRX States: 11010101
+[13:49:37] - DEBUG: GUI updated with pressure: 4.85E-06 mbar
+[13:49:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:38] - DEBUG: No connection to CCS temperature controller 1
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:38] - DEBUG: No connection to CCS temperature controller 2
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:38] - DEBUG: No connection to CCS temperature controller 3
+[13:49:38] - INFO: checking com ports
+[13:49:38] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:38] - WARNING: DP16 Unit 5 not responding
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:38] - DEBUG: No connection to CCS temperature controller 1
+[13:49:38] - DEBUG: Sent command:GETD
+[13:49:38] - DEBUG: Flushing serial input buffer
+[13:49:38] - DEBUG: Sending command: GETD
+[13:49:38] - DEBUG: Response: 000000000OK
+[13:49:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:39] - DEBUG: No connection to CCS temperature controller 2
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:39] - DEBUG: No connection to CCS temperature controller 3
+[13:49:39] - INFO: checking com ports
+[13:49:39] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:39] - DEBUG: VTRX States: 11010101
+[13:49:39] - DEBUG: GUI updated with pressure: 4.92E-06 mbar
+[13:49:39] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:39] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:39] - DEBUG: No connection to CCS temperature controller 1
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:39] - DEBUG: No connection to CCS temperature controller 2
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Sent command:GETD
+[13:49:39] - DEBUG: Flushing serial input buffer
+[13:49:39] - DEBUG: Sending command: GETD
+[13:49:39] - DEBUG: Response: 000000000OK
+[13:49:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:39] - DEBUG: No connection to CCS temperature controller 3
+[13:49:39] - INFO: checking com ports
+[13:49:39] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:40] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:40] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 1
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 2
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 3
+[13:49:40] - INFO: checking com ports
+[13:49:40] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:40] - WARNING: DP16 Unit 6 not responding
+[13:49:40] - DEBUG: VTRX States: 11010101
+[13:49:40] - DEBUG: GUI updated with pressure: 5.04E-06 mbar
+[13:49:40] - ERROR: Failed to reconnect to PMON
+[13:49:40] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:49:40] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:40] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 1
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 2
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Sent command:GETD
+[13:49:40] - DEBUG: Flushing serial input buffer
+[13:49:40] - DEBUG: Sending command: GETD
+[13:49:40] - DEBUG: Response: 000000000OK
+[13:49:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:40] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:40] - DEBUG: No connection to CCS temperature controller 3
+[13:49:40] - INFO: checking com ports
+[13:49:40] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:40] - DEBUG: VTRX States: 11010101
+[13:49:40] - DEBUG: GUI updated with pressure: 5.14E-06 mbar
+[13:49:41] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:41] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:41] - DEBUG: No connection to CCS temperature controller 1
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:41] - DEBUG: No connection to CCS temperature controller 2
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:41] - DEBUG: No connection to CCS temperature controller 3
+[13:49:41] - INFO: checking com ports
+[13:49:41] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:41] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:41] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:41] - WARNING: DP16 Unit 1 not responding
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:41] - DEBUG: Response: 000000000OK
+[13:49:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:41] - DEBUG: Sent command:GETD
+[13:49:41] - DEBUG: Flushing serial input buffer
+[13:49:41] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 1
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 2
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 3
+[13:49:42] - INFO: checking com ports
+[13:49:42] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:42] - DEBUG: VTRX States: 11010101
+[13:49:42] - DEBUG: GUI updated with pressure: 5.24E-06 mbar
+[13:49:42] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:42] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 1
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 2
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Sent command:GETD
+[13:49:42] - DEBUG: Flushing serial input buffer
+[13:49:42] - DEBUG: Sending command: GETD
+[13:49:42] - DEBUG: Response: 000000000OK
+[13:49:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:42] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:42] - DEBUG: No connection to CCS temperature controller 3
+[13:49:42] - INFO: checking com ports
+[13:49:42] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:43] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:43] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 1
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 2
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 3
+[13:49:43] - WARNING: DP16 Unit 2 not responding
+[13:49:43] - INFO: checking com ports
+[13:49:43] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:43] - DEBUG: VTRX States: 11010101
+[13:49:43] - DEBUG: GUI updated with pressure: 5.28E-06 mbar
+[13:49:43] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:43] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 1
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 2
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Sent command:GETD
+[13:49:43] - DEBUG: Flushing serial input buffer
+[13:49:43] - DEBUG: Sending command: GETD
+[13:49:43] - DEBUG: Response: 000000000OK
+[13:49:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:43] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:43] - DEBUG: No connection to CCS temperature controller 3
+[13:49:43] - INFO: checking com ports
+[13:49:43] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:44] - DEBUG: VTRX States: 11010101
+[13:49:44] - DEBUG: GUI updated with pressure: 5.27E-06 mbar
+[13:49:44] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:44] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:44] - DEBUG: No connection to CCS temperature controller 1
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:44] - DEBUG: No connection to CCS temperature controller 2
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Sent command:GETD
+[13:49:44] - DEBUG: Flushing serial input buffer
+[13:49:44] - DEBUG: Sending command: GETD
+[13:49:44] - DEBUG: Response: 000000000OK
+[13:49:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:44] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:44] - DEBUG: No connection to CCS temperature controller 3
+[13:49:44] - INFO: checking com ports
+[13:49:44] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:44] - WARNING: DP16 Unit 3 not responding
+[13:49:44] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:44] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 1
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 2
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 3
+[13:49:45] - INFO: checking com ports
+[13:49:45] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:45] - DEBUG: VTRX States: 11010101
+[13:49:45] - DEBUG: GUI updated with pressure: 5.34E-06 mbar
+[13:49:45] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:45] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 1
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 2
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Sent command:GETD
+[13:49:45] - DEBUG: Flushing serial input buffer
+[13:49:45] - DEBUG: Sending command: GETD
+[13:49:45] - DEBUG: Response: 000000000OK
+[13:49:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:45] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:45] - DEBUG: No connection to CCS temperature controller 3
+[13:49:45] - INFO: checking com ports
+[13:49:45] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:46] - WARNING: DP16 Unit 4 not responding
+[13:49:46] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:46] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 1
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 2
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 3
+[13:49:46] - INFO: checking com ports
+[13:49:46] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:46] - DEBUG: VTRX States: 11010101
+[13:49:46] - DEBUG: GUI updated with pressure: 5.38E-06 mbar
+[13:49:46] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:46] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 1
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 2
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Sent command:GETD
+[13:49:46] - DEBUG: Flushing serial input buffer
+[13:49:46] - DEBUG: Sending command: GETD
+[13:49:46] - DEBUG: Response: 000000000OK
+[13:49:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:46] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:46] - DEBUG: No connection to CCS temperature controller 3
+[13:49:46] - INFO: checking com ports
+[13:49:46] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:47] - DEBUG: VTRX States: 11010101
+[13:49:47] - DEBUG: GUI updated with pressure: 5.46E-06 mbar
+[13:49:47] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:47] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:47] - DEBUG: No connection to CCS temperature controller 1
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:47] - DEBUG: No connection to CCS temperature controller 2
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Sent command:GETD
+[13:49:47] - DEBUG: Flushing serial input buffer
+[13:49:47] - DEBUG: Sending command: GETD
+[13:49:47] - DEBUG: Response: 000000000OK
+[13:49:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:47] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:47] - DEBUG: No connection to CCS temperature controller 3
+[13:49:47] - WARNING: DP16 Unit 5 not responding
+[13:49:47] - INFO: checking com ports
+[13:49:47] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:48] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:48] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 1
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 2
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 3
+[13:49:48] - INFO: checking com ports
+[13:49:48] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:48] - DEBUG: VTRX States: 11010101
+[13:49:48] - DEBUG: GUI updated with pressure: 5.38E-06 mbar
+[13:49:48] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:48] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 1
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 2
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Sent command:GETD
+[13:49:48] - DEBUG: Flushing serial input buffer
+[13:49:48] - DEBUG: Sending command: GETD
+[13:49:48] - DEBUG: Response: 000000000OK
+[13:49:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:48] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:48] - DEBUG: No connection to CCS temperature controller 3
+[13:49:48] - INFO: checking com ports
+[13:49:48] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:48] - DEBUG: VTRX States: 11010101
+[13:49:48] - DEBUG: GUI updated with pressure: 5.27E-06 mbar
+[13:49:48] - WARNING: DP16 Unit 6 not responding
+[13:49:49] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:49] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:49] - DEBUG: No connection to CCS temperature controller 1
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:49] - DEBUG: No connection to CCS temperature controller 2
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:49] - DEBUG: No connection to CCS temperature controller 3
+[13:49:49] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:49:49] - INFO: checking com ports
+[13:49:49] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:49] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:49] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:49] - DEBUG: No connection to CCS temperature controller 1
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:49] - DEBUG: No connection to CCS temperature controller 2
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:49] - DEBUG: Response: 000000000OK
+[13:49:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:49] - DEBUG: Sent command:GETD
+[13:49:49] - DEBUG: Flushing serial input buffer
+[13:49:49] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:50] - DEBUG: No connection to CCS temperature controller 3
+[13:49:50] - INFO: checking com ports
+[13:49:50] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:50] - DEBUG: VTRX States: 11010101
+[13:49:50] - DEBUG: GUI updated with pressure: 5.32E-06 mbar
+[13:49:50] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:50] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:50] - DEBUG: No connection to CCS temperature controller 1
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:50] - DEBUG: No connection to CCS temperature controller 2
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Sent command:GETD
+[13:49:50] - DEBUG: Flushing serial input buffer
+[13:49:50] - DEBUG: Sending command: GETD
+[13:49:50] - DEBUG: Response: 000000000OK
+[13:49:50] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:50] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:50] - DEBUG: No connection to CCS temperature controller 3
+[13:49:50] - INFO: checking com ports
+[13:49:50] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:50] - WARNING: DP16 Unit 1 not responding
+[13:49:51] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:51] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 1
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 2
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 3
+[13:49:51] - INFO: checking com ports
+[13:49:51] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:51] - DEBUG: VTRX States: 11010101
+[13:49:51] - DEBUG: GUI updated with pressure: 5.25E-06 mbar
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 1
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 2
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Sent command:GETD
+[13:49:51] - DEBUG: Flushing serial input buffer
+[13:49:51] - DEBUG: Sending command: GETD
+[13:49:51] - DEBUG: Response: 000000000OK
+[13:49:51] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:51] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:51] - DEBUG: No connection to CCS temperature controller 3
+[13:49:51] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:51] - INFO: checking com ports
+[13:49:51] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:51] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:51] - DEBUG: VTRX States: 11010101
+[13:49:51] - DEBUG: GUI updated with pressure: 5.30E-06 mbar
+[13:49:52] - WARNING: DP16 Unit 2 not responding
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:52] - DEBUG: No connection to CCS temperature controller 1
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:52] - DEBUG: No connection to CCS temperature controller 2
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:52] - DEBUG: No connection to CCS temperature controller 3
+[13:49:52] - INFO: checking com ports
+[13:49:52] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:52] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:52] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Sent command:GETD
+[13:49:52] - DEBUG: Flushing serial input buffer
+[13:49:52] - DEBUG: Sending command: GETD
+[13:49:52] - DEBUG: Response: 000000000OK
+[13:49:52] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:52] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:52] - DEBUG: No connection to CCS temperature controller 1
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:53] - DEBUG: No connection to CCS temperature controller 2
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:53] - DEBUG: No connection to CCS temperature controller 3
+[13:49:53] - INFO: checking com ports
+[13:49:53] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:53] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:53] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:53] - DEBUG: VTRX States: 11010101
+[13:49:53] - DEBUG: GUI updated with pressure: 5.42E-06 mbar
+[13:49:53] - WARNING: DP16 Unit 3 not responding
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:53] - DEBUG: No connection to CCS temperature controller 1
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:53] - DEBUG: No connection to CCS temperature controller 2
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Sent command:GETD
+[13:49:53] - DEBUG: Flushing serial input buffer
+[13:49:53] - DEBUG: Sending command: GETD
+[13:49:53] - DEBUG: Response: 000000000OK
+[13:49:53] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:53] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:53] - DEBUG: No connection to CCS temperature controller 3
+[13:49:53] - INFO: checking com ports
+[13:49:53] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:53] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:53] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 1
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 2
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 3
+[13:49:54] - INFO: checking com ports
+[13:49:54] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:54] - DEBUG: VTRX States: 11010101
+[13:49:54] - DEBUG: GUI updated with pressure: 5.61E-06 mbar
+[13:49:54] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:54] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 1
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 2
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Sent command:GETD
+[13:49:54] - DEBUG: Flushing serial input buffer
+[13:49:54] - DEBUG: Sending command: GETD
+[13:49:54] - DEBUG: Response: 000000000OK
+[13:49:54] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:54] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:54] - DEBUG: No connection to CCS temperature controller 3
+[13:49:54] - INFO: checking com ports
+[13:49:54] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:54] - WARNING: DP16 Unit 4 not responding
+[13:49:54] - DEBUG: VTRX States: 11010101
+[13:49:54] - DEBUG: GUI updated with pressure: 5.35E-06 mbar
+[13:49:55] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:55] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:55] - DEBUG: No connection to CCS temperature controller 1
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:55] - DEBUG: No connection to CCS temperature controller 2
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Sent command:GETD
+[13:49:55] - DEBUG: Flushing serial input buffer
+[13:49:55] - DEBUG: Sending command: GETD
+[13:49:55] - DEBUG: Response: 000000000OK
+[13:49:55] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:55] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:55] - DEBUG: No connection to CCS temperature controller 3
+[13:49:55] - INFO: checking com ports
+[13:49:55] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:55] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:55] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 1
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 2
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 3
+[13:49:56] - INFO: checking com ports
+[13:49:56] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:56] - DEBUG: VTRX States: 11010101
+[13:49:56] - DEBUG: GUI updated with pressure: 5.55E-06 mbar
+[13:49:56] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:56] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:56] - WARNING: DP16 Unit 5 not responding
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 1
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 2
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Sent command:GETD
+[13:49:56] - DEBUG: Flushing serial input buffer
+[13:49:56] - DEBUG: Sending command: GETD
+[13:49:56] - DEBUG: Response: 000000000OK
+[13:49:56] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:56] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:56] - DEBUG: No connection to CCS temperature controller 3
+[13:49:56] - INFO: checking com ports
+[13:49:56] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:56] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:56] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 1
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 2
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 3
+[13:49:57] - INFO: checking com ports
+[13:49:57] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:57] - DEBUG: VTRX States: 11010101
+[13:49:57] - DEBUG: GUI updated with pressure: 5.69E-06 mbar
+[13:49:57] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:57] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:57] - WARNING: DP16 Unit 6 not responding
+[13:49:57] - ERROR: Failed to reconnect to PMON
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 1
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 2
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Sent command:GETD
+[13:49:57] - DEBUG: Flushing serial input buffer
+[13:49:57] - DEBUG: Sending command: GETD
+[13:49:57] - DEBUG: Response: 000000000OK
+[13:49:57] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:57] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:57] - DEBUG: No connection to CCS temperature controller 3
+[13:49:57] - INFO: checking com ports
+[13:49:57] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:58] - DEBUG: VTRX States: 11010101
+[13:49:58] - DEBUG: GUI updated with pressure: 5.76E-06 mbar
+[13:49:58] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:58] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:58] - DEBUG: No connection to CCS temperature controller 1
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:58] - DEBUG: No connection to CCS temperature controller 2
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Sent command:GETD
+[13:49:58] - DEBUG: Flushing serial input buffer
+[13:49:58] - DEBUG: Sending command: GETD
+[13:49:58] - DEBUG: Response: 000000000OK
+[13:49:58] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:58] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:58] - DEBUG: No connection to CCS temperature controller 3
+[13:49:58] - INFO: checking com ports
+[13:49:58] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:58] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:49:58] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:58] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 1
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 2
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 3
+[13:49:59] - INFO: checking com ports
+[13:49:59] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:59] - DEBUG: VTRX States: 11010101
+[13:49:59] - DEBUG: GUI updated with pressure: 5.99E-06 mbar
+[13:49:59] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:59] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 1
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 2
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Sent command:GETD
+[13:49:59] - DEBUG: Flushing serial input buffer
+[13:49:59] - DEBUG: Sending command: GETD
+[13:49:59] - DEBUG: Response: 000000000OK
+[13:49:59] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:49:59] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:49:59] - DEBUG: No connection to CCS temperature controller 3
+[13:49:59] - INFO: checking com ports
+[13:49:59] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:49:59] - DEBUG: VTRX States: 11010101
+[13:49:59] - DEBUG: GUI updated with pressure: 6.15E-06 mbar
+[13:49:59] - WARNING: DP16 Unit 1 not responding
+[13:49:59] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:49:59] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 1
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 2
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 3
+[13:50:00] - INFO: checking com ports
+[13:50:00] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:00] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:00] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 1
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 2
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Sent command:GETD
+[13:50:00] - DEBUG: Flushing serial input buffer
+[13:50:00] - DEBUG: Sending command: GETD
+[13:50:00] - DEBUG: Response: 000000000OK
+[13:50:00] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:00] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:00] - DEBUG: No connection to CCS temperature controller 3
+[13:50:00] - INFO: checking com ports
+[13:50:00] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:01] - DEBUG: VTRX States: 11010101
+[13:50:01] - DEBUG: GUI updated with pressure: 6.22E-06 mbar
+[13:50:01] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:01] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:01] - WARNING: DP16 Unit 2 not responding
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:01] - DEBUG: No connection to CCS temperature controller 1
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:01] - DEBUG: No connection to CCS temperature controller 2
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Sent command:GETD
+[13:50:01] - DEBUG: Flushing serial input buffer
+[13:50:01] - DEBUG: Sending command: GETD
+[13:50:01] - DEBUG: Response: 000000000OK
+[13:50:01] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:01] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:01] - DEBUG: No connection to CCS temperature controller 3
+[13:50:01] - INFO: checking com ports
+[13:50:01] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:01] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:01] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 1
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 2
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 3
+[13:50:02] - INFO: checking com ports
+[13:50:02] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:02] - DEBUG: VTRX States: 11010101
+[13:50:02] - DEBUG: GUI updated with pressure: 6.07E-06 mbar
+[13:50:02] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:02] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:02] - WARNING: DP16 Unit 3 not responding
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 1
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 2
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Sent command:GETD
+[13:50:02] - DEBUG: Flushing serial input buffer
+[13:50:02] - DEBUG: Sending command: GETD
+[13:50:02] - DEBUG: Response: 000000000OK
+[13:50:02] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:02] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:02] - DEBUG: No connection to CCS temperature controller 3
+[13:50:02] - INFO: checking com ports
+[13:50:02] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:02] - DEBUG: VTRX States: 11010101
+[13:50:02] - DEBUG: GUI updated with pressure: 6.12E-06 mbar
+[13:50:03] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:03] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:03] - DEBUG: No connection to CCS temperature controller 1
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:03] - DEBUG: No connection to CCS temperature controller 2
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:03] - DEBUG: No connection to CCS temperature controller 3
+[13:50:03] - INFO: checking com ports
+[13:50:03] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:03] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:03] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:03] - DEBUG: No connection to CCS temperature controller 1
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Sent command:GETD
+[13:50:03] - DEBUG: Flushing serial input buffer
+[13:50:03] - DEBUG: Sending command: GETD
+[13:50:03] - DEBUG: Response: 000000000OK
+[13:50:03] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:03] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:03] - DEBUG: No connection to CCS temperature controller 2
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:04] - DEBUG: No connection to CCS temperature controller 3
+[13:50:04] - INFO: checking com ports
+[13:50:04] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:04] - WARNING: DP16 Unit 4 not responding
+[13:50:04] - DEBUG: VTRX States: 11010101
+[13:50:04] - DEBUG: GUI updated with pressure: 6.06E-06 mbar
+[13:50:04] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:04] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:04] - DEBUG: No connection to CCS temperature controller 1
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:04] - DEBUG: No connection to CCS temperature controller 2
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Sent command:GETD
+[13:50:04] - DEBUG: Flushing serial input buffer
+[13:50:04] - DEBUG: Sending command: GETD
+[13:50:04] - DEBUG: Response: 000000000OK
+[13:50:04] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:04] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:04] - DEBUG: No connection to CCS temperature controller 3
+[13:50:04] - INFO: checking com ports
+[13:50:04] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:04] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:04] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 1
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 2
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 3
+[13:50:05] - INFO: checking com ports
+[13:50:05] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:05] - DEBUG: VTRX States: 11010101
+[13:50:05] - DEBUG: GUI updated with pressure: 6.02E-06 mbar
+[13:50:05] - WARNING: DP16 Unit 5 not responding
+[13:50:05] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:05] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 1
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 2
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Sent command:GETD
+[13:50:05] - DEBUG: Flushing serial input buffer
+[13:50:05] - DEBUG: Sending command: GETD
+[13:50:05] - DEBUG: Response: 000000000OK
+[13:50:05] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:05] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:05] - DEBUG: No connection to CCS temperature controller 3
+[13:50:05] - INFO: checking com ports
+[13:50:05] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:05] - DEBUG: VTRX States: 11010101
+[13:50:05] - DEBUG: GUI updated with pressure: 6.25E-06 mbar
+[13:50:06] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:06] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:06] - DEBUG: No connection to CCS temperature controller 1
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:06] - DEBUG: No connection to CCS temperature controller 2
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:06] - DEBUG: No connection to CCS temperature controller 3
+[13:50:06] - INFO: checking com ports
+[13:50:06] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:06] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:06] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:06] - WARNING: DP16 Unit 6 not responding
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:06] - DEBUG: No connection to CCS temperature controller 1
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:06] - DEBUG: Response: 000000000OK
+[13:50:06] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:06] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:06] - DEBUG: Sent command:GETD
+[13:50:06] - DEBUG: Flushing serial input buffer
+[13:50:06] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:07] - DEBUG: No connection to CCS temperature controller 2
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:07] - DEBUG: No connection to CCS temperature controller 3
+[13:50:07] - INFO: checking com ports
+[13:50:07] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:07] - DEBUG: VTRX States: 11010101
+[13:50:07] - DEBUG: GUI updated with pressure: 6.35E-06 mbar
+[13:50:07] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:07] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:07] - DEBUG: No connection to CCS temperature controller 1
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:07] - DEBUG: No connection to CCS temperature controller 2
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Sent command:GETD
+[13:50:07] - DEBUG: Flushing serial input buffer
+[13:50:07] - DEBUG: Sending command: GETD
+[13:50:07] - DEBUG: Response: 000000000OK
+[13:50:07] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:07] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:07] - DEBUG: No connection to CCS temperature controller 3
+[13:50:07] - INFO: checking com ports
+[13:50:07] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:07] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:07] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 1
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 2
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 3
+[13:50:08] - INFO: checking com ports
+[13:50:08] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[13:50:08] - DEBUG: VTRX States: 11010101
+[13:50:08] - DEBUG: GUI updated with pressure: 6.34E-06 mbar
+[13:50:08] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:50:08] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:08] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 1
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 2
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Sent command:GETD
+[13:50:08] - DEBUG: Flushing serial input buffer
+[13:50:08] - DEBUG: Sending command: GETD
+[13:50:08] - DEBUG: Response: 000000000OK
+[13:50:08] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:08] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:08] - DEBUG: No connection to CCS temperature controller 3
+[13:50:08] - INFO: checking com ports
+[13:50:08] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:08] - DEBUG: VTRX States: 11010101
+[13:50:08] - DEBUG: GUI updated with pressure: 6.47E-06 mbar
+[13:50:09] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:09] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:09] - DEBUG: No connection to CCS temperature controller 1
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:09] - DEBUG: No connection to CCS temperature controller 2
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Sent command:GETD
+[13:50:09] - DEBUG: Flushing serial input buffer
+[13:50:09] - DEBUG: Sending command: GETD
+[13:50:09] - DEBUG: Response: 000000000OK
+[13:50:09] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:09] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:09] - DEBUG: No connection to CCS temperature controller 3
+[13:50:09] - INFO: checking com ports
+[13:50:09] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:09] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:09] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:09] - WARNING: DP16 Unit 1 not responding
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 1
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 2
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 3
+[13:50:10] - INFO: checking com ports
+[13:50:10] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:10] - DEBUG: VTRX States: 11010101
+[13:50:10] - DEBUG: GUI updated with pressure: 6.33E-06 mbar
+[13:50:10] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:10] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 1
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 2
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Sent command:GETD
+[13:50:10] - DEBUG: Flushing serial input buffer
+[13:50:10] - DEBUG: Sending command: GETD
+[13:50:10] - DEBUG: Response: 000000000OK
+[13:50:10] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:10] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:10] - DEBUG: No connection to CCS temperature controller 3
+[13:50:10] - INFO: checking com ports
+[13:50:10] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:11] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:11] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:11] - WARNING: DP16 Unit 2 not responding
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 1
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 2
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 3
+[13:50:11] - INFO: checking com ports
+[13:50:11] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:11] - DEBUG: VTRX States: 11010101
+[13:50:11] - DEBUG: GUI updated with pressure: 6.30E-06 mbar
+[13:50:11] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:11] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 1
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 2
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Sent command:GETD
+[13:50:11] - DEBUG: Flushing serial input buffer
+[13:50:11] - DEBUG: Sending command: GETD
+[13:50:11] - DEBUG: Response: 000000000OK
+[13:50:11] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:11] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:11] - DEBUG: No connection to CCS temperature controller 3
+[13:50:11] - INFO: checking com ports
+[13:50:11] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:12] - DEBUG: VTRX States: 11010101
+[13:50:12] - DEBUG: GUI updated with pressure: 6.45E-06 mbar
+[13:50:12] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:12] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:12] - DEBUG: No connection to CCS temperature controller 1
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:12] - DEBUG: No connection to CCS temperature controller 2
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Sent command:GETD
+[13:50:12] - DEBUG: Flushing serial input buffer
+[13:50:12] - DEBUG: Sending command: GETD
+[13:50:12] - DEBUG: Response: 000000000OK
+[13:50:12] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:12] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:12] - DEBUG: No connection to CCS temperature controller 3
+[13:50:12] - INFO: checking com ports
+[13:50:12] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:12] - WARNING: DP16 Unit 3 not responding
+[13:50:12] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:12] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 1
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 2
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 3
+[13:50:13] - INFO: checking com ports
+[13:50:13] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:13] - DEBUG: VTRX States: 11010101
+[13:50:13] - DEBUG: GUI updated with pressure: 6.45E-06 mbar
+[13:50:13] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:13] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 1
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 2
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Sent command:GETD
+[13:50:13] - DEBUG: Flushing serial input buffer
+[13:50:13] - DEBUG: Sending command: GETD
+[13:50:13] - DEBUG: Response: 000000000OK
+[13:50:13] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:13] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:13] - DEBUG: No connection to CCS temperature controller 3
+[13:50:13] - INFO: checking com ports
+[13:50:13] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:13] - WARNING: DP16 Unit 4 not responding
+[13:50:14] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:14] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 1
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 2
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 3
+[13:50:14] - INFO: checking com ports
+[13:50:14] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:14] - DEBUG: VTRX States: 11010101
+[13:50:14] - DEBUG: GUI updated with pressure: 6.50E-06 mbar
+[13:50:14] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:14] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 1
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 2
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Sent command:GETD
+[13:50:14] - DEBUG: Flushing serial input buffer
+[13:50:14] - DEBUG: Sending command: GETD
+[13:50:14] - DEBUG: Response: 000000000OK
+[13:50:14] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:14] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:14] - DEBUG: No connection to CCS temperature controller 3
+[13:50:14] - INFO: checking com ports
+[13:50:14] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:15] - DEBUG: VTRX States: 11010101
+[13:50:15] - DEBUG: GUI updated with pressure: 6.58E-06 mbar
+[13:50:15] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:15] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:15] - WARNING: DP16 Unit 5 not responding
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:15] - DEBUG: No connection to CCS temperature controller 1
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:15] - DEBUG: No connection to CCS temperature controller 2
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Sent command:GETD
+[13:50:15] - DEBUG: Flushing serial input buffer
+[13:50:15] - DEBUG: Sending command: GETD
+[13:50:15] - DEBUG: Response: 000000000OK
+[13:50:15] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:15] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:15] - DEBUG: No connection to CCS temperature controller 3
+[13:50:15] - INFO: checking com ports
+[13:50:15] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:15] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:15] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 1
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 2
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 3
+[13:50:16] - INFO: checking com ports
+[13:50:16] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:16] - DEBUG: VTRX States: 11010101
+[13:50:16] - DEBUG: GUI updated with pressure: 6.50E-06 mbar
+[13:50:16] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:16] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 1
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 2
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Sent command:GETD
+[13:50:16] - DEBUG: Flushing serial input buffer
+[13:50:16] - DEBUG: Sending command: GETD
+[13:50:16] - DEBUG: Response: 000000000OK
+[13:50:16] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:16] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:16] - DEBUG: No connection to CCS temperature controller 3
+[13:50:16] - WARNING: DP16 Unit 6 not responding
+[13:50:16] - INFO: checking com ports
+[13:50:16] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:16] - ERROR: Failed to reconnect to PMON
+[13:50:16] - DEBUG: VTRX States: 11010101
+[13:50:16] - DEBUG: GUI updated with pressure: 6.39E-06 mbar
+[13:50:17] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:17] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:17] - DEBUG: No connection to CCS temperature controller 1
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:17] - DEBUG: No connection to CCS temperature controller 2
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:17] - DEBUG: No connection to CCS temperature controller 3
+[13:50:17] - INFO: checking com ports
+[13:50:17] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:17] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:17] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:17] - DEBUG: No connection to CCS temperature controller 1
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:17] - DEBUG: No connection to CCS temperature controller 2
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:17] - DEBUG: Response: 000000000OK
+[13:50:17] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:17] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:17] - DEBUG: Sent command:GETD
+[13:50:17] - DEBUG: Flushing serial input buffer
+[13:50:17] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:18] - DEBUG: No connection to CCS temperature controller 3
+[13:50:18] - INFO: checking com ports
+[13:50:18] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:18] - DEBUG: VTRX States: 11010101
+[13:50:18] - DEBUG: GUI updated with pressure: 6.34E-06 mbar
+[13:50:18] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:18] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:18] - DEBUG: No connection to CCS temperature controller 1
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:18] - DEBUG: No connection to CCS temperature controller 2
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Sent command:GETD
+[13:50:18] - DEBUG: Flushing serial input buffer
+[13:50:18] - DEBUG: Sending command: GETD
+[13:50:18] - DEBUG: Response: 000000000OK
+[13:50:18] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:18] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:18] - DEBUG: No connection to CCS temperature controller 3
+[13:50:18] - INFO: checking com ports
+[13:50:18] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:19] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:19] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 1
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 2
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 3
+[13:50:19] - INFO: checking com ports
+[13:50:19] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:19] - DEBUG: VTRX States: 11010101
+[13:50:19] - DEBUG: GUI updated with pressure: 6.32E-06 mbar
+[13:50:19] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:19] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 1
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 2
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Sent command:GETD
+[13:50:19] - DEBUG: Flushing serial input buffer
+[13:50:19] - DEBUG: Sending command: GETD
+[13:50:19] - DEBUG: Response: 000000000OK
+[13:50:19] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:19] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:19] - DEBUG: No connection to CCS temperature controller 3
+[13:50:19] - INFO: checking com ports
+[13:50:19] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:19] - DEBUG: VTRX States: 11010101
+[13:50:19] - DEBUG: GUI updated with pressure: 6.30E-06 mbar
+[13:50:20] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:50:20] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:20] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:20] - DEBUG: No connection to CCS temperature controller 1
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:20] - DEBUG: No connection to CCS temperature controller 2
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:20] - DEBUG: No connection to CCS temperature controller 3
+[13:50:20] - INFO: checking com ports
+[13:50:20] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:20] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:20] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:20] - DEBUG: No connection to CCS temperature controller 1
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:20] - DEBUG: Response: 000000000OK
+[13:50:20] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:20] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:20] - DEBUG: Sent command:GETD
+[13:50:20] - DEBUG: Flushing serial input buffer
+[13:50:20] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:21] - DEBUG: No connection to CCS temperature controller 2
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:21] - DEBUG: No connection to CCS temperature controller 3
+[13:50:21] - INFO: checking com ports
+[13:50:21] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:21] - DEBUG: VTRX States: 11010101
+[13:50:21] - DEBUG: GUI updated with pressure: 6.30E-06 mbar
+[13:50:21] - WARNING: DP16 Unit 1 not responding
+[13:50:21] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:21] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:21] - DEBUG: No connection to CCS temperature controller 1
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:21] - DEBUG: No connection to CCS temperature controller 2
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Sent command:GETD
+[13:50:21] - DEBUG: Flushing serial input buffer
+[13:50:21] - DEBUG: Sending command: GETD
+[13:50:21] - DEBUG: Response: 000000000OK
+[13:50:21] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:21] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:21] - DEBUG: No connection to CCS temperature controller 3
+[13:50:21] - INFO: checking com ports
+[13:50:21] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:22] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:22] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 1
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 2
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 3
+[13:50:22] - INFO: checking com ports
+[13:50:22] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:22] - DEBUG: VTRX States: 11010101
+[13:50:22] - DEBUG: GUI updated with pressure: 6.21E-06 mbar
+[13:50:22] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:22] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 1
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 2
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Sent command:GETD
+[13:50:22] - DEBUG: Flushing serial input buffer
+[13:50:22] - DEBUG: Sending command: GETD
+[13:50:22] - DEBUG: Response: 000000000OK
+[13:50:22] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:22] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:22] - DEBUG: No connection to CCS temperature controller 3
+[13:50:22] - WARNING: DP16 Unit 2 not responding
+[13:50:22] - INFO: checking com ports
+[13:50:22] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:22] - DEBUG: VTRX States: 11010101
+[13:50:22] - DEBUG: GUI updated with pressure: 6.35E-06 mbar
+[13:50:23] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:23] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:23] - DEBUG: No connection to CCS temperature controller 1
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:23] - DEBUG: No connection to CCS temperature controller 2
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:23] - DEBUG: Response: 000000000OK
+[13:50:23] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:23] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:23] - DEBUG: No connection to CCS temperature controller 3
+[13:50:23] - INFO: checking com ports
+[13:50:23] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:23] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:23] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:23] - DEBUG: Sent command:GETD
+[13:50:23] - DEBUG: Flushing serial input buffer
+[13:50:23] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 1
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 2
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 3
+[13:50:24] - INFO: checking com ports
+[13:50:24] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:24] - DEBUG: VTRX States: 11010101
+[13:50:24] - DEBUG: GUI updated with pressure: 6.44E-06 mbar
+[13:50:24] - WARNING: DP16 Unit 3 not responding
+[13:50:24] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:24] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 1
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 2
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Sent command:GETD
+[13:50:24] - DEBUG: Flushing serial input buffer
+[13:50:24] - DEBUG: Sending command: GETD
+[13:50:24] - DEBUG: Response: 000000000OK
+[13:50:24] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:24] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:24] - DEBUG: No connection to CCS temperature controller 3
+[13:50:24] - INFO: checking com ports
+[13:50:24] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:25] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:25] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 1
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 2
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 3
+[13:50:25] - INFO: checking com ports
+[13:50:25] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:25] - DEBUG: VTRX States: 11010101
+[13:50:25] - DEBUG: GUI updated with pressure: 6.41E-06 mbar
+[13:50:25] - WARNING: DP16 Unit 4 not responding
+[13:50:25] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:25] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 1
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 2
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Sent command:GETD
+[13:50:25] - DEBUG: Flushing serial input buffer
+[13:50:25] - DEBUG: Sending command: GETD
+[13:50:25] - DEBUG: Response: 000000000OK
+[13:50:25] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:25] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:25] - DEBUG: No connection to CCS temperature controller 3
+[13:50:25] - INFO: checking com ports
+[13:50:25] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:26] - DEBUG: VTRX States: 11010101
+[13:50:26] - DEBUG: GUI updated with pressure: 6.58E-06 mbar
+[13:50:26] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:26] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:26] - DEBUG: No connection to CCS temperature controller 1
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:26] - DEBUG: No connection to CCS temperature controller 2
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Sent command:GETD
+[13:50:26] - DEBUG: Flushing serial input buffer
+[13:50:26] - DEBUG: Sending command: GETD
+[13:50:26] - DEBUG: Response: 000000000OK
+[13:50:26] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:26] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:26] - DEBUG: No connection to CCS temperature controller 3
+[13:50:26] - INFO: checking com ports
+[13:50:26] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:27] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:27] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:27] - WARNING: DP16 Unit 5 not responding
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 1
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 2
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 3
+[13:50:27] - INFO: checking com ports
+[13:50:27] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:27] - DEBUG: VTRX States: 11010101
+[13:50:27] - DEBUG: GUI updated with pressure: 6.62E-06 mbar
+[13:50:27] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:27] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 1
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 2
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Sent command:GETD
+[13:50:27] - DEBUG: Flushing serial input buffer
+[13:50:27] - DEBUG: Sending command: GETD
+[13:50:27] - DEBUG: Response: 000000000OK
+[13:50:27] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:27] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:27] - DEBUG: No connection to CCS temperature controller 3
+[13:50:27] - INFO: checking com ports
+[13:50:27] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:28] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 1
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 2
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 3
+[13:50:28] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:28] - INFO: checking com ports
+[13:50:28] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:28] - WARNING: DP16 Unit 6 not responding
+[13:50:28] - DEBUG: VTRX States: 11010101
+[13:50:28] - DEBUG: GUI updated with pressure: 6.56E-06 mbar
+[13:50:28] - ERROR: Failed to reconnect to PMON
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 1
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 2
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Sent command:GETD
+[13:50:28] - DEBUG: Flushing serial input buffer
+[13:50:28] - DEBUG: Sending command: GETD
+[13:50:28] - DEBUG: Response: 000000000OK
+[13:50:28] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:28] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:28] - DEBUG: No connection to CCS temperature controller 3
+[13:50:28] - INFO: checking com ports
+[13:50:28] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:28] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:29] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:29] - DEBUG: VTRX States: 11010101
+[13:50:29] - DEBUG: GUI updated with pressure: 6.67E-06 mbar
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:29] - DEBUG: No connection to CCS temperature controller 1
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:29] - DEBUG: No connection to CCS temperature controller 2
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Sent command:GETD
+[13:50:29] - DEBUG: Flushing serial input buffer
+[13:50:29] - DEBUG: Sending command: GETD
+[13:50:29] - DEBUG: Response: 000000000OK
+[13:50:29] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:29] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:29] - DEBUG: No connection to CCS temperature controller 3
+[13:50:29] - INFO: checking com ports
+[13:50:29] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:29] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:29] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 1
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 2
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 3
+[13:50:30] - INFO: checking com ports
+[13:50:30] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:30] - DEBUG: VTRX States: 11010101
+[13:50:30] - DEBUG: GUI updated with pressure: 6.63E-06 mbar
+[13:50:30] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:30] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 1
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 2
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Sent command:GETD
+[13:50:30] - DEBUG: Flushing serial input buffer
+[13:50:30] - DEBUG: Sending command: GETD
+[13:50:30] - DEBUG: Response: 000000000OK
+[13:50:30] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:30] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:30] - DEBUG: No connection to CCS temperature controller 3
+[13:50:30] - INFO: checking com ports
+[13:50:30] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:30] - DEBUG: VTRX States: 11010101
+[13:50:30] - DEBUG: GUI updated with pressure: 6.50E-06 mbar
+[13:50:30] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:30] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:31] - DEBUG: No connection to CCS temperature controller 1
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:31] - DEBUG: No connection to CCS temperature controller 2
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:31] - DEBUG: No connection to CCS temperature controller 3
+[13:50:31] - INFO: checking com ports
+[13:50:31] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:31] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:31] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:31] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:31] - DEBUG: No connection to CCS temperature controller 1
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Sent command:GETD
+[13:50:31] - DEBUG: Flushing serial input buffer
+[13:50:31] - DEBUG: Sending command: GETD
+[13:50:31] - DEBUG: Response: 000000000OK
+[13:50:31] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:31] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:31] - DEBUG: No connection to CCS temperature controller 2
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:32] - DEBUG: No connection to CCS temperature controller 3
+[13:50:32] - INFO: checking com ports
+[13:50:32] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:32] - DEBUG: VTRX States: 11010101
+[13:50:32] - DEBUG: GUI updated with pressure: 6.28E-06 mbar
+[13:50:32] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:32] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:32] - DEBUG: No connection to CCS temperature controller 1
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:32] - DEBUG: No connection to CCS temperature controller 2
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Sent command:GETD
+[13:50:32] - DEBUG: Flushing serial input buffer
+[13:50:32] - DEBUG: Sending command: GETD
+[13:50:32] - DEBUG: Response: 000000000OK
+[13:50:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:32] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:32] - DEBUG: No connection to CCS temperature controller 3
+[13:50:32] - INFO: checking com ports
+[13:50:32] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:32] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:32] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:33] - WARNING: DP16 Unit 1 not responding
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 1
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 2
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 3
+[13:50:33] - INFO: checking com ports
+[13:50:33] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:33] - DEBUG: VTRX States: 11010101
+[13:50:33] - DEBUG: GUI updated with pressure: 6.43E-06 mbar
+[13:50:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 1
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 2
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Sent command:GETD
+[13:50:33] - DEBUG: Flushing serial input buffer
+[13:50:33] - DEBUG: Sending command: GETD
+[13:50:33] - DEBUG: Response: 000000000OK
+[13:50:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:33] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:33] - DEBUG: No connection to CCS temperature controller 3
+[13:50:33] - INFO: checking com ports
+[13:50:33] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:33] - DEBUG: VTRX States: 11010101
+[13:50:33] - DEBUG: GUI updated with pressure: 6.25E-06 mbar
+[13:50:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:34] - DEBUG: No connection to CCS temperature controller 1
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:34] - DEBUG: No connection to CCS temperature controller 2
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:34] - DEBUG: No connection to CCS temperature controller 3
+[13:50:34] - WARNING: DP16 Unit 2 not responding
+[13:50:34] - INFO: checking com ports
+[13:50:34] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:34] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:34] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Sent command:GETD
+[13:50:34] - DEBUG: Flushing serial input buffer
+[13:50:34] - DEBUG: Sending command: GETD
+[13:50:34] - DEBUG: Response: 000000000OK
+[13:50:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:34] - DEBUG: No connection to CCS temperature controller 1
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:35] - DEBUG: No connection to CCS temperature controller 2
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:35] - DEBUG: No connection to CCS temperature controller 3
+[13:50:35] - INFO: checking com ports
+[13:50:35] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:35] - DEBUG: VTRX States: 11010101
+[13:50:35] - DEBUG: GUI updated with pressure: 6.33E-06 mbar
+[13:50:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:35] - DEBUG: No connection to CCS temperature controller 1
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:35] - DEBUG: No connection to CCS temperature controller 2
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Sent command:GETD
+[13:50:35] - DEBUG: Flushing serial input buffer
+[13:50:35] - DEBUG: Sending command: GETD
+[13:50:35] - DEBUG: Response: 000000000OK
+[13:50:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:35] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:35] - DEBUG: No connection to CCS temperature controller 3
+[13:50:35] - INFO: checking com ports
+[13:50:35] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:35] - WARNING: DP16 Unit 3 not responding
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 1
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 2
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 3
+[13:50:36] - INFO: checking com ports
+[13:50:36] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:36] - DEBUG: VTRX States: 11010101
+[13:50:36] - DEBUG: GUI updated with pressure: 6.28E-06 mbar
+[13:50:36] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:36] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 1
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 2
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Sent command:GETD
+[13:50:36] - DEBUG: Flushing serial input buffer
+[13:50:36] - DEBUG: Sending command: GETD
+[13:50:36] - DEBUG: Response: 000000000OK
+[13:50:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:36] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:36] - DEBUG: No connection to CCS temperature controller 3
+[13:50:36] - INFO: checking com ports
+[13:50:36] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:37] - DEBUG: VTRX States: 11010101
+[13:50:37] - DEBUG: GUI updated with pressure: 6.25E-06 mbar
+[13:50:37] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:37] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:37] - WARNING: DP16 Unit 4 not responding
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:37] - DEBUG: No connection to CCS temperature controller 1
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:37] - DEBUG: No connection to CCS temperature controller 2
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Sent command:GETD
+[13:50:37] - DEBUG: Flushing serial input buffer
+[13:50:37] - DEBUG: Sending command: GETD
+[13:50:37] - DEBUG: Response: 000000000OK
+[13:50:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:37] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:37] - DEBUG: No connection to CCS temperature controller 3
+[13:50:37] - INFO: checking com ports
+[13:50:37] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:37] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:37] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 1
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 2
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 3
+[13:50:38] - INFO: checking com ports
+[13:50:38] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:38] - DEBUG: VTRX States: 11010101
+[13:50:38] - DEBUG: GUI updated with pressure: 6.30E-06 mbar
+[13:50:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:38] - WARNING: DP16 Unit 5 not responding
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 1
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 2
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Sent command:GETD
+[13:50:38] - DEBUG: Flushing serial input buffer
+[13:50:38] - DEBUG: Sending command: GETD
+[13:50:38] - DEBUG: Response: 000000000OK
+[13:50:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:38] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:38] - DEBUG: No connection to CCS temperature controller 3
+[13:50:38] - INFO: checking com ports
+[13:50:38] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 1
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 2
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 3
+[13:50:39] - INFO: checking com ports
+[13:50:39] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:39] - DEBUG: VTRX States: 11010101
+[13:50:39] - DEBUG: GUI updated with pressure: 6.17E-06 mbar
+[13:50:39] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:39] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 1
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 2
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Sent command:GETD
+[13:50:39] - DEBUG: Flushing serial input buffer
+[13:50:39] - DEBUG: Sending command: GETD
+[13:50:39] - DEBUG: Response: 000000000OK
+[13:50:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:39] - DEBUG: No connection to CCS temperature controller 3
+[13:50:39] - INFO: checking com ports
+[13:50:39] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:40] - WARNING: DP16 Unit 6 not responding
+[13:50:40] - DEBUG: VTRX States: 11010101
+[13:50:40] - DEBUG: GUI updated with pressure: 6.21E-06 mbar
+[13:50:40] - ERROR: Failed to reconnect to PMON
+[13:50:40] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:40] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:40] - DEBUG: No connection to CCS temperature controller 1
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:40] - DEBUG: No connection to CCS temperature controller 2
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Sent command:GETD
+[13:50:40] - DEBUG: Flushing serial input buffer
+[13:50:40] - DEBUG: Sending command: GETD
+[13:50:40] - DEBUG: Response: 000000000OK
+[13:50:40] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:40] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:40] - DEBUG: No connection to CCS temperature controller 3
+[13:50:40] - INFO: checking com ports
+[13:50:40] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:40] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:40] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 1
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 2
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 3
+[13:50:41] - INFO: checking com ports
+[13:50:41] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:41] - DEBUG: VTRX States: 11010101
+[13:50:41] - DEBUG: GUI updated with pressure: 5.98E-06 mbar
+[13:50:41] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:41] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 1
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 2
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Sent command:GETD
+[13:50:41] - DEBUG: Flushing serial input buffer
+[13:50:41] - DEBUG: Sending command: GETD
+[13:50:41] - DEBUG: Response: 000000000OK
+[13:50:41] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:41] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:41] - DEBUG: No connection to CCS temperature controller 3
+[13:50:41] - INFO: checking com ports
+[13:50:41] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:41] - DEBUG: VTRX States: 11010101
+[13:50:41] - DEBUG: GUI updated with pressure: 6.12E-06 mbar
+[13:50:41] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:41] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:42] - DEBUG: No connection to CCS temperature controller 1
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:42] - DEBUG: No connection to CCS temperature controller 2
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:42] - DEBUG: No connection to CCS temperature controller 3
+[13:50:42] - INFO: checking com ports
+[13:50:42] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:42] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:42] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:42] - DEBUG: No connection to CCS temperature controller 1
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Sent command:GETD
+[13:50:42] - DEBUG: Flushing serial input buffer
+[13:50:42] - DEBUG: Sending command: GETD
+[13:50:42] - DEBUG: Response: 000000000OK
+[13:50:42] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:42] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:42] - DEBUG: No connection to CCS temperature controller 2
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:43] - DEBUG: No connection to CCS temperature controller 3
+[13:50:43] - INFO: checking com ports
+[13:50:43] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:43] - DEBUG: VTRX States: 11010101
+[13:50:43] - DEBUG: GUI updated with pressure: 6.07E-06 mbar
+[13:50:43] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:43] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:43] - DEBUG: Attempting to connect on port ModbusSerialClient /dev/ttyUSB0:0
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:43] - DEBUG: No connection to CCS temperature controller 1
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:43] - DEBUG: No connection to CCS temperature controller 2
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Sent command:GETD
+[13:50:43] - DEBUG: Flushing serial input buffer
+[13:50:43] - DEBUG: Sending command: GETD
+[13:50:43] - DEBUG: Response: 000000000OK
+[13:50:43] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:43] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:43] - DEBUG: No connection to CCS temperature controller 3
+[13:50:43] - INFO: checking com ports
+[13:50:43] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:43] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:43] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 1
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 2
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 3
+[13:50:44] - INFO: checking com ports
+[13:50:44] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:44] - DEBUG: VTRX States: 11010101
+[13:50:44] - DEBUG: GUI updated with pressure: 6.08E-06 mbar
+[13:50:44] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:44] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:44] - WARNING: DP16 Unit 1 not responding
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 1
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 2
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Sent command:GETD
+[13:50:44] - DEBUG: Flushing serial input buffer
+[13:50:44] - DEBUG: Sending command: GETD
+[13:50:44] - DEBUG: Response: 000000000OK
+[13:50:44] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:44] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:44] - DEBUG: No connection to CCS temperature controller 3
+[13:50:44] - INFO: checking com ports
+[13:50:44] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:44] - DEBUG: VTRX States: 11010101
+[13:50:44] - DEBUG: GUI updated with pressure: 6.19E-06 mbar
+[13:50:45] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:45] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:45] - DEBUG: No connection to CCS temperature controller 1
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:45] - DEBUG: No connection to CCS temperature controller 2
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:45] - DEBUG: No connection to CCS temperature controller 3
+[13:50:45] - INFO: checking com ports
+[13:50:45] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:45] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:45] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:45] - DEBUG: No connection to CCS temperature controller 1
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:45] - DEBUG: Response: 000000000OK
+[13:50:45] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:45] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:45] - DEBUG: Sent command:GETD
+[13:50:45] - DEBUG: Flushing serial input buffer
+[13:50:45] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:46] - DEBUG: No connection to CCS temperature controller 2
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:46] - DEBUG: No connection to CCS temperature controller 3
+[13:50:46] - WARNING: DP16 Unit 2 not responding
+[13:50:46] - INFO: checking com ports
+[13:50:46] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:46] - DEBUG: VTRX States: 11010101
+[13:50:46] - DEBUG: GUI updated with pressure: 6.21E-06 mbar
+[13:50:46] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:46] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:46] - DEBUG: No connection to CCS temperature controller 1
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:46] - DEBUG: No connection to CCS temperature controller 2
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Sent command:GETD
+[13:50:46] - DEBUG: Flushing serial input buffer
+[13:50:46] - DEBUG: Sending command: GETD
+[13:50:46] - DEBUG: Response: 000000000OK
+[13:50:46] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:46] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:46] - DEBUG: No connection to CCS temperature controller 3
+[13:50:46] - INFO: checking com ports
+[13:50:46] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:46] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:46] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 1
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 2
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 3
+[13:50:47] - INFO: checking com ports
+[13:50:47] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:47] - DEBUG: VTRX States: 11010101
+[13:50:47] - DEBUG: GUI updated with pressure: 6.14E-06 mbar
+[13:50:47] - WARNING: DP16 Unit 3 not responding
+[13:50:47] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:47] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 1
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 2
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Sent command:GETD
+[13:50:47] - DEBUG: Flushing serial input buffer
+[13:50:47] - DEBUG: Sending command: GETD
+[13:50:47] - DEBUG: Response: 000000000OK
+[13:50:47] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:47] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:47] - DEBUG: No connection to CCS temperature controller 3
+[13:50:47] - INFO: checking com ports
+[13:50:47] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:47] - DEBUG: VTRX States: 11010101
+[13:50:47] - DEBUG: GUI updated with pressure: 6.13E-06 mbar
+[13:50:48] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:48] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:48] - DEBUG: No connection to CCS temperature controller 1
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:48] - DEBUG: No connection to CCS temperature controller 2
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Sent command:GETD
+[13:50:48] - DEBUG: Flushing serial input buffer
+[13:50:48] - DEBUG: Sending command: GETD
+[13:50:48] - DEBUG: Response: 000000000OK
+[13:50:48] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:48] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:48] - DEBUG: No connection to CCS temperature controller 3
+[13:50:48] - INFO: checking com ports
+[13:50:48] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:48] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:48] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:48] - WARNING: DP16 Unit 4 not responding
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 1
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 2
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 3
+[13:50:49] - INFO: checking com ports
+[13:50:49] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:49] - DEBUG: VTRX States: 11010101
+[13:50:49] - DEBUG: GUI updated with pressure: 6.25E-06 mbar
+[13:50:49] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:49] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 1
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 2
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Sent command:GETD
+[13:50:49] - DEBUG: Flushing serial input buffer
+[13:50:49] - DEBUG: Sending command: GETD
+[13:50:49] - DEBUG: Response: 000000000OK
+[13:50:49] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[13:50:49] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[13:50:49] - DEBUG: No connection to CCS temperature controller 3
+[13:50:49] - INFO: checking com ports
+[13:50:49] - DEBUG: PMON temps: {1: 'DISCONNECTED', 2: 'DISCONNECTED', 3: 'DISCONNECTED', 4: 'DISCONNECTED', 5: 'DISCONNECTED', 6: 'DISCONNECTED'}
+[13:50:49] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[13:50:49] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+

--- a/log_export_2026-02-27_14-02-38.txt
+++ b/log_export_2026-02-27_14-02-38.txt
@@ -1,0 +1,703 @@
+[14:02:31] - INFO: Serial connection established on /dev/pts/25
+[14:02:31] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:31] - INFO: Serial connection established on /dev/pts/30
+[14:02:31] - INFO: G9 driver initialized
+[14:02:31] - DEBUG: Initializing E5CNModbus with port: /dev/pts/29
+[14:02:31] - ERROR: Failed to connect to the E5CN Modbus device.
+[14:02:31] - ERROR: Cannot start reading temperatures - connection failed
+[14:02:31] - ERROR: Failed to start temperature controllers at /dev/pts/29
+[14:02:31] - INFO: Serial connection established on /dev/pts/26
+[14:02:31] - DEBUG: Raw command sent: SABC3
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: SABC3
+[14:02:31] - DEBUG: Response: OK
+[14:02:31] - DEBUG: Raw response received: OK
+[14:02:31] - INFO: Set preset mode for CathodeA PS to 3 (normal mode).
+[14:02:31] - DEBUG: Raw command sent: GABC
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: GABC
+[14:02:31] - DEBUG: Response: 3OK
+[14:02:31] - DEBUG: Raw response received: 3OK
+[14:02:31] - INFO: Current preset selection: 3
+[14:02:31] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeA PS. Response: 3
+[14:02:31] - DEBUG: Setting OVP for cathode CathodeA PS to: 1.00
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: SOVP0100
+[14:02:31] - DEBUG: Response: OK
+[14:02:31] - INFO: Set OVP for cathode CathodeA PS to 1.00V
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: GOVP
+[14:02:31] - DEBUG: Response: 0100OK
+[14:02:31] - INFO: OVP value: 1.00
+[14:02:31] - INFO: OVP setting confirmed for cathode CathodeA PS: 1.00V
+[14:02:31] - DEBUG: Setting OCP for cathode CathodeA PS to: 9.00A
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: SOCP0900
+[14:02:31] - DEBUG: Response: OK
+[14:02:31] - INFO: Set OCP for cathode CathodeA PS to 9.00A
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: GOCP
+[14:02:31] - DEBUG: Response: 0900OK
+[14:02:31] - DEBUG: OCP value: 9.00A
+[14:02:31] - INFO: OCP setting confirmed for cathode CathodeA PS: 9.00A
+[14:02:31] - INFO: Initialized CathodeA PS on port /dev/pts/26
+[14:02:31] - INFO: Serial connection established on /dev/pts/27
+[14:02:31] - DEBUG: Raw command sent: SABC3
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: SABC3
+[14:02:31] - DEBUG: Response: OK
+[14:02:31] - DEBUG: Raw response received: OK
+[14:02:31] - INFO: Set preset mode for CathodeB PS to 3 (normal mode).
+[14:02:31] - DEBUG: Raw command sent: GABC
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: GABC
+[14:02:31] - DEBUG: Response: 3OK
+[14:02:31] - DEBUG: Raw response received: 3OK
+[14:02:31] - INFO: Current preset selection: 3
+[14:02:31] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeB PS. Response: 3
+[14:02:31] - DEBUG: Setting OVP for cathode CathodeB PS to: 1.00
+[14:02:31] - DEBUG: Flushing serial input buffer
+[14:02:31] - DEBUG: Sending command: SOVP0100
+[14:02:32] - DEBUG: Response: OK
+[14:02:32] - INFO: Set OVP for cathode CathodeB PS to 1.00V
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GOVP
+[14:02:32] - DEBUG: Response: 0100OK
+[14:02:32] - INFO: OVP value: 1.00
+[14:02:32] - INFO: OVP setting confirmed for cathode CathodeB PS: 1.00V
+[14:02:32] - DEBUG: Setting OCP for cathode CathodeB PS to: 9.00A
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: SOCP0900
+[14:02:32] - DEBUG: Response: OK
+[14:02:32] - INFO: Set OCP for cathode CathodeB PS to 9.00A
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GOCP
+[14:02:32] - DEBUG: Response: 0900OK
+[14:02:32] - DEBUG: OCP value: 9.00A
+[14:02:32] - INFO: OCP setting confirmed for cathode CathodeB PS: 9.00A
+[14:02:32] - INFO: Initialized CathodeB PS on port /dev/pts/27
+[14:02:32] - INFO: Serial connection established on /dev/pts/28
+[14:02:32] - DEBUG: Raw command sent: SABC3
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: SABC3
+[14:02:32] - DEBUG: Response: OK
+[14:02:32] - DEBUG: Raw response received: OK
+[14:02:32] - INFO: Set preset mode for CathodeC PS to 3 (normal mode).
+[14:02:32] - DEBUG: Raw command sent: GABC
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GABC
+[14:02:32] - DEBUG: Response: 3OK
+[14:02:32] - DEBUG: Raw response received: 3OK
+[14:02:32] - INFO: Current preset selection: 3
+[14:02:32] - INFO: Asserted preset mode 3 (normal mode) for cathode CathodeC PS. Response: 3
+[14:02:32] - DEBUG: Setting OVP for cathode CathodeC PS to: 1.00
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: SOVP0100
+[14:02:32] - DEBUG: Response: OK
+[14:02:32] - INFO: Set OVP for cathode CathodeC PS to 1.00V
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GOVP
+[14:02:32] - DEBUG: Response: 0100OK
+[14:02:32] - INFO: OVP value: 1.00
+[14:02:32] - INFO: OVP setting confirmed for cathode CathodeC PS: 1.00V
+[14:02:32] - DEBUG: Setting OCP for cathode CathodeC PS to: 9.00A
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: SOCP0900
+[14:02:32] - DEBUG: Response: OK
+[14:02:32] - INFO: Set OCP for cathode CathodeC PS to 9.00A
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GOCP
+[14:02:32] - DEBUG: Response: 0900OK
+[14:02:32] - DEBUG: OCP value: 9.00A
+[14:02:32] - INFO: OCP setting confirmed for cathode CathodeC PS: 9.00A
+[14:02:32] - INFO: Initialized CathodeC PS on port /dev/pts/28
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 1
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 2
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 3
+[14:02:32] - INFO: checking com ports
+[14:02:32] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:32] - WARNING: No interlock information is here; Queue is Empty
+[14:02:32] - CRITICAL: No data available from G9
+[14:02:32] - DEBUG: Dashboard beam callback registered
+[14:02:31] - DEBUG: Attempting PMON connect on /dev/ttyUSB0 @ 9600,8N1
+[14:02:32] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:32] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:32] - INFO: Connecting to BCON on /dev/pts/32…
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 1
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 2
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Sent command:GETD
+[14:02:32] - DEBUG: Flushing serial input buffer
+[14:02:32] - DEBUG: Sending command: GETD
+[14:02:32] - DEBUG: Response: 000000000OK
+[14:02:32] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:32] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:32] - DEBUG: No connection to CCS temperature controller 3
+[14:02:32] - INFO: checking com ports
+[14:02:32] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:33] - DEBUG: VTRX States: 11010101
+[14:02:33] - DEBUG: GUI updated with pressure: 4.88E-06 mbar
+[14:02:33] - DEBUG: VTRX States: 11010101
+[14:02:33] - DEBUG: GUI updated with pressure: 4.73E-06 mbar
+[14:02:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:33] - INFO: Interlock E-STOP Int: red -> green
+[14:02:33] - INFO: Interlock E-STOP Ext: red -> green
+[14:02:33] - INFO: Interlock Door: red -> green
+[14:02:33] - INFO: Interlock Vacuum Power: red -> green
+[14:02:33] - INFO: Interlock Vacuum Pressure: red -> green
+[14:02:33] - INFO: Interlock High Oil: red -> green
+[14:02:33] - INFO: Interlock Low Oil: red -> green
+[14:02:33] - INFO: Interlock Water: red -> green
+[14:02:33] - INFO: Interlock All Interlocks: red -> green
+[14:02:33] - INFO: Interlock G9SP Active: red -> green
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:33] - DEBUG: No connection to CCS temperature controller 1
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:33] - DEBUG: No connection to CCS temperature controller 2
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Sent command:GETD
+[14:02:33] - DEBUG: Flushing serial input buffer
+[14:02:33] - DEBUG: Sending command: GETD
+[14:02:33] - DEBUG: Response: 000000000OK
+[14:02:33] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:33] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:33] - DEBUG: No connection to CCS temperature controller 3
+[14:02:33] - INFO: checking com ports
+[14:02:33] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:33] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:33] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 1
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 2
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 3
+[14:02:34] - INFO: checking com ports
+[14:02:34] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:34] - DEBUG: VTRX States: 11010101
+[14:02:34] - DEBUG: GUI updated with pressure: 4.74E-06 mbar
+[14:02:34] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:34] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 1
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 2
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Sent command:GETD
+[14:02:34] - DEBUG: Flushing serial input buffer
+[14:02:34] - DEBUG: Sending command: GETD
+[14:02:34] - DEBUG: Response: 000000000OK
+[14:02:34] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:34] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:34] - DEBUG: No connection to CCS temperature controller 3
+[14:02:34] - INFO: checking com ports
+[14:02:34] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:35] - INFO: BCON connected on /dev/pts/32
+[14:02:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 1
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 2
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 3
+[14:02:35] - INFO: checking com ports
+[14:02:35] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:35] - DEBUG: VTRX States: 11010101
+[14:02:35] - DEBUG: GUI updated with pressure: 4.62E-06 mbar
+[14:02:35] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:35] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 1
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 2
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Sent command:GETD
+[14:02:35] - DEBUG: Flushing serial input buffer
+[14:02:35] - DEBUG: Sending command: GETD
+[14:02:35] - DEBUG: Response: 000000000OK
+[14:02:35] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:35] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:35] - DEBUG: No connection to CCS temperature controller 3
+[14:02:35] - INFO: checking com ports
+[14:02:36] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:36] - DEBUG: VTRX States: 11010101
+[14:02:36] - DEBUG: GUI updated with pressure: 4.51E-06 mbar
+[14:02:36] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:36] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:36] - DEBUG: No connection to CCS temperature controller 1
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:36] - DEBUG: No connection to CCS temperature controller 2
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Sent command:GETD
+[14:02:36] - DEBUG: Flushing serial input buffer
+[14:02:36] - DEBUG: Sending command: GETD
+[14:02:36] - DEBUG: Response: 000000000OK
+[14:02:36] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:36] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:36] - DEBUG: No connection to CCS temperature controller 3
+[14:02:36] - INFO: checking com ports
+[14:02:36] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:36] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:36] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 1
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 2
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 3
+[14:02:37] - INFO: checking com ports
+[14:02:37] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:37] - DEBUG: VTRX States: 11010101
+[14:02:37] - DEBUG: GUI updated with pressure: 4.69E-06 mbar
+[14:02:37] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:37] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 1
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 2
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Sent command:GETD
+[14:02:37] - DEBUG: Flushing serial input buffer
+[14:02:37] - DEBUG: Sending command: GETD
+[14:02:37] - DEBUG: Response: 000000000OK
+[14:02:37] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:37] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:37] - DEBUG: No connection to CCS temperature controller 3
+[14:02:37] - INFO: checking com ports
+[14:02:37] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:38] - DEBUG: No connection to CCS temperature controller 1
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:38] - DEBUG: No connection to CCS temperature controller 2
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:38] - DEBUG: No connection to CCS temperature controller 3
+[14:02:38] - INFO: checking com ports
+[14:02:38] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:38] - DEBUG: VTRX States: 11010101
+[14:02:38] - DEBUG: GUI updated with pressure: 4.78E-06 mbar
+[14:02:38] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:38] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Sent command:GETD
+[14:02:38] - DEBUG: Flushing serial input buffer
+[14:02:38] - DEBUG: Sending command: GETD
+[14:02:38] - DEBUG: Response: 000000000OK
+[14:02:38] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:38] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:38] - DEBUG: No connection to CCS temperature controller 1
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:39] - DEBUG: No connection to CCS temperature controller 2
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:39] - DEBUG: No connection to CCS temperature controller 3
+[14:02:39] - INFO: checking com ports
+[14:02:39] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+[14:02:39] - DEBUG: VTRX States: 11010101
+[14:02:39] - DEBUG: GUI updated with pressure: 4.99E-06 mbar
+[14:02:39] - DEBUG: Safety Output Terminal Data Flags: [0, 0, 0, 0, 1, 0, 0]
+[14:02:39] - DEBUG: Safety Input Terminal Data Flags: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Power supply 1 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:39] - DEBUG: No connection to CCS temperature controller 1
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Power supply 2 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:39] - DEBUG: No connection to CCS temperature controller 2
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Raw GETD response (attempt 1): 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Sent command:GETD
+[14:02:39] - DEBUG: Flushing serial input buffer
+[14:02:39] - DEBUG: Sending command: GETD
+[14:02:39] - DEBUG: Response: 000000000OK
+[14:02:39] - DEBUG: Parsed GETD response: 0.00V, 0.00A, CV Mode
+[14:02:39] - DEBUG: Power supply 3 readings - Voltage: 0.00V, Current: 0.00A, Mode: CV Mode
+[14:02:39] - DEBUG: No connection to CCS temperature controller 3
+[14:02:39] - INFO: checking com ports
+[14:02:39] - DEBUG: PMON temps: {1: 'None', 2: 'None', 3: 'None', 4: 'None', 5: 'None', 6: 'None'}
+

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def start_main_app(com_ports):
     """
     root = tk.Tk()
     root.title("EBEAM System Dashboard")
-    root.state('zoomed')
+    root.attributes('-zoomed', True)
 
     # Track fullscreen state
     fullscreen = False
@@ -70,10 +70,8 @@ def start_main_app(com_ports):
         return "break"
     
     def toggle_maximize(event=None):
-        if root.state() == 'zoomed':
-            root.state('normal')
-        else:
-            root.state('zoomed')
+        current = bool(root.attributes('-zoomed'))
+        root.attributes('-zoomed', not current)
         return "break"
 
     def save_logs(event=None):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import platform
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
@@ -29,6 +30,20 @@ MD_TEXT_DIM = "#9E9E9E"
 MIN_DASHBOARD_WIDTH = 1200
 MIN_DASHBOARD_HEIGHT = 675
 
+PLATFORM_SYSTEM = platform.system().lower()
+IS_WINDOWS = PLATFORM_SYSTEM == "windows"
+IS_LINUX = PLATFORM_SYSTEM == "linux"
+
+
+def list_serial_ports_by_os():
+    """Return available serial ports filtered for the current OS."""
+    ports = [port.device for port in serial.tools.list_ports.comports() if port.device]
+    if IS_WINDOWS:
+        ports = [port for port in ports if port.upper().startswith("COM")]
+    elif IS_LINUX:
+        ports = [port for port in ports if port.startswith("/dev/tty")]
+    return sorted(set(ports))
+
 def create_dummy_port_labels(subsystems):
     """
     Create a list of dummy port labels that the user can select
@@ -58,18 +73,41 @@ def start_main_app(com_ports):
     root.title("EBEAM System Dashboard")
     root.configure(bg=MD_BG)
     root.minsize(MIN_DASHBOARD_WIDTH, MIN_DASHBOARD_HEIGHT)
-    root.attributes('-zoomed', True)
+
+    def supports_zoomed() -> bool:
+        try:
+            root.attributes('-zoomed')
+            return True
+        except tk.TclError:
+            return False
+
+    can_zoom = supports_zoomed()
+
+    def set_maximized(enable: bool):
+        if can_zoom:
+            root.attributes('-zoomed', bool(enable))
+            return
+        if enable:
+            screen_w = root.winfo_screenwidth()
+            screen_h = root.winfo_screenheight()
+            root.geometry(f"{screen_w}x{screen_h}+0+0")
+
+    set_maximized(True)
     restore_geometry = "1920x1080"
 
     # Track fullscreen state
     fullscreen = False
-    was_zoomed = True
+    was_zoomed = can_zoom
     was_fullscreen = False
+    window_is_maximized = True
 
     def restore_window_size_1080p():
+        nonlocal window_is_maximized
         root.attributes('-fullscreen', False)
-        root.attributes('-zoomed', False)
+        if can_zoom:
+            root.attributes('-zoomed', False)
         root.geometry(restore_geometry)
+        window_is_maximized = False
   
     def quit_app(event=None):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
@@ -96,21 +134,23 @@ def start_main_app(com_ports):
         return "break"
     
     def toggle_maximize(event=None):
-        current = bool(root.attributes('-zoomed'))
+        nonlocal window_is_maximized
+        current = bool(root.attributes('-zoomed')) if can_zoom else window_is_maximized
         if current:
             restore_window_size_1080p()
         else:
-            root.attributes('-zoomed', True)
+            set_maximized(True)
+            window_is_maximized = True
         return "break"
 
     def enforce_restore_geometry(event=None):
         nonlocal was_zoomed, was_fullscreen, fullscreen
         if event is not None and event.widget is not root:
             return
-        is_zoomed = bool(root.attributes('-zoomed'))
+        is_zoomed = bool(root.attributes('-zoomed')) if can_zoom else window_is_maximized
         is_fullscreen = bool(root.attributes('-fullscreen'))
         fullscreen = is_fullscreen
-        if was_zoomed and (not is_zoomed) and (not is_fullscreen):
+        if can_zoom and was_zoomed and (not is_zoomed) and (not is_fullscreen):
             root.geometry(restore_geometry)
         if was_fullscreen and (not is_fullscreen) and (not is_zoomed):
             root.geometry(restore_geometry)
@@ -234,7 +274,7 @@ def config_com_ports(saved_com_ports):
             pass
     
     # Get real COM ports on the system
-    real_ports = [port.device for port in serial.tools.list_ports.comports()]
+    real_ports = list_serial_ports_by_os()
     # Create a combined list of real + dummy port labels for user to pick
     dummy_port_labels = create_dummy_port_labels(SUBSYSTEMS)
     # Combine real + dummy port labels

--- a/main.py
+++ b/main.py
@@ -18,6 +18,17 @@ SUBSYSTEMS = [
     'BeamPulse',
 ]
 
+# Material Design Dark Theme Palette
+MD_BG = "#1E1E2E"
+MD_CARD = "#2A2A3C"
+MD_CARD_BORDER = "#3A3A4C"
+MD_PRIMARY = "#7C4DFF"
+MD_PRIMARY_HOVER = "#6A3FE0"
+MD_TEXT = "#E0E0E0"
+MD_TEXT_DIM = "#9E9E9E"
+MIN_DASHBOARD_WIDTH = 1200
+MIN_DASHBOARD_HEIGHT = 675
+
 def create_dummy_port_labels(subsystems):
     """
     Create a list of dummy port labels that the user can select
@@ -45,10 +56,20 @@ def start_main_app(com_ports):
     """
     root = tk.Tk()
     root.title("EBEAM System Dashboard")
+    root.configure(bg=MD_BG)
+    root.minsize(MIN_DASHBOARD_WIDTH, MIN_DASHBOARD_HEIGHT)
     root.attributes('-zoomed', True)
+    restore_geometry = "1920x1080"
 
     # Track fullscreen state
     fullscreen = False
+    was_zoomed = True
+    was_fullscreen = False
+
+    def restore_window_size_1080p():
+        root.attributes('-fullscreen', False)
+        root.attributes('-zoomed', False)
+        root.geometry(restore_geometry)
   
     def quit_app(event=None):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
@@ -58,21 +79,43 @@ def start_main_app(com_ports):
     
     def toggle_fullscreen(event=None):
         nonlocal fullscreen
-        fullscreen = not fullscreen
-        root.attributes('-fullscreen', fullscreen)
+        is_fullscreen = bool(root.attributes('-fullscreen'))
+        if is_fullscreen:
+            fullscreen = False
+            restore_window_size_1080p()
+        else:
+            fullscreen = True
+            root.attributes('-fullscreen', True)
         return "break"
     
     def escape_handler(event=None):
         nonlocal fullscreen
         if fullscreen:
             fullscreen = False
-            root.attributes('-fullscreen', False)
+            restore_window_size_1080p()
         return "break"
     
     def toggle_maximize(event=None):
         current = bool(root.attributes('-zoomed'))
-        root.attributes('-zoomed', not current)
+        if current:
+            restore_window_size_1080p()
+        else:
+            root.attributes('-zoomed', True)
         return "break"
+
+    def enforce_restore_geometry(event=None):
+        nonlocal was_zoomed, was_fullscreen, fullscreen
+        if event is not None and event.widget is not root:
+            return
+        is_zoomed = bool(root.attributes('-zoomed'))
+        is_fullscreen = bool(root.attributes('-fullscreen'))
+        fullscreen = is_fullscreen
+        if was_zoomed and (not is_zoomed) and (not is_fullscreen):
+            root.geometry(restore_geometry)
+        if was_fullscreen and (not is_fullscreen) and (not is_zoomed):
+            root.geometry(restore_geometry)
+        was_zoomed = is_zoomed
+        was_fullscreen = is_fullscreen
 
     def save_logs(event=None):
         if hasattr(app, 'messages_frame'):
@@ -170,6 +213,7 @@ def start_main_app(com_ports):
   
 
     app = EBEAMSystemDashboard(root, com_ports)
+    root.bind('<Configure>', enforce_restore_geometry, add='+')
     root.mainloop()
 
 def config_com_ports(saved_com_ports):
@@ -198,6 +242,39 @@ def config_com_ports(saved_com_ports):
 
     config_root = tk.Tk()
     config_root.title("Configure COM Ports")
+    config_root.configure(bg=MD_BG)
+
+    style = ttk.Style(config_root)
+    if "clam" in style.theme_names():
+        style.theme_use("clam")
+    style.configure(".", background=MD_BG, foreground=MD_TEXT)
+    style.configure("TFrame", background=MD_BG)
+    style.configure("TLabel", background=MD_BG, foreground=MD_TEXT)
+    style.configure("TButton", background=MD_PRIMARY, foreground="#FFFFFF", borderwidth=0, focusthickness=0, padding=(10, 6))
+    style.map("TButton", background=[("active", MD_PRIMARY_HOVER), ("pressed", MD_PRIMARY)], foreground=[("disabled", MD_TEXT_DIM)])
+    style.configure(
+        "MD.TCombobox",
+        fieldbackground=MD_CARD,
+        background=MD_CARD_BORDER,
+        foreground=MD_TEXT,
+        arrowcolor=MD_TEXT,
+        bordercolor=MD_CARD_BORDER,
+        lightcolor=MD_CARD_BORDER,
+        darkcolor=MD_CARD_BORDER,
+        insertcolor=MD_TEXT,
+        padding=(6, 4),
+    )
+    style.map(
+        "MD.TCombobox",
+        fieldbackground=[("readonly", MD_CARD), ("focus", MD_CARD)],
+        background=[("readonly", MD_CARD_BORDER), ("active", MD_PRIMARY_HOVER)],
+        foreground=[("readonly", MD_TEXT), ("disabled", MD_TEXT_DIM)],
+        arrowcolor=[("active", "#FFFFFF"), ("readonly", MD_TEXT)],
+    )
+    config_root.option_add('*TCombobox*Listbox*Background', MD_CARD)
+    config_root.option_add('*TCombobox*Listbox*Foreground', MD_TEXT)
+    config_root.option_add('*TCombobox*Listbox*selectBackground', MD_PRIMARY)
+    config_root.option_add('*TCombobox*Listbox*selectForeground', '#FFFFFF')
 
     selections = {}
 
@@ -209,10 +286,10 @@ def config_com_ports(saved_com_ports):
         frame = ttk.Frame(main_frame)
         frame.pack(pady=5, anchor='center')
 
-        label = tk.Label(
+        label = ttk.Label(
             frame, 
             text=f"{subsystem} COM Port:", 
-            width=25, 
+            width=25,
             anchor='e'
         )
         label.pack(side=tk.LEFT, padx=(0, 10))
@@ -225,7 +302,8 @@ def config_com_ports(saved_com_ports):
             values=combined_port_options, 
             textvariable=selected_port, 
             state='readonly', 
-            width=15
+            width=15,
+            style='MD.TCombobox'
         )
         combobox.pack(side=tk.LEFT)
         selections[subsystem] = selected_port
@@ -262,7 +340,7 @@ def config_com_ports(saved_com_ports):
         # Launch the main application
         start_main_app(selected_ports)
 
-    submit_button = tk.Button(config_root, text="Submit", command=on_submit)
+    submit_button = ttk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack(pady=20)
     
     config_root.bind('<Return>', lambda event: on_submit())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pymodbus==3.7.3
 pyserial==3.5
 scipy==1.14.1
 tkdial==0.0.7
-pandas==2.1.3
+pandas>=2.2.0

--- a/simulator/__init__.py
+++ b/simulator/__init__.py
@@ -1,0 +1,1 @@
+"""EBEAM Dashboard Hardware Simulator package."""

--- a/simulator/instruments.py
+++ b/simulator/instruments.py
@@ -672,7 +672,7 @@ class G9DriverSim(BaseSimulator):
 # ---------------------------------------------------------------------------
 
 class DP16ProcessMonitorSim(BaseSimulator):
-    """Simulates 5 × DP16PT RTD temperature monitors (Modbus slaves 1–5)."""
+    """Simulates 6 × DP16PT RTD temperature monitors (Modbus slaves 1–6)."""
 
     def __init__(self, pair: VirtualSerialPair):
         super().__init__(pair, "DP16")
@@ -682,7 +682,11 @@ class DP16ProcessMonitorSim(BaseSimulator):
             "temp_3": 29.0,    # Chamber Top
             "temp_4": 30.0,    # Chamber Bot
             "temp_5": 22.0,    # Air temp
+            "temp_6": 25.0,    # Unassigned
         }
+        self._status_by_unit = {unit: 0x0006 for unit in range(1, 7)}
+        # Manual default: 0x4A (Decimal point 2, °C, filter constant 4)
+        self._rdgcnf_by_unit = {unit: 0x004A for unit in range(1, 7)}
         self._buf = b""
 
     def run(self):
@@ -703,7 +707,7 @@ class DP16ProcessMonitorSim(BaseSimulator):
         while len(self._buf) >= 8:
             slave = self._buf[0]
             func = self._buf[1]
-            if func == 0x03:
+            if func in (0x03, 0x04):
                 if len(self._buf) < 8:
                     break
                 frame = self._buf[:8]
@@ -715,30 +719,119 @@ class DP16ProcessMonitorSim(BaseSimulator):
                 self._buf = self._buf[8:]
                 addr = struct.unpack(">H", frame[2:4])[0]
                 count = struct.unpack(">H", frame[4:6])[0]
-                self._respond_read(slave, addr, count)
+                self._respond_read(slave, func, addr, count)
+            elif func == 0x06:
+                if len(self._buf) < 8:
+                    break
+                frame = self._buf[:8]
+                crc_recv = struct.unpack("<H", frame[6:8])[0]
+                crc_calc = _modbus_crc(frame[:6])
+                if crc_recv != crc_calc:
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[8:]
+                addr = struct.unpack(">H", frame[2:4])[0]
+                value = struct.unpack(">H", frame[4:6])[0]
+                self._respond_write_single(slave, addr, value)
             else:
+                # Unknown function code for a valid slave -> Modbus exception 01
                 self._buf = self._buf[1:]
+                if 1 <= slave <= 6:
+                    self.pair.write(_modbus_exception(slave, func, 0x01))
 
-    def _respond_read(self, slave: int, addr: int, count: int):
-        if slave < 1 or slave > 5:
+    @staticmethod
+    def _rdgcnf_decimal_multiplier(rdgcnf: int) -> int:
+        decimal_code = (rdgcnf >> 5) & 0x07
+        if decimal_code == 1:
+            return 1
+        if decimal_code == 2:
+            return 10
+        if decimal_code == 3:
+            return 100
+        if decimal_code == 4:
+            return 1000
+        return 1
+
+    def _respond_read(self, slave: int, func: int, addr: int, count: int):
+        if slave < 1 or slave > 6:
             return
+
+        if count <= 0:
+            self.pair.write(_modbus_exception(slave, func, 0x03))
+            return
+
         with self.lock:
             temp = self.state.get(f"temp_{slave}", 25.0)
-        if addr == 0x0240 and count >= 1:
-            # Status register → 0x0006 = running
-            payload = bytes([count * 2]) + struct.pack(">H", 0x0006)
-            if count > 1:
-                payload += b'\x00\x00' * (count - 1)
-        elif addr == 0x0210 and count >= 2:
+
+        if addr == 0x0210:
+            # Driver map: process value as IEEE 754 float in two registers
+            if count != 2:
+                self.pair.write(_modbus_exception(slave, func, 0x03))
+                return
             # Process value as IEEE 754 big-endian float
             raw = struct.pack(">f", temp)
             hi, lo = struct.unpack(">HH", raw)
-            payload = bytes([count * 2]) + struct.pack(">H", hi) + struct.pack(">H", lo)
-            if count > 2:
-                payload += b'\x00\x00' * (count - 2)
+            payload = bytes([4]) + struct.pack(">H", hi) + struct.pack(">H", lo)
+        elif addr == 0x0240:
+            # Driver map: status register
+            if count != 1:
+                self.pair.write(_modbus_exception(slave, func, 0x03))
+                return
+            with self.lock:
+                status = self._status_by_unit.get(slave, 0x0006)
+            payload = bytes([2]) + struct.pack(">H", status)
+        elif addr == 0x0248:
+            # Driver map: reading config register
+            if count != 1:
+                self.pair.write(_modbus_exception(slave, func, 0x03))
+                return
+            with self.lock:
+                rdgcnf = self._rdgcnf_by_unit.get(slave, 0x004A)
+            payload = bytes([2]) + struct.pack(">H", rdgcnf)
+        elif addr == 8:
+            # Manual table 6.2: RDGCNF register
+            if count != 1:
+                self.pair.write(_modbus_exception(slave, func, 0x03))
+                return
+            with self.lock:
+                rdgcnf = self._rdgcnf_by_unit.get(slave, 0x004A)
+            payload = bytes([2]) + struct.pack(">H", rdgcnf)
+        elif addr == 39:
+            # Manual table 6.2: Process value as signed integer counts
+            if count != 1:
+                self.pair.write(_modbus_exception(slave, func, 0x03))
+                return
+            with self.lock:
+                rdgcnf = self._rdgcnf_by_unit.get(slave, 0x004A)
+            multiplier = self._rdgcnf_decimal_multiplier(rdgcnf)
+            raw_counts = int(round(temp * multiplier))
+            raw_counts = max(-32768, min(32767, raw_counts))
+            payload = bytes([2]) + struct.pack(">H", raw_counts & 0xFFFF)
         else:
-            payload = bytes([count * 2]) + b'\x00\x00' * count
-        resp = _modbus_response(slave, 0x03, payload)
+            self.pair.write(_modbus_exception(slave, func, 0x02))
+            return
+
+        resp = _modbus_response(slave, func, payload)
+        time.sleep(0.005)
+        self.pair.write(resp)
+
+    def _respond_write_single(self, slave: int, addr: int, value: int):
+        if slave < 1 or slave > 6:
+            return
+
+        with self.lock:
+            if addr in (8, 0x0248):
+                # RDGCNF is 8-bit in manual; keep upper byte zeroed
+                self._rdgcnf_by_unit[slave] = value & 0x00FF
+            elif addr == 0x0240:
+                self._status_by_unit[slave] = value & 0xFFFF
+            else:
+                self.pair.write(_modbus_exception(slave, 0x06, 0x02))
+                return
+
+        # Per Modbus spec for FC06: echo request fields
+        payload = struct.pack(">H", addr) + struct.pack(">H", value & 0xFFFF)
+        resp = _modbus_response(slave, 0x06, payload)
         time.sleep(0.005)
         self.pair.write(resp)
 

--- a/simulator/instruments.py
+++ b/simulator/instruments.py
@@ -352,6 +352,17 @@ class G9DriverSim(BaseSimulator):
         self.state = {name: True for name in self.INTERLOCK_NAMES}
         self._buf = b""
 
+    def interlock_chain_ok(self) -> bool:
+        with self.lock:
+            return all(self.state.get(name, True) for name in self.INTERLOCK_NAMES[:11])
+
+    def _pack_flags(self, bits: list[bool], total_bytes: int = 6) -> bytes:
+        packed = bytearray(total_bytes)
+        for i, bit in enumerate(bits):
+            if bit:
+                packed[i // 8] |= (1 << (i % 8))
+        return bytes(packed)
+
     def run(self):
         while not self._stop.is_set():
             chunk = self.pair.read(256, timeout=0.05)
@@ -377,35 +388,37 @@ class G9DriverSim(BaseSimulator):
     def _send_response(self):
         """Build a 199-byte G9SP response packet."""
         resp = bytearray(199)
-        resp[0] = 0x40  # header
-        resp[1] = 0xC3  # length indicator
+        resp[0] = 0x40
+        resp[1] = 0x00
+        resp[2] = 0x00
+        resp[3] = 0xC3
         # OCTD at byte 7
         resp[7] = 0x00
-        # Build SITSF (safety input terminal status flags) — 6 bytes at offset 21
-        # and SITDF (safety input terminal data flags) — 6 bytes at offset 11.
-        # For the simulator: SITSF bit=1 means OK (same as SITDF).
+
         with self.lock:
-            bits = 0
-            for i, name in enumerate(self.INTERLOCK_NAMES):
-                if self.state.get(name, False):
-                    bits |= (1 << i)
-        # Pack 13 bits into the first 2 bytes of each 6-byte field
-        sitsf_bytes = bits.to_bytes(2, 'big')
-        sitdf_bytes = bits.to_bytes(2, 'big')
+            input_bits = [bool(self.state.get(name, False)) for name in self.INTERLOCK_NAMES]
+            chain_ok = all(input_bits[:11])
+            g9_active = bool(self.state.get("g9sp_active", True))
+
+        sitsf_bytes = self._pack_flags(input_bits, total_bytes=6)
+        sitdf_bytes = self._pack_flags(input_bits, total_bytes=6)
+
+        # Output flags: bit 4 is consumed by driver as g9_active signal
+        out_bits = [False] * 7
+        out_bits[4] = bool(chain_ok and g9_active)
+        sotsf_bytes = self._pack_flags(out_bits, total_bytes=4)
+        sotdf_bytes = self._pack_flags(out_bits, total_bytes=4)
+
         # SITDF at offset 11, 6 bytes
-        resp[11] = sitdf_bytes[0]
-        resp[12] = sitdf_bytes[1]
-        # SOTDF at offset 17, 4 bytes — outputs all ON
-        resp[17] = 0xFF
-        resp[18] = 0xFF
+        resp[11:17] = sitdf_bytes
+        # SOTDF at offset 17, 4 bytes
+        resp[17:21] = sotdf_bytes
         # SITSF at offset 21, 6 bytes
-        resp[21] = sitsf_bytes[0]
-        resp[22] = sitsf_bytes[1]
+        resp[21:27] = sitsf_bytes
         # SOTSF at offset 27, 4 bytes
-        resp[27] = 0xFF
-        resp[28] = 0xFF
-        # US (unit status) at offset 73, 2 bytes — 0=OK
-        resp[73] = 0x00
+        resp[27:31] = sotsf_bytes
+        # US (unit status) at offset 73, 2 bytes — 0x0100 = normal
+        resp[73] = 0x01
         resp[74] = 0x00
         # Checksum at bytes 195–196: sum of 0..194 & 0xFFFF big-endian
         cksum = sum(resp[:195]) & 0xFFFF
@@ -544,6 +557,7 @@ class BCONDriverSim(BaseSimulator):
 
         self.watchdog_timeout_ms = self.DEFAULT_WATCHDOG_MS
         self.telemetry_period_ms = self.DEFAULT_TELEMETRY_MS
+        self._interlock_input_ok = True
         self.last_command_ms = self._now_ms()
         self.watchdog_grace_deadline_ms = self.last_command_ms + self.WATCHDOG_BOOT_GRACE_MS
         self.last_modbus_error = self.ERR_NONE
@@ -564,6 +578,7 @@ class BCONDriverSim(BaseSimulator):
             "sys_state": 0,       # 0=READY
             "armed": False,
             "interlock_ok": True,
+            "interlock_forced_off": False,
             "fault_latched": False,
             "watchdog_ok": True,
             "last_error": 0,
@@ -584,6 +599,20 @@ class BCONDriverSim(BaseSimulator):
             self._sync_public_state()
             self._stop.wait(0.02)
 
+    def set_interlock_ok(self, ok: bool):
+        with self.lock:
+            self._interlock_input_ok = bool(ok)
+
+    def force_interlock_off(self):
+        with self.lock:
+            self.state["interlock_forced_off"] = True
+            self.state["interlock_ok"] = False
+
+    def reset_interlock(self):
+        with self.lock:
+            self.state["interlock_forced_off"] = False
+            self.state["interlock_ok"] = bool(self._interlock_input_ok)
+
     def _now_ms(self) -> int:
         return int(time.monotonic() * 1000)
 
@@ -594,7 +623,9 @@ class BCONDriverSim(BaseSimulator):
         return (now - self.last_command_ms) <= self.watchdog_timeout_ms
 
     def _is_interlock_satisfied(self) -> bool:
-        return bool(self.state.get("interlock_ok", True))
+        if bool(self.state.get("interlock_forced_off", False)):
+            return False
+        return bool(self._interlock_input_ok)
 
     def _is_any_overcurrent_asserted(self) -> bool:
         return any(self._channels[ch]["overcurrent"] for ch in (1, 2, 3))
@@ -704,7 +735,7 @@ class BCONDriverSim(BaseSimulator):
     def _sync_public_state(self):
         with self.lock:
             self.state["sys_state"] = self._evaluate_top_level_state()
-            self.state["interlock_ok"] = bool(self.state.get("interlock_ok", True))
+            self.state["interlock_ok"] = self._is_interlock_satisfied()
             self.state["watchdog_ok"] = self._is_watchdog_healthy()
             self.state["fault_latched"] = bool(self.state.get("fault_latched", False))
             self.state["last_error"] = self.last_modbus_error

--- a/simulator/instruments.py
+++ b/simulator/instruments.py
@@ -136,10 +136,25 @@ class PowerSupply9104Sim(BaseSimulator):
             "mode": 0,              # 0=CV, 1=CC
             "ovp": 42.0,
             "ocp": 5.0,
-            "preset": 0,
-            "presets": {0: (0.0, 0.0), 1: (0.0, 0.0), 2: (0.0, 0.0)},
+            "preset": 3,
+            "presets": {0: (0.0, 0.0), 1: (0.0, 0.0), 2: (0.0, 0.0), 3: (0.0, 0.0)},
+            "sw_times": {0: 1, 1: 1, 2: 1},
+            "delta_times": {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0},
         }
         self._buf = b""
+
+    @staticmethod
+    def _clamp(value: int, lo: int, hi: int) -> int:
+        return max(lo, min(hi, value))
+
+    @staticmethod
+    def _split_preset_and_value(raw: str) -> tuple[int, int] | None:
+        raw = raw.strip().replace(" ", "")
+        if len(raw) < 5 or not raw.isdigit():
+            return None
+        preset = int(raw[0])
+        value = int(raw[1:5])
+        return preset, value
 
     def run(self):
         while not self._stop.is_set():
@@ -184,17 +199,28 @@ class PowerSupply9104Sim(BaseSimulator):
             elif cmd == "GOUT":
                 return f"{'1' if self.state['output_on'] else '0'}\rOK"
             elif cmd.startswith("VOLT"):
-                raw = cmd[4:].strip()
-                if len(raw) >= 5:
-                    cv = int(raw[1:5])
+                parsed = self._split_preset_and_value(cmd[4:])
+                if parsed:
+                    preset, cv = parsed
                     self.state["voltage_set"] = cv / 100.0
+                    if preset in self.state["presets"]:
+                        _, cur = self.state["presets"][preset]
+                        self.state["presets"][preset] = (self.state["voltage_set"], cur)
+                    # If command targets active preset, reflect into active setpoint
+                    if preset == self.state["preset"]:
+                        self.state["voltage_set"] = cv / 100.0
                     self._notify()
                 return "OK"
             elif cmd.startswith("CURR"):
-                raw = cmd[4:].strip()
-                if len(raw) >= 5:
-                    ca = int(raw[1:5])
+                parsed = self._split_preset_and_value(cmd[4:])
+                if parsed:
+                    preset, ca = parsed
                     self.state["current_set"] = ca / 100.0
+                    if preset in self.state["presets"]:
+                        volt, _ = self.state["presets"][preset]
+                        self.state["presets"][preset] = (volt, self.state["current_set"])
+                    if preset == self.state["preset"]:
+                        self.state["current_set"] = ca / 100.0
                     self._notify()
                 return "OK"
             elif cmd == "GETD":
@@ -221,15 +247,105 @@ class PowerSupply9104Sim(BaseSimulator):
                 sv, si = self.state["presets"].get(p, (0, 0))
                 return f"{int(sv*100):04d}{int(si*100):04d}\rOK"
             elif cmd.startswith("SETD"):
+                # SETD<preset><voltage><current>
+                raw = cmd[4:].strip().replace(" ", "")
+                if len(raw) >= 9 and raw[:9].isdigit():
+                    p = int(raw[0])
+                    v = int(raw[1:5]) / 100.0
+                    c = int(raw[5:9]) / 100.0
+                    if p in self.state["presets"]:
+                        self.state["presets"][p] = (v, c)
+                    if p == self.state["preset"]:
+                        self.state["voltage_set"] = v
+                        self.state["current_set"] = c
+                    self._notify()
                 return "OK"
             elif cmd == "GABC":
                 return f"{self.state['preset']}\rOK"
             elif cmd.startswith("SABC"):
-                self.state["preset"] = int(cmd[4]) if len(cmd) > 4 else 0
+                if len(cmd) > 4 and cmd[4].isdigit():
+                    p = self._clamp(int(cmd[4]), 0, 3)
+                    self.state["preset"] = p
+                    v, c = self.state["presets"].get(p, (0.0, 0.0))
+                    self.state["voltage_set"] = v
+                    self.state["current_set"] = c
+                    self._notify()
+                return "OK"
+            elif cmd.startswith("GDLT"):
+                raw = cmd[4:].strip()
+                idx = int(raw[0]) if raw and raw[0].isdigit() else 0
+                idx = self._clamp(idx, 0, 5)
+                return f"{int(self.state['delta_times'][idx]):02d}\rOK"
+            elif cmd.startswith("SDLT"):
+                raw = cmd[4:].strip().replace(" ", "")
+                if len(raw) >= 3 and raw[:3].isdigit():
+                    idx = self._clamp(int(raw[0]), 0, 5)
+                    val = self._clamp(int(raw[1:3]), 0, 20)
+                    self.state["delta_times"][idx] = val
+                    self._notify()
+                return "OK"
+            elif cmd.startswith("GSWT"):
+                raw = cmd[4:].strip()
+                if raw and raw[0].isdigit():
+                    idx = self._clamp(int(raw[0]), 0, 2)
+                    return f"{int(self.state['sw_times'][idx]):03d}\rOK"
+                # Some host code calls GSWT without index; return first entry.
+                return f"{int(self.state['sw_times'][0]):03d}\rOK"
+            elif cmd.startswith("SSWT"):
+                raw = cmd[4:].strip().replace(" ", "")
+                if len(raw) >= 4 and raw[:4].isdigit():
+                    idx = self._clamp(int(raw[0]), 0, 2)
+                    val = self._clamp(int(raw[1:4]), 0, 600)
+                    self.state["sw_times"][idx] = val
+                    self._notify()
+                return "OK"
+            elif cmd.startswith("RUNP"):
                 return "OK"
             elif cmd in ("SESS", "ENDS", "STOP"):
                 return "OK"
             elif cmd == "GALL":
+                # Keep response shape close to manual examples while remaining lightweight.
+                abc = int(self.state["preset"])
+                channel = 0
+                uvl = int(self.state["ovp"] * 100)
+                ucl = int(self.state["ocp"] * 100)
+                out = 1 if self.state["output_on"] else 0
+                sw1 = int(self.state["sw_times"][0])
+                sw2 = int(self.state["sw_times"][1])
+                sw3 = int(self.state["sw_times"][2])
+                dt = "".join(f"{int(self.state['delta_times'][i]):02d}" for i in range(6))
+                mode = 8160
+                set_values = []
+                for p in (0, 1, 2, 3):
+                    v, c = self.state["presets"][p]
+                    set_values.append(f"{int(v * 100):04d}")
+                    set_values.append(f"{int(c * 100):04d}")
+                body = (
+                    f"{abc}{channel}{uvl:04d}{ucl:04d}{out}"
+                    f"{sw1:03d}{sw2:03d}{sw3:03d}{dt}{mode:04d}"
+                    + "".join(set_values)
+                )
+                return f"{body}\rOK"
+            elif cmd.startswith("SETM"):
+                # SETM<v1><i1><sw1><v2><i2><sw2><v3><i3><sw3>
+                raw = cmd[4:].strip().replace(" ", "")
+                if len(raw) >= 33 and raw[:33].isdigit():
+                    v1 = int(raw[0:4]) / 100.0
+                    i1 = int(raw[4:8]) / 100.0
+                    s1 = self._clamp(int(raw[8:11]), 0, 600)
+                    v2 = int(raw[11:15]) / 100.0
+                    i2 = int(raw[15:19]) / 100.0
+                    s2 = self._clamp(int(raw[19:22]), 0, 600)
+                    v3 = int(raw[22:26]) / 100.0
+                    i3 = int(raw[26:30]) / 100.0
+                    s3 = self._clamp(int(raw[30:33]), 0, 600)
+                    self.state["presets"][0] = (v1, i1)
+                    self.state["presets"][1] = (v2, i2)
+                    self.state["presets"][2] = (v3, i3)
+                    self.state["sw_times"][0] = s1
+                    self.state["sw_times"][1] = s2
+                    self.state["sw_times"][2] = s3
+                    self._notify()
                 return "OK"
             return "OK"
 
@@ -318,10 +434,13 @@ class E5CNModbusSim(BaseSimulator):
             return
         with self.lock:
             temp = self.state.get(f"temp_{slave}", 25.0)
-        # E5CN: register 0x0000, count=2 → response regs[1] = temp*10
+        # E5CN PV representation used by this project:
+        # read addr 0x0000, count=2, with PV in regs[1] at 0.1°C resolution.
+        # Encode as signed 16-bit two's complement for sub-zero values.
         regs = [0] * count
         if addr == 0x0000 and count >= 2:
-            regs[1] = int(temp * 10) & 0xFFFF
+            pv_raw = int(round(temp * 10.0))
+            regs[1] = pv_raw & 0xFFFF
         payload = bytes([count * 2])
         for r in regs:
             payload += struct.pack(">H", r & 0xFFFF)
@@ -350,7 +469,16 @@ class G9DriverSim(BaseSimulator):
     def __init__(self, pair: VirtualSerialPair):
         super().__init__(pair, "G9SP")
         self.state = {name: True for name in self.INTERLOCK_NAMES}
+        self.state.update({
+            "config_id": 0x0001,
+            "unit_conduction_minutes": 0,
+            "output_power_error": False,
+            "function_block_error": False,
+            "input_error_codes": [0] * 20,
+            "output_error_codes": [0] * 20,
+        })
         self._buf = b""
+        self._started_at = time.time()
 
     def interlock_chain_ok(self) -> bool:
         with self.lock:
@@ -362,6 +490,29 @@ class G9DriverSim(BaseSimulator):
             if bit:
                 packed[i // 8] |= (1 << (i % 8))
         return bytes(packed)
+
+    @staticmethod
+    def _pack_nibbles(error_codes: list[int], total_bytes: int) -> bytes:
+        packed = bytearray(total_bytes)
+        for i in range(total_bytes):
+            lo_idx = i * 2
+            hi_idx = lo_idx + 1
+            lo = int(error_codes[lo_idx]) & 0x0F if lo_idx < len(error_codes) else 0
+            hi = int(error_codes[hi_idx]) & 0x0F if hi_idx < len(error_codes) else 0
+            packed[i] = lo | (hi << 4)
+        return bytes(packed)
+
+    def _is_valid_request(self, frame: bytes) -> bool:
+        if len(frame) != 19:
+            return False
+        # +0..+8 fixed command header per manual
+        if frame[:9] != b"\x40\x00\x00\x0F\x4B\x03\x4D\x00\x01":
+            return False
+        if frame[17:19] != b"\x2A\x0D":
+            return False
+        recv_cksum = struct.unpack(">H", frame[15:17])[0]
+        calc_cksum = sum(frame[:15]) & 0xFFFF
+        return recv_cksum == calc_cksum
 
     def run(self):
         while not self._stop.is_set():
@@ -382,8 +533,31 @@ class G9DriverSim(BaseSimulator):
                 self._buf = self._buf[idx:]
             if len(self._buf) < 19:
                 return
+            frame = self._buf[:19]
             self._buf = self._buf[19:]  # consume request
-            self._send_response()
+            if self._is_valid_request(frame):
+                self._send_response()
+            else:
+                self._send_error_response()
+
+    def _send_error_response(self):
+        """Build a manual-conformant command-format error response."""
+        resp = bytearray(199)
+        resp[0] = 0x40
+        resp[1] = 0x00
+        resp[2] = 0x00
+        resp[3] = 0x06  # Incorrect command format
+        resp[4] = 0x00
+        resp[5] = 0x01  # non-zero end code for format error
+        # no service code/data for incorrect command format
+        cksum = sum(resp[:195]) & 0xFFFF
+        resp[195] = (cksum >> 8) & 0xFF
+        resp[196] = cksum & 0xFF
+        resp[197] = 0x2A
+        resp[198] = 0x0D
+        time.sleep(0.01)
+        self.pair.write(bytes(resp))
+        self._notify()
 
     def _send_response(self):
         """Build a 199-byte G9SP response packet."""
@@ -392,22 +566,67 @@ class G9DriverSim(BaseSimulator):
         resp[1] = 0x00
         resp[2] = 0x00
         resp[3] = 0xC3
-        # OCTD at byte 7
-        resp[7] = 0x00
+        # End code + service code for normal response
+        resp[4] = 0x00
+        resp[5] = 0x00
+        resp[6] = 0xCB
+        # OCTD starts at byte 7
+        resp[7:11] = b"\x00\x00\x00\x00"
 
         with self.lock:
             input_bits = [bool(self.state.get(name, False)) for name in self.INTERLOCK_NAMES]
             chain_ok = all(input_bits[:11])
             g9_active = bool(self.state.get("g9sp_active", True))
+            input_error_codes = list(self.state.get("input_error_codes", [0] * 20))
+            output_error_codes = list(self.state.get("output_error_codes", [0] * 20))
+            output_power_error = bool(self.state.get("output_power_error", False))
+            function_block_error = bool(self.state.get("function_block_error", False))
+            config_id = int(self.state.get("config_id", 0x0001)) & 0xFFFF
+            started_at = self._started_at
 
-        sitsf_bytes = self._pack_flags(input_bits, total_bytes=6)
+        # Update conduction time in minutes.
+        conduction_minutes = max(0, int((time.time() - started_at) / 60.0)) & 0xFFFFFF
+        with self.lock:
+            self.state["unit_conduction_minutes"] = conduction_minutes
+
         sitdf_bytes = self._pack_flags(input_bits, total_bytes=6)
+        # Status flags indicate terminal health (1=normal, 0=error), independent from ON/OFF data flags.
+        input_status_bits = []
+        for i in range(len(self.INTERLOCK_NAMES)):
+            has_error = (i < len(input_error_codes) and int(input_error_codes[i]) != 0)
+            input_status_bits.append(not has_error)
+        sitsf_bytes = self._pack_flags(input_status_bits, total_bytes=6)
 
         # Output flags: bit 4 is consumed by driver as g9_active signal
         out_bits = [False] * 7
         out_bits[4] = bool(chain_ok and g9_active)
-        sotsf_bytes = self._pack_flags(out_bits, total_bytes=4)
         sotdf_bytes = self._pack_flags(out_bits, total_bytes=4)
+        output_status_bits = [True] * 7
+        for i in range(7):
+            if i < len(output_error_codes) and int(output_error_codes[i]) != 0:
+                output_status_bits[i] = False
+        sotsf_bytes = self._pack_flags(output_status_bits, total_bytes=4)
+
+        sitec_bytes = self._pack_nibbles(input_error_codes, total_bytes=24)
+        sotec_bytes = self._pack_nibbles(output_error_codes, total_bytes=16)
+
+        safety_io_error = any(code != 0 for code in input_error_codes[:20]) or any(
+            code != 0 for code in output_error_codes[:20]
+        )
+
+        # Unit Status bits per manual:
+        # byte0 bit0: Unit Normal Operating Flag
+        # byte1 bit1: Output Power Supply Error Flag
+        # byte1 bit2: Safety I/O Terminal Error Flag
+        # byte1 bit5: Function Block Error Flag
+        unit_status_lo = 0x01 if not (output_power_error or safety_io_error or function_block_error) else 0x00
+        unit_status_hi = 0x00
+        if output_power_error:
+            unit_status_hi |= 0x02
+        if safety_io_error:
+            unit_status_hi |= 0x04
+        if function_block_error:
+            unit_status_hi |= 0x20
 
         # SITDF at offset 11, 6 bytes
         resp[11:17] = sitdf_bytes
@@ -417,9 +636,25 @@ class G9DriverSim(BaseSimulator):
         resp[21:27] = sitsf_bytes
         # SOTSF at offset 27, 4 bytes
         resp[27:31] = sotsf_bytes
-        # US (unit status) at offset 73, 2 bytes — 0x0100 = normal
-        resp[73] = 0x01
-        resp[74] = 0x00
+
+        # SITEC at offset 31, 24 bytes
+        resp[31:55] = sitec_bytes
+        # SOTEC at offset 55, 16 bytes
+        resp[55:71] = sotec_bytes
+        # Unit Status at offset 73, 2 bytes
+        resp[73] = unit_status_lo
+        resp[74] = unit_status_hi
+
+        # Configuration ID at offset 75, rightmost then leftmost byte
+        resp[75] = config_id & 0xFF
+        resp[76] = (config_id >> 8) & 0xFF
+
+        # Unit conduction time at offset 77: 3 bytes little significance first + reserved byte
+        resp[77] = conduction_minutes & 0xFF
+        resp[78] = (conduction_minutes >> 8) & 0xFF
+        resp[79] = (conduction_minutes >> 16) & 0xFF
+        resp[80] = 0x00
+
         # Checksum at bytes 195–196: sum of 0..194 & 0xFFFF big-endian
         cksum = sum(resp[:195]) & 0xFFFF
         resp[195] = (cksum >> 8) & 0xFF

--- a/simulator/instruments.py
+++ b/simulator/instruments.py
@@ -1,0 +1,1049 @@
+"""
+instruments.py — Simulated hardware instrument backends.
+
+Each simulator runs in its own thread, reads commands from the master side of a
+PTY pair, and writes responses (or streams data) back.  All state is stored in
+plain dicts so the GUI can read / mutate it directly (with a lock).
+
+Instrument simulators implemented:
+- VTRXSimulator          (read-only ASCII stream — vacuum system)
+- PowerSupply9104Sim     (ASCII cmd/response — cathode heater PSU)
+- E5CNModbusSim          (Modbus RTU 8E2 — temperature controllers, 3 units)
+- G9DriverSim            (raw binary packet — interlocks)
+- DP16ProcessMonitorSim  (Modbus RTU 8N1 — process temperature monitors)
+- BCONDriverSim          (Modbus RTU — beam pulse controller)
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import random
+import select
+import struct
+import threading
+import time
+from typing import Any, Callable
+
+from simulator.virtual_serial import VirtualSerialPair
+
+
+# ---------------------------------------------------------------------------
+#  Base class
+# ---------------------------------------------------------------------------
+
+class BaseSimulator:
+    """Common lifecycle for all simulator threads."""
+
+    def __init__(self, pair: VirtualSerialPair, name: str):
+        self.pair = pair
+        self.name = name
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run_wrapper, daemon=True, name=name)
+        self.lock = threading.RLock()
+        # Flat state dict; GUI reads/writes with self.lock held.
+        self.state: dict[str, Any] = {}
+        self._on_state_change: Callable | None = None
+
+    def set_state_callback(self, cb: Callable):
+        self._on_state_change = cb
+
+    def _notify(self):
+        if self._on_state_change:
+            try:
+                self._on_state_change()
+            except Exception:
+                pass
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+
+    def _run_wrapper(self):
+        try:
+            self.run()
+        except Exception as exc:
+            print(f"[{self.name}] simulator error: {exc}")
+
+    def run(self):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+#  VTRX — vacuum system read-only stream
+# ---------------------------------------------------------------------------
+
+class VTRXSimulator(BaseSimulator):
+    """Streams semicolon-delimited ASCII lines at ~1 Hz like the real VTRX."""
+
+    def __init__(self, pair: VirtualSerialPair):
+        super().__init__(pair, "VTRX")
+        self.state = {
+            "pressure": 5.0e-6,       # Torr
+            "pumps_power": True,
+            "turbo_rotor": True,
+            "turbo_vent_open": False,
+            "gauge_972b_power": True,
+            "turbo_gate_closed": False,
+            "turbo_gate_open": True,
+            "argon_gate_open": False,
+            "argon_gate_closed": True,
+        }
+
+    def run(self):
+        while not self._stop.is_set():
+            with self.lock:
+                p = self.state["pressure"]
+                bits = "".join([
+                    "1" if self.state["pumps_power"] else "0",
+                    "1" if self.state["turbo_rotor"] else "0",
+                    "1" if self.state["turbo_vent_open"] else "0",
+                    "1" if self.state["gauge_972b_power"] else "0",
+                    "1" if self.state["turbo_gate_closed"] else "0",
+                    "1" if self.state["turbo_gate_open"] else "0",
+                    "1" if self.state["argon_gate_open"] else "0",
+                    "1" if self.state["argon_gate_closed"] else "0",
+                ])
+            # add small random walk
+            p *= 1 + random.gauss(0, 0.02)
+            p = max(1e-9, min(1e-1, p))
+            with self.lock:
+                self.state["pressure"] = p
+            sci = f"{p:.2E}"
+            line = f"{p:.6e};{sci};{bits}\n"
+            self.pair.write(line.encode())
+            self._notify()
+            self._stop.wait(1.0)
+
+
+# ---------------------------------------------------------------------------
+#  BK Precision 9104 power supply (ASCII)
+# ---------------------------------------------------------------------------
+
+class PowerSupply9104Sim(BaseSimulator):
+    """Simulates one 9104 PSU (ASCII command/response over RS-232)."""
+
+    def __init__(self, pair: VirtualSerialPair, name: str = "9104"):
+        super().__init__(pair, name)
+        self.state = {
+            "output_on": False,
+            "voltage_set": 0.0,     # Volts
+            "current_set": 0.0,     # Amps
+            "voltage_read": 0.0,
+            "current_read": 0.0,
+            "mode": 0,              # 0=CV, 1=CC
+            "ovp": 42.0,
+            "ocp": 5.0,
+            "preset": 0,
+            "presets": {0: (0.0, 0.0), 1: (0.0, 0.0), 2: (0.0, 0.0)},
+        }
+        self._buf = b""
+
+    def run(self):
+        while not self._stop.is_set():
+            chunk = self.pair.read(256, timeout=0.05)
+            if chunk:
+                self._buf += chunk
+                self._process_buffer()
+            # simulate actual readings
+            with self.lock:
+                if self.state["output_on"]:
+                    self.state["voltage_read"] = self.state["voltage_set"] + random.gauss(0, 0.01)
+                    self.state["current_read"] = self.state["current_set"] * 0.95 + random.gauss(0, 0.005)
+                else:
+                    self.state["voltage_read"] = 0.0
+                    self.state["current_read"] = 0.0
+            self._stop.wait(0.02)
+
+    def _process_buffer(self):
+        while b"\r" in self._buf or b"\n" in self._buf:
+            for sep in (b"\r\n", b"\r", b"\n"):
+                idx = self._buf.find(sep)
+                if idx != -1:
+                    cmd_bytes = self._buf[:idx]
+                    self._buf = self._buf[idx + len(sep):]
+                    break
+            else:
+                break
+            cmd = cmd_bytes.decode("ascii", errors="ignore").strip()
+            if not cmd:
+                continue
+            resp = self._handle_command(cmd)
+            if resp is not None:
+                self.pair.write(resp.encode() + b"\r")
+
+    def _handle_command(self, cmd: str) -> str | None:
+        with self.lock:
+            if cmd.startswith("SOUT"):
+                val = cmd[4:]
+                self.state["output_on"] = val.strip() == "1"
+                self._notify()
+                return "OK"
+            elif cmd == "GOUT":
+                return f"{'1' if self.state['output_on'] else '0'}\rOK"
+            elif cmd.startswith("VOLT"):
+                raw = cmd[4:].strip()
+                if len(raw) >= 5:
+                    cv = int(raw[1:5])
+                    self.state["voltage_set"] = cv / 100.0
+                    self._notify()
+                return "OK"
+            elif cmd.startswith("CURR"):
+                raw = cmd[4:].strip()
+                if len(raw) >= 5:
+                    ca = int(raw[1:5])
+                    self.state["current_set"] = ca / 100.0
+                    self._notify()
+                return "OK"
+            elif cmd == "GETD":
+                v = int(self.state["voltage_read"] * 100) % 10000
+                i = int(self.state["current_read"] * 100) % 10000
+                m = self.state["mode"]
+                return f"{v:04d}{i:04d}{m}\rOK"
+            elif cmd.startswith("SOVP"):
+                cv = int(cmd[4:8])
+                self.state["ovp"] = cv / 100.0
+                return "OK"
+            elif cmd == "GOVP":
+                v = int(self.state["ovp"] * 100)
+                return f"{v:04d}\rOK"
+            elif cmd.startswith("SOCP"):
+                ca = int(cmd[4:8])
+                self.state["ocp"] = ca / 100.0
+                return "OK"
+            elif cmd == "GOCP":
+                c = int(self.state["ocp"] * 100)
+                return f"{c:04d}\rOK"
+            elif cmd.startswith("GETS"):
+                p = int(cmd[4]) if len(cmd) > 4 else 0
+                sv, si = self.state["presets"].get(p, (0, 0))
+                return f"{int(sv*100):04d}{int(si*100):04d}\rOK"
+            elif cmd.startswith("SETD"):
+                return "OK"
+            elif cmd == "GABC":
+                return f"{self.state['preset']}\rOK"
+            elif cmd.startswith("SABC"):
+                self.state["preset"] = int(cmd[4]) if len(cmd) > 4 else 0
+                return "OK"
+            elif cmd in ("SESS", "ENDS", "STOP"):
+                return "OK"
+            elif cmd == "GALL":
+                return "OK"
+            return "OK"
+
+
+# ---------------------------------------------------------------------------
+#  Modbus RTU helpers
+# ---------------------------------------------------------------------------
+
+def _modbus_crc(data: bytes) -> int:
+    """CRC-16/Modbus."""
+    crc = 0xFFFF
+    for b in data:
+        crc ^= b
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return crc
+
+
+def _modbus_response(slave: int, func: int, payload: bytes) -> bytes:
+    """Build a complete Modbus RTU response frame."""
+    frame = bytes([slave, func]) + payload
+    crc = _modbus_crc(frame)
+    return frame + struct.pack("<H", crc)
+
+
+def _modbus_exception(slave: int, func: int, exc_code: int) -> bytes:
+    return _modbus_response(slave, func | 0x80, bytes([exc_code]))
+
+
+# ---------------------------------------------------------------------------
+#  E5CN temperature controllers (Modbus RTU, 3 units, 8E2)
+# ---------------------------------------------------------------------------
+
+class E5CNModbusSim(BaseSimulator):
+    """Simulates 3 × Omron E5CN temp controllers (slave 1–3) on one bus."""
+
+    def __init__(self, pair: VirtualSerialPair):
+        super().__init__(pair, "E5CN")
+        self.state = {
+            "temp_1": 25.0,
+            "temp_2": 26.0,
+            "temp_3": 24.5,
+        }
+        self._buf = b""
+
+    def run(self):
+        while not self._stop.is_set():
+            chunk = self.pair.read(256, timeout=0.05)
+            if chunk:
+                self._buf += chunk
+                self._process()
+            # random walk temperatures
+            with self.lock:
+                for k in ("temp_1", "temp_2", "temp_3"):
+                    self.state[k] += random.gauss(0, 0.1)
+                    self.state[k] = max(-20.0, min(500.0, self.state[k]))
+            self._notify()
+            self._stop.wait(0.02)
+
+    def _process(self):
+        # Modbus RTU: minimum frame = 8 bytes (1 slave + 1 func + 2 addr + 2 count + 2 crc)
+        while len(self._buf) >= 8:
+            slave = self._buf[0]
+            func = self._buf[1]
+            if func == 0x03:  # read holding registers
+                if len(self._buf) < 8:
+                    break
+                frame = self._buf[:8]
+                crc_recv = struct.unpack("<H", frame[6:8])[0]
+                crc_calc = _modbus_crc(frame[:6])
+                if crc_recv != crc_calc:
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[8:]
+                addr = struct.unpack(">H", frame[2:4])[0]
+                count = struct.unpack(">H", frame[4:6])[0]
+                self._respond_read(slave, addr, count)
+            else:
+                self._buf = self._buf[1:]
+
+    def _respond_read(self, slave: int, addr: int, count: int):
+        if slave < 1 or slave > 3:
+            return
+        with self.lock:
+            temp = self.state.get(f"temp_{slave}", 25.0)
+        # E5CN: register 0x0000, count=2 → response regs[1] = temp*10
+        regs = [0] * count
+        if addr == 0x0000 and count >= 2:
+            regs[1] = int(temp * 10) & 0xFFFF
+        payload = bytes([count * 2])
+        for r in regs:
+            payload += struct.pack(">H", r & 0xFFFF)
+        resp = _modbus_response(slave, 0x03, payload)
+        time.sleep(0.005)  # simulate bus turnaround
+        self.pair.write(resp)
+
+
+# ---------------------------------------------------------------------------
+#  G9SP interlocks (raw binary packet)
+# ---------------------------------------------------------------------------
+
+class G9DriverSim(BaseSimulator):
+    """Simulates the Omron G9SP safety controller binary protocol."""
+
+    # 13 interlock names in bit order
+    INTERLOCK_NAMES = [
+        "e_stop_int_a", "e_stop_int_b",
+        "e_stop_ext_a", "e_stop_ext_b",
+        "door_a", "door_b",
+        "vacuum_power", "vacuum_pressure",
+        "high_oil", "low_oil",
+        "water", "hvolt_on", "g9sp_active",
+    ]
+
+    def __init__(self, pair: VirtualSerialPair):
+        super().__init__(pair, "G9SP")
+        self.state = {name: True for name in self.INTERLOCK_NAMES}
+        self._buf = b""
+
+    def run(self):
+        while not self._stop.is_set():
+            chunk = self.pair.read(256, timeout=0.05)
+            if chunk:
+                self._buf += chunk
+                self._try_respond()
+            self._stop.wait(0.02)
+
+    def _try_respond(self):
+        # G9SP send packet = 19 bytes, starts with 0x40
+        while len(self._buf) >= 19:
+            idx = self._buf.find(b'\x40')
+            if idx == -1:
+                self._buf = b""
+                return
+            if idx > 0:
+                self._buf = self._buf[idx:]
+            if len(self._buf) < 19:
+                return
+            self._buf = self._buf[19:]  # consume request
+            self._send_response()
+
+    def _send_response(self):
+        """Build a 199-byte G9SP response packet."""
+        resp = bytearray(199)
+        resp[0] = 0x40  # header
+        resp[1] = 0xC3  # length indicator
+        # OCTD at byte 7
+        resp[7] = 0x00
+        # Build SITSF (safety input terminal status flags) — 6 bytes at offset 21
+        # and SITDF (safety input terminal data flags) — 6 bytes at offset 11.
+        # For the simulator: SITSF bit=1 means OK (same as SITDF).
+        with self.lock:
+            bits = 0
+            for i, name in enumerate(self.INTERLOCK_NAMES):
+                if self.state.get(name, False):
+                    bits |= (1 << i)
+        # Pack 13 bits into the first 2 bytes of each 6-byte field
+        sitsf_bytes = bits.to_bytes(2, 'big')
+        sitdf_bytes = bits.to_bytes(2, 'big')
+        # SITDF at offset 11, 6 bytes
+        resp[11] = sitdf_bytes[0]
+        resp[12] = sitdf_bytes[1]
+        # SOTDF at offset 17, 4 bytes — outputs all ON
+        resp[17] = 0xFF
+        resp[18] = 0xFF
+        # SITSF at offset 21, 6 bytes
+        resp[21] = sitsf_bytes[0]
+        resp[22] = sitsf_bytes[1]
+        # SOTSF at offset 27, 4 bytes
+        resp[27] = 0xFF
+        resp[28] = 0xFF
+        # US (unit status) at offset 73, 2 bytes — 0=OK
+        resp[73] = 0x00
+        resp[74] = 0x00
+        # Checksum at bytes 195–196: sum of 0..194 & 0xFFFF big-endian
+        cksum = sum(resp[:195]) & 0xFFFF
+        resp[195] = (cksum >> 8) & 0xFF
+        resp[196] = cksum & 0xFF
+        # Footer
+        resp[197] = 0x2A
+        resp[198] = 0x0D
+        time.sleep(0.01)
+        self.pair.write(bytes(resp))
+        self._notify()
+
+
+# ---------------------------------------------------------------------------
+#  DP16 process monitor (Modbus RTU, up to 6 units)
+# ---------------------------------------------------------------------------
+
+class DP16ProcessMonitorSim(BaseSimulator):
+    """Simulates 5 × DP16PT RTD temperature monitors (Modbus slaves 1–5)."""
+
+    def __init__(self, pair: VirtualSerialPair):
+        super().__init__(pair, "DP16")
+        self.state = {
+            "temp_1": 32.0,    # Solenoid 1
+            "temp_2": 33.5,    # Solenoid 2
+            "temp_3": 29.0,    # Chamber Top
+            "temp_4": 30.0,    # Chamber Bot
+            "temp_5": 22.0,    # Air temp
+        }
+        self._buf = b""
+
+    def run(self):
+        while not self._stop.is_set():
+            chunk = self.pair.read(256, timeout=0.05)
+            if chunk:
+                self._buf += chunk
+                self._process()
+            # random walk
+            with self.lock:
+                for k in list(self.state.keys()):
+                    self.state[k] += random.gauss(0, 0.05)
+                    self.state[k] = max(-50.0, min(400.0, self.state[k]))
+            self._notify()
+            self._stop.wait(0.02)
+
+    def _process(self):
+        while len(self._buf) >= 8:
+            slave = self._buf[0]
+            func = self._buf[1]
+            if func == 0x03:
+                if len(self._buf) < 8:
+                    break
+                frame = self._buf[:8]
+                crc_recv = struct.unpack("<H", frame[6:8])[0]
+                crc_calc = _modbus_crc(frame[:6])
+                if crc_recv != crc_calc:
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[8:]
+                addr = struct.unpack(">H", frame[2:4])[0]
+                count = struct.unpack(">H", frame[4:6])[0]
+                self._respond_read(slave, addr, count)
+            else:
+                self._buf = self._buf[1:]
+
+    def _respond_read(self, slave: int, addr: int, count: int):
+        if slave < 1 or slave > 5:
+            return
+        with self.lock:
+            temp = self.state.get(f"temp_{slave}", 25.0)
+        if addr == 0x0240 and count >= 1:
+            # Status register → 0x0006 = running
+            payload = bytes([count * 2]) + struct.pack(">H", 0x0006)
+            if count > 1:
+                payload += b'\x00\x00' * (count - 1)
+        elif addr == 0x0210 and count >= 2:
+            # Process value as IEEE 754 big-endian float
+            raw = struct.pack(">f", temp)
+            hi, lo = struct.unpack(">HH", raw)
+            payload = bytes([count * 2]) + struct.pack(">H", hi) + struct.pack(">H", lo)
+            if count > 2:
+                payload += b'\x00\x00' * (count - 2)
+        else:
+            payload = bytes([count * 2]) + b'\x00\x00' * count
+        resp = _modbus_response(slave, 0x03, payload)
+        time.sleep(0.005)
+        self.pair.write(resp)
+
+
+# ---------------------------------------------------------------------------
+#  BCON beam pulse controller (Modbus RTU, 160 registers)
+# ---------------------------------------------------------------------------
+
+class BCONDriverSim(BaseSimulator):
+    """Simulates the BCON Arduino Mega Modbus RTU firmware."""
+
+    # Register layout
+    REG_WATCHDOG_MS = 0
+    REG_TELEMETRY_MS = 1
+    REG_COMMAND = 2
+    # CH params: base 10/20/30  +  0=mode, 1=pulse_ms, 2=count, 3=enable_toggle
+    # Status: base 100
+    REG_SYS_STATE = 100
+    REG_SYS_REASON = 101
+    REG_FAULT_LATCHED = 102
+    REG_INTERLOCK_OK = 103
+    REG_WATCHDOG_OK = 104
+    REG_LAST_ERROR = 105
+    # CH status: base 110/120/130  +  0=mode,1=pulse_ms,2=count,3=remaining,4=en_st,5=pwr_st,6=oc_st,7=gated_st,8=output_level
+
+    MODBUS_SLAVE_ID = 1
+    HEARTBEAT_MIN_MS = 50
+    HEARTBEAT_MAX_MS = 60000
+    DEFAULT_WATCHDOG_MS = 1500
+    DEFAULT_TELEMETRY_MS = 1500
+    WATCHDOG_BOOT_GRACE_MS = 4000
+
+    PULSE_DURATION_MIN_MS = 1
+    PULSE_DURATION_MAX_MS = 60000
+    PULSE_COUNT_MIN = 1
+    PULSE_COUNT_MAX = 10000
+
+    # Firmware-like modbus error codes exposed in REG_LAST_ERROR
+    ERR_NONE = 0
+    ERR_ILLEGAL_FUNCTION = 1
+    ERR_ILLEGAL_ADDRESS = 2
+    ERR_ILLEGAL_VALUE = 3
+    ERR_DEVICE_FAILURE = 4
+    ERR_NOT_READY = 10
+    ERR_FAULT_STILL_ACTIVE = 11
+    ERR_INTERLOCK_NOT_READY = 12
+    ERR_BUFFER_OVERFLOW = 13
+
+    def __init__(self, pair: VirtualSerialPair):
+        super().__init__(pair, "BCON")
+
+        self.watchdog_timeout_ms = self.DEFAULT_WATCHDOG_MS
+        self.telemetry_period_ms = self.DEFAULT_TELEMETRY_MS
+        self.last_command_ms = self._now_ms()
+        self.watchdog_grace_deadline_ms = self.last_command_ms + self.WATCHDOG_BOOT_GRACE_MS
+        self.last_modbus_error = self.ERR_NONE
+
+        self._channels = {
+            1: {"mode": 0, "pulse_ms": 100, "count": 1, "remaining": 0, "output": 0,
+                "enabled": False, "power": False, "overcurrent": False, "gated": 0,
+                "phase": "idle", "deadline_ms": 0},
+            2: {"mode": 0, "pulse_ms": 100, "count": 1, "remaining": 0, "output": 0,
+                "enabled": False, "power": False, "overcurrent": False, "gated": 0,
+                "phase": "idle", "deadline_ms": 0},
+            3: {"mode": 0, "pulse_ms": 100, "count": 1, "remaining": 0, "output": 0,
+                "enabled": False, "power": False, "overcurrent": False, "gated": 0,
+                "phase": "idle", "deadline_ms": 0},
+        }
+
+        self.state = {
+            "sys_state": 0,       # 0=READY
+            "armed": False,
+            "interlock_ok": True,
+            "fault_latched": False,
+            "watchdog_ok": True,
+            "last_error": 0,
+            "ch1_mode": 0, "ch1_enabled": False, "ch1_output": 0,
+            "ch2_mode": 0, "ch2_enabled": False, "ch2_output": 0,
+            "ch3_mode": 0, "ch3_enabled": False, "ch3_output": 0,
+        }
+        self._buf = b""
+
+    def run(self):
+        while not self._stop.is_set():
+            chunk = self.pair.read(512, timeout=0.05)
+            if chunk:
+                self._buf += chunk
+                self._process()
+            self._update_overcurrent_latch()
+            self._apply_outputs()
+            self._sync_public_state()
+            self._stop.wait(0.02)
+
+    def _now_ms(self) -> int:
+        return int(time.monotonic() * 1000)
+
+    def _is_watchdog_healthy(self) -> bool:
+        now = self._now_ms()
+        if now < self.watchdog_grace_deadline_ms:
+            return True
+        return (now - self.last_command_ms) <= self.watchdog_timeout_ms
+
+    def _is_interlock_satisfied(self) -> bool:
+        return bool(self.state.get("interlock_ok", True))
+
+    def _is_any_overcurrent_asserted(self) -> bool:
+        return any(self._channels[ch]["overcurrent"] for ch in (1, 2, 3))
+
+    def _evaluate_top_level_state(self) -> int:
+        if not self._is_interlock_satisfied():
+            return 1
+        if not self._is_watchdog_healthy():
+            return 2
+        if self.state.get("fault_latched", False):
+            return 3
+        return 0
+
+    def _set_modbus_error(self, code: int):
+        self.last_modbus_error = code
+
+    def _set_channel_off(self, ch: int):
+        c = self._channels[ch]
+        c["mode"] = 0
+        c["remaining"] = 0
+        c["output"] = 0
+        c["gated"] = 0
+        c["phase"] = "idle"
+        c["deadline_ms"] = 0
+
+    def _set_channel_dc(self, ch: int):
+        c = self._channels[ch]
+        c["mode"] = 1
+        c["remaining"] = 0
+        c["output"] = 1
+        c["gated"] = 1
+        c["phase"] = "dc"
+        c["deadline_ms"] = 0
+
+    def _set_channel_pulse(self, ch: int):
+        c = self._channels[ch]
+        c["mode"] = 2
+        c["remaining"] = 1
+        c["output"] = 1
+        c["gated"] = 1
+        c["phase"] = "pulse_high"
+        c["deadline_ms"] = self._now_ms() + int(c["pulse_ms"])
+
+    def _set_channel_pulse_train(self, ch: int):
+        c = self._channels[ch]
+        c["mode"] = 3
+        c["remaining"] = int(c["count"])
+        c["output"] = 1
+        c["gated"] = 1
+        c["phase"] = "train_high"
+        c["deadline_ms"] = self._now_ms() + int(c["pulse_ms"])
+
+    def _update_overcurrent_latch(self):
+        if self._is_any_overcurrent_asserted():
+            self.state["fault_latched"] = True
+
+    def _apply_outputs(self):
+        now = self._now_ms()
+        top_state = self._evaluate_top_level_state()
+
+        if top_state != 0:
+            for ch in (1, 2, 3):
+                self._channels[ch]["output"] = 0
+                self._channels[ch]["gated"] = 0
+            return
+
+        for ch in (1, 2, 3):
+            c = self._channels[ch]
+            mode = c["mode"]
+
+            if mode == 0:
+                c["output"] = 0
+                c["gated"] = 0
+                c["phase"] = "idle"
+                c["deadline_ms"] = 0
+                c["remaining"] = 0
+                continue
+
+            if mode == 1:
+                c["output"] = 1
+                c["gated"] = 1
+                c["phase"] = "dc"
+                continue
+
+            if mode == 2:
+                if now >= c["deadline_ms"]:
+                    self._set_channel_off(ch)
+                continue
+
+            if mode == 3 and now >= c["deadline_ms"]:
+                if c["phase"] == "train_high":
+                    c["output"] = 0
+                    c["gated"] = 0
+                    if c["remaining"] > 0:
+                        c["remaining"] -= 1
+                    if c["remaining"] == 0:
+                        self._set_channel_off(ch)
+                    else:
+                        c["phase"] = "train_low"
+                        c["deadline_ms"] = now + int(c["pulse_ms"])
+                else:
+                    c["output"] = 1
+                    c["gated"] = 1
+                    c["phase"] = "train_high"
+                    c["deadline_ms"] = now + int(c["pulse_ms"])
+
+    def _sync_public_state(self):
+        with self.lock:
+            self.state["sys_state"] = self._evaluate_top_level_state()
+            self.state["interlock_ok"] = bool(self.state.get("interlock_ok", True))
+            self.state["watchdog_ok"] = self._is_watchdog_healthy()
+            self.state["fault_latched"] = bool(self.state.get("fault_latched", False))
+            self.state["last_error"] = self.last_modbus_error
+            self.state["armed"] = (self.state["sys_state"] == 0 and not self.state["fault_latched"])
+            for ch in (1, 2, 3):
+                c = self._channels[ch]
+                self.state[f"ch{ch}_mode"] = c["mode"]
+                self.state[f"ch{ch}_enabled"] = bool(c["enabled"])
+                self.state[f"ch{ch}_output"] = int(c["output"])
+
+    def _decode_channel_control_register(self, reg: int):
+        if reg < 10 or reg > 33:
+            return None
+        decade = reg // 10
+        units = reg % 10
+        if decade < 1 or decade > 3 or units > 3:
+            return None
+        return decade, units
+
+    def _decode_channel_status_register(self, reg: int):
+        if reg < 110:
+            return None
+        delta = reg - 110
+        ch_index = delta // 10
+        field = delta % 10
+        if ch_index > 2 or field > 8:
+            return None
+        return ch_index + 1, field
+
+    def _read_holding_register(self, reg: int):
+        if reg == self.REG_WATCHDOG_MS:
+            return int(self.watchdog_timeout_ms)
+        if reg == self.REG_TELEMETRY_MS:
+            return int(self.telemetry_period_ms)
+        if reg == self.REG_COMMAND:
+            return 0
+        if reg == self.REG_SYS_STATE:
+            return self._evaluate_top_level_state()
+        if reg == self.REG_SYS_REASON:
+            return self._evaluate_top_level_state()
+        if reg == self.REG_FAULT_LATCHED:
+            return 1 if self.state.get("fault_latched", False) else 0
+        if reg == self.REG_INTERLOCK_OK:
+            return 1 if self._is_interlock_satisfied() else 0
+        if reg == self.REG_WATCHDOG_OK:
+            return 1 if self._is_watchdog_healthy() else 0
+        if reg == self.REG_LAST_ERROR:
+            return int(self.last_modbus_error)
+
+        decoded_control = self._decode_channel_control_register(reg)
+        if decoded_control:
+            ch, field = decoded_control
+            c = self._channels[ch]
+            if field == 0:
+                return int(c["mode"])
+            if field == 1:
+                return int(c["pulse_ms"])
+            if field == 2:
+                return int(c["count"])
+            if field == 3:
+                return 0
+
+        decoded_status = self._decode_channel_status_register(reg)
+        if decoded_status:
+            ch, field = decoded_status
+            c = self._channels[ch]
+            if field == 0:
+                return int(c["mode"])
+            if field == 1:
+                return int(c["pulse_ms"])
+            if field == 2:
+                return int(c["count"])
+            if field == 3:
+                return int(c["remaining"])
+            if field == 4:
+                return 1 if c["enabled"] else 0
+            if field == 5:
+                return 1 if c["power"] else 0
+            if field == 6:
+                return 1 if c["overcurrent"] else 0
+            if field == 7:
+                return 1 if c["gated"] else 0
+            if field == 8:
+                return 1 if c["output"] else 0
+
+        return None
+
+    def _write_holding_register(self, reg: int, value: int):
+        ex_out = 0x03
+
+        if reg == self.REG_WATCHDOG_MS:
+            if value < self.HEARTBEAT_MIN_MS or value > self.HEARTBEAT_MAX_MS:
+                self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+                return False, ex_out
+            self.watchdog_timeout_ms = int(value)
+            self._set_modbus_error(self.ERR_NONE)
+            return True, ex_out
+
+        if reg == self.REG_TELEMETRY_MS:
+            self.telemetry_period_ms = int(value)
+            self._set_modbus_error(self.ERR_NONE)
+            return True, ex_out
+
+        if reg == self.REG_COMMAND:
+            if value == 0:
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+            if value == 1:
+                for ch in (1, 2, 3):
+                    self._set_channel_off(ch)
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+            if value in (2, 3):
+                if self._is_any_overcurrent_asserted():
+                    self._set_modbus_error(self.ERR_FAULT_STILL_ACTIVE)
+                    return False, 0x04
+                if not self._is_interlock_satisfied():
+                    self._set_modbus_error(self.ERR_INTERLOCK_NOT_READY)
+                    return False, 0x04
+                self.state["fault_latched"] = False
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+            self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+            return False, ex_out
+
+        decoded = self._decode_channel_control_register(reg)
+        if not decoded:
+            self._set_modbus_error(self.ERR_ILLEGAL_ADDRESS)
+            return False, 0x02
+
+        ch, field = decoded
+        c = self._channels[ch]
+
+        if field == 1:
+            if value < self.PULSE_DURATION_MIN_MS or value > self.PULSE_DURATION_MAX_MS:
+                self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+                return False, ex_out
+            c["pulse_ms"] = int(value)
+            self._set_modbus_error(self.ERR_NONE)
+            return True, ex_out
+
+        if field == 2:
+            if value < self.PULSE_COUNT_MIN or value > self.PULSE_COUNT_MAX:
+                self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+                return False, ex_out
+            c["count"] = int(value)
+            self._set_modbus_error(self.ERR_NONE)
+            return True, ex_out
+
+        if field == 3:
+            if value != 1:
+                self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+                return False, ex_out
+            c["enabled"] = not c["enabled"]
+            c["power"] = bool(c["enabled"])
+            self._set_modbus_error(self.ERR_NONE)
+            return True, ex_out
+
+        if field == 0:
+            top_state = self._evaluate_top_level_state()
+
+            if value == 0:
+                self._set_channel_off(ch)
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+
+            if top_state != 0:
+                self._set_modbus_error(self.ERR_NOT_READY)
+                return False, 0x04
+
+            if value == 1:
+                if not c["enabled"]:
+                    c["enabled"] = True
+                    c["power"] = True
+                self._set_channel_dc(ch)
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+
+            if value == 2:
+                if not c["enabled"]:
+                    c["enabled"] = True
+                    c["power"] = True
+                if c["count"] <= 1:
+                    self._set_channel_pulse(ch)
+                else:
+                    self._set_channel_pulse_train(ch)
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+
+            if value == 3:
+                if c["count"] < 2:
+                    self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+                    return False, ex_out
+                if not c["enabled"]:
+                    c["enabled"] = True
+                    c["power"] = True
+                self._set_channel_pulse_train(ch)
+                self._set_modbus_error(self.ERR_NONE)
+                return True, ex_out
+
+            self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+            return False, ex_out
+
+        self._set_modbus_error(self.ERR_ILLEGAL_ADDRESS)
+        return False, 0x02
+
+    def _process(self):
+        while len(self._buf) >= 8:
+            slave = self._buf[0]
+            func = self._buf[1]
+            is_broadcast = (slave == 0)
+
+            if func == 0x03:  # read holding registers
+                if len(self._buf) < 8:
+                    break
+                frame = self._buf[:8]
+                crc_recv = struct.unpack("<H", frame[6:8])[0]
+                if crc_recv != _modbus_crc(frame[:6]):
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[8:]
+                if slave not in (0, self.MODBUS_SLAVE_ID):
+                    continue
+                self.last_command_ms = self._now_ms()
+                addr = struct.unpack(">H", frame[2:4])[0]
+                count = struct.unpack(">H", frame[4:6])[0]
+                self._respond_read(slave, addr, count, is_broadcast)
+
+            elif func == 0x06:  # write single register
+                if len(self._buf) < 8:
+                    break
+                frame = self._buf[:8]
+                crc_recv = struct.unpack("<H", frame[6:8])[0]
+                if crc_recv != _modbus_crc(frame[:6]):
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[8:]
+                if slave not in (0, self.MODBUS_SLAVE_ID):
+                    continue
+                self.last_command_ms = self._now_ms()
+                addr = struct.unpack(">H", frame[2:4])[0]
+                value = struct.unpack(">H", frame[4:6])[0]
+                self._handle_write_single(slave, addr, value, frame, is_broadcast)
+
+            elif func == 0x10:  # write multiple registers
+                if len(self._buf) < 9:
+                    break
+                quantity = struct.unpack(">H", self._buf[4:6])[0]
+                byte_count = self._buf[6]
+                frame_len = 9 + byte_count
+                if len(self._buf) < frame_len:
+                    break
+                frame = self._buf[:frame_len]
+                crc_recv = struct.unpack("<H", frame[-2:])[0]
+                if crc_recv != _modbus_crc(frame[:-2]):
+                    self._buf = self._buf[1:]
+                    continue
+                self._buf = self._buf[frame_len:]
+                if slave not in (0, self.MODBUS_SLAVE_ID):
+                    continue
+                self.last_command_ms = self._now_ms()
+                self._handle_write_multiple(slave, frame, is_broadcast)
+            else:
+                # Unsupported function: drop one byte and keep searching.
+                self._buf = self._buf[1:]
+
+    def _respond_read(self, slave: int, addr: int, count: int, is_broadcast: bool):
+        if count == 0 or count > 125:
+            self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+            if not is_broadcast:
+                self.pair.write(_modbus_exception(slave, 0x03, 0x03))
+            return
+
+        regs: list[int] = []
+        with self.lock:
+            for i in range(count):
+                val = self._read_holding_register(addr + i)
+                if val is None:
+                    self._set_modbus_error(self.ERR_ILLEGAL_ADDRESS)
+                    if not is_broadcast:
+                        self.pair.write(_modbus_exception(slave, 0x03, 0x02))
+                    return
+                regs.append(int(val) & 0xFFFF)
+
+        payload = bytes([count * 2])
+        for val in regs:
+            payload += struct.pack(">H", val)
+
+        self._set_modbus_error(self.ERR_NONE)
+        if not is_broadcast:
+            resp = _modbus_response(slave, 0x03, payload)
+            time.sleep(0.002)
+            self.pair.write(resp)
+
+    def _handle_write_single(self, slave: int, addr: int, value: int, frame: bytes, is_broadcast: bool):
+        with self.lock:
+            ok, ex_code = self._write_holding_register(addr, value)
+            self._sync_public_state()
+
+        self._notify()
+        if ok:
+            if not is_broadcast:
+                resp = _modbus_response(slave, 0x06, frame[2:6])
+                time.sleep(0.002)
+                self.pair.write(resp)
+            return
+
+        if not is_broadcast:
+            self.pair.write(_modbus_exception(slave, 0x06, ex_code))
+
+    def _handle_write_multiple(self, slave: int, frame: bytes, is_broadcast: bool):
+        start_reg = struct.unpack(">H", frame[2:4])[0]
+        quantity = struct.unpack(">H", frame[4:6])[0]
+        byte_count = frame[6]
+
+        if quantity == 0 or quantity > 123 or byte_count != quantity * 2:
+            self._set_modbus_error(self.ERR_ILLEGAL_VALUE)
+            if not is_broadcast:
+                self.pair.write(_modbus_exception(slave, 0x10, 0x03))
+            return
+
+        values = []
+        for i in range(quantity):
+            off = 7 + i * 2
+            values.append(struct.unpack(">H", frame[off:off + 2])[0])
+
+        with self.lock:
+            for i, value in enumerate(values):
+                ok, ex_code = self._write_holding_register(start_reg + i, value)
+                if not ok:
+                    self._sync_public_state()
+                    if not is_broadcast:
+                        self.pair.write(_modbus_exception(slave, 0x10, ex_code))
+                    return
+            self._sync_public_state()
+
+        self._notify()
+        if not is_broadcast:
+            payload = struct.pack(">HH", start_reg, quantity)
+            resp = _modbus_response(slave, 0x10, payload)
+            time.sleep(0.002)
+            self.pair.write(resp)

--- a/simulator/run_simulator.py
+++ b/simulator/run_simulator.py
@@ -62,6 +62,16 @@ def main():
         "BCON":      BCONDriverSim(pm.get("BeamPulse")),
     }
 
+    # Cross-link interlocks: BCON interlock follows G9 chain health.
+    g9 = simulators["G9SP"]
+    bcon = simulators["BCON"]
+
+    def _sync_interlocks():
+        bcon.set_interlock_ok(g9.interlock_chain_ok())
+
+    g9.set_state_callback(_sync_interlocks)
+    _sync_interlocks()
+
     # ── 3. Start all simulator threads ────────────────────────────────────
     for name, sim in simulators.items():
         sim.start()

--- a/simulator/run_simulator.py
+++ b/simulator/run_simulator.py
@@ -46,7 +46,12 @@ def main():
     args = parser.parse_args()
 
     # ── 1. Create virtual serial port pairs ───────────────────────────────
-    pm = PortManager()
+    try:
+        pm = PortManager()
+    except Exception as exc:
+        print(f"Failed to create virtual serial ports: {exc}")
+        print("Hint: On Windows, install/create com0com pairs or set EBEAM_SIM_PORT_MAP(_FILE).")
+        return 1
     print("Virtual serial port pairs created:")
     print(pm)
 
@@ -118,4 +123,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/simulator/run_simulator.py
+++ b/simulator/run_simulator.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+run_simulator.py — Launch the EBEAM hardware simulator.
+
+Creates virtual serial port pairs, starts all instrument simulator threads,
+opens the Material-style simulator GUI, and (optionally) launches the
+dashboard pointing at the virtual ports.
+
+Usage:
+    python -m simulator.run_simulator               # simulator GUI only
+    python -m simulator.run_simulator --dashboard    # also start dashboard
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+# Ensure project root is on sys.path
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from simulator.virtual_serial import PortManager
+from simulator.instruments import (
+    VTRXSimulator,
+    PowerSupply9104Sim,
+    E5CNModbusSim,
+    G9DriverSim,
+    DP16ProcessMonitorSim,
+    BCONDriverSim,
+)
+from simulator.sim_gui import SimulatorGUI
+
+
+def main():
+    parser = argparse.ArgumentParser(description="EBEAM Hardware Simulator")
+    parser.add_argument("--dashboard", action="store_true",
+                        help="Automatically launch the dashboard connected to virtual ports")
+    parser.add_argument("--print-ports", action="store_true",
+                        help="Print the virtual port mapping as JSON and exit")
+    args = parser.parse_args()
+
+    # ── 1. Create virtual serial port pairs ───────────────────────────────
+    pm = PortManager()
+    print("Virtual serial port pairs created:")
+    print(pm)
+
+    # ── 2. Instantiate instrument simulators ──────────────────────────────
+    simulators = {
+        "VTRX":      VTRXSimulator(pm.get("VTRXSubsystem")),
+        "CathodeA":  PowerSupply9104Sim(pm.get("CathodeA PS"), "CathodeA"),
+        "CathodeB":  PowerSupply9104Sim(pm.get("CathodeB PS"), "CathodeB"),
+        "CathodeC":  PowerSupply9104Sim(pm.get("CathodeC PS"), "CathodeC"),
+        "E5CN":      E5CNModbusSim(pm.get("TempControllers")),
+        "G9SP":      G9DriverSim(pm.get("Interlocks")),
+        "DP16":      DP16ProcessMonitorSim(pm.get("ProcessMonitors")),
+        "BCON":      BCONDriverSim(pm.get("BeamPulse")),
+    }
+
+    # ── 3. Start all simulator threads ────────────────────────────────────
+    for name, sim in simulators.items():
+        sim.start()
+        print(f"  ✓ {name} simulator started")
+
+    # ── 4. Optionally print ports and exit ────────────────────────────────
+    if args.print_ports:
+        print(json.dumps(pm.com_ports(), indent=2))
+        return
+
+    # ── 5. Optionally launch the dashboard ────────────────────────────────
+    dashboard_proc = None
+    if args.dashboard:
+        # Write the virtual-port mapping so the dashboard can load it
+        com_ports_path = os.path.join(_PROJECT_ROOT, "usr", "usr_data", "com_ports.json")
+        os.makedirs(os.path.dirname(com_ports_path), exist_ok=True)
+        with open(com_ports_path, "w") as f:
+            json.dump(pm.com_ports(), f, indent=2)
+        print(f"\n  COM port mapping written to {com_ports_path}")
+
+        # Launch dashboard as a subprocess
+        dashboard_proc = subprocess.Popen(
+            [sys.executable, os.path.join(_PROJECT_ROOT, "main.py")],
+            cwd=_PROJECT_ROOT,
+        )
+        print(f"  Dashboard launched (PID {dashboard_proc.pid})")
+
+    # ── 6. Open the simulator GUI (blocks until closed) ───────────────────
+    print("\nOpening simulator GUI …")
+    gui = SimulatorGUI(simulators)
+    try:
+        gui.mainloop()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # ── 7. Cleanup ────────────────────────────────────────────────────
+        print("\nShutting down …")
+        for sim in simulators.values():
+            sim.stop()
+        pm.close_all()
+        if dashboard_proc and dashboard_proc.poll() is None:
+            dashboard_proc.terminate()
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/simulator/sim_gui.py
+++ b/simulator/sim_gui.py
@@ -348,12 +348,17 @@ class BCONCard(Card):
         ttk.Label(row3, text="Interlock:", style="Card.TLabel").pack(side="left")
         self.il_dot = IndicatorDot(row3)
         self.il_dot.pack(side="right", padx=4)
-        # Toggle interlock
-        btn = tk.Button(row3, text="Toggle", bg=MD_CHIP_BG, fg=MD_TEXT,
+        # One-way fault injection: force BCON interlock OFF
+        self.force_off_btn = tk.Button(row3, text="Force OFF", bg=MD_CHIP_BG, fg=MD_TEXT,
                         activebackground="#4A4A5C", activeforeground=MD_TEXT,
                         relief="flat", font=("Segoe UI", 9), bd=0, padx=6, pady=2,
-                        command=self._toggle_interlock)
-        btn.pack(side="right", padx=4)
+                command=self._force_interlock_off)
+        self.force_off_btn.pack(side="right", padx=4)
+        self.reset_btn = tk.Button(row3, text="Reset", bg=MD_CHIP_BG, fg=MD_TEXT,
+                activebackground="#4A4A5C", activeforeground=MD_TEXT,
+                relief="flat", font=("Segoe UI", 9), bd=0, padx=6, pady=2,
+                command=self._reset_interlock)
+        self.reset_btn.pack(side="right", padx=4)
 
         # Per-channel
         self.ch_lbls = {}
@@ -372,9 +377,21 @@ class BCONCard(Card):
             ttk.Label(f, text="OUT:", style="CardSubtitle.TLabel").pack(side="right")
             self.ch_lbls[ch] = {"mode": mode_lbl, "en": en_dot, "out": out_dot}
 
-    def _toggle_interlock(self):
-        with self.sim.lock:
-            self.sim.state["interlock_ok"] = not self.sim.state.get("interlock_ok", True)
+    def _force_interlock_off(self):
+        if hasattr(self.sim, "force_interlock_off"):
+            self.sim.force_interlock_off()
+        else:
+            with self.sim.lock:
+                self.sim.state["interlock_ok"] = False
+                self.sim.state["interlock_forced_off"] = True
+
+    def _reset_interlock(self):
+        if hasattr(self.sim, "reset_interlock"):
+            self.sim.reset_interlock()
+        else:
+            with self.sim.lock:
+                self.sim.state["interlock_forced_off"] = False
+                self.sim.state["interlock_ok"] = True
 
     def refresh(self):
         modes = {0: "OFF", 1: "DC", 2: "PULSE", 3: "TRAIN"}
@@ -387,6 +404,12 @@ class BCONCard(Card):
         self.state_lbl.config(text=txt, style=sty)
         self.armed_dot.set_color(MD_GREEN if s.get("armed") else MD_TEXT_DARK)
         self.il_dot.set_color(MD_GREEN if s.get("interlock_ok") else MD_RED)
+        if s.get("interlock_forced_off", False):
+            self.force_off_btn.config(text="FORCED OFF", state="disabled")
+            self.reset_btn.config(state="normal")
+        else:
+            self.force_off_btn.config(text="Force OFF", state="normal")
+            self.reset_btn.config(state="disabled")
         for ch in (1, 2, 3):
             m = s.get(f"ch{ch}_mode", 0)
             self.ch_lbls[ch]["mode"].config(text=modes.get(m, "?"))

--- a/simulator/sim_gui.py
+++ b/simulator/sim_gui.py
@@ -1,0 +1,515 @@
+"""
+sim_gui.py — Material-style dark-themed simulator GUI.
+
+Shows live status of every simulated instrument in a card-based layout.
+Operators can toggle interlock inputs, nudge temperatures, toggle PSU
+outputs, and change BCON channel modes — all of which the dashboard sees
+in real-time via the virtual serial links.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+import threading
+from typing import Any
+
+# ---------------------------------------------------------------------------
+#  Material Design colour palette
+# ---------------------------------------------------------------------------
+MD_BG           = "#1E1E2E"    # surface
+MD_CARD         = "#2A2A3C"    # card
+MD_CARD_BORDER  = "#3A3A4C"
+MD_PRIMARY      = "#7C4DFF"    # deep purple accent
+MD_PRIMARY_DARK = "#651FFF"
+MD_GREEN        = "#00E676"
+MD_RED          = "#FF5252"
+MD_AMBER        = "#FFD740"
+MD_TEXT         = "#E0E0E0"
+MD_TEXT_DIM     = "#9E9E9E"
+MD_TEXT_DARK    = "#616161"
+MD_CHIP_BG      = "#3A3A4C"
+MD_ENTRY_BG     = "#353548"
+MD_ENTRY_FG     = "#E0E0E0"
+
+
+def _configure_styles():
+    """Register ttk styles once."""
+    style = ttk.Style()
+    style.theme_use("clam")
+
+    style.configure("Card.TFrame", background=MD_CARD)
+    style.configure("Surface.TFrame", background=MD_BG)
+    style.configure("Card.TLabel", background=MD_CARD, foreground=MD_TEXT,
+                     font=("Segoe UI", 10))
+    style.configure("CardTitle.TLabel", background=MD_CARD, foreground=MD_PRIMARY,
+                     font=("Segoe UI", 12, "bold"))
+    style.configure("CardSubtitle.TLabel", background=MD_CARD, foreground=MD_TEXT_DIM,
+                     font=("Segoe UI", 9))
+    style.configure("Surface.TLabel", background=MD_BG, foreground=MD_TEXT,
+                     font=("Segoe UI", 10))
+    style.configure("Header.TLabel", background=MD_BG, foreground=MD_TEXT,
+                     font=("Segoe UI", 16, "bold"))
+    style.configure("Subtitle.TLabel", background=MD_BG, foreground=MD_TEXT_DIM,
+                     font=("Segoe UI", 10))
+    style.configure("Green.TLabel", background=MD_CARD, foreground=MD_GREEN,
+                     font=("Segoe UI", 10, "bold"))
+    style.configure("Red.TLabel", background=MD_CARD, foreground=MD_RED,
+                     font=("Segoe UI", 10, "bold"))
+    style.configure("Amber.TLabel", background=MD_CARD, foreground=MD_AMBER,
+                     font=("Segoe UI", 10))
+    style.configure("Value.TLabel", background=MD_CARD, foreground="#FFFFFF",
+                     font=("Consolas", 13, "bold"))
+
+    # Buttons
+    style.configure("Accent.TButton", background=MD_PRIMARY, foreground="#FFFFFF",
+                     font=("Segoe UI", 10, "bold"), padding=(12, 6))
+    style.map("Accent.TButton",
+              background=[("active", MD_PRIMARY_DARK), ("pressed", MD_PRIMARY_DARK)])
+    style.configure("Toggle.TButton", background=MD_CHIP_BG, foreground=MD_TEXT,
+                     font=("Segoe UI", 9), padding=(8, 4))
+    style.map("Toggle.TButton",
+              background=[("active", "#4A4A5C")])
+
+    # Scales
+    style.configure("Card.Horizontal.TScale", background=MD_CARD,
+                     troughcolor=MD_ENTRY_BG)
+
+    # Notebook
+    style.configure("Dark.TNotebook", background=MD_BG)
+    style.configure("Dark.TNotebook.Tab", background=MD_CARD, foreground=MD_TEXT_DIM,
+                     font=("Segoe UI", 10), padding=(14, 6))
+    style.map("Dark.TNotebook.Tab",
+              background=[("selected", MD_PRIMARY)],
+              foreground=[("selected", "#FFFFFF")])
+
+
+# ---------------------------------------------------------------------------
+#  Reusable card widget
+# ---------------------------------------------------------------------------
+
+class Card(ttk.Frame):
+    """Rounded-corner card container (approximated with a solid background)."""
+
+    def __init__(self, parent, title: str = "", **kw):
+        super().__init__(parent, style="Card.TFrame", padding=12, **kw)
+        if title:
+            ttk.Label(self, text=title, style="CardTitle.TLabel").pack(anchor="w")
+            ttk.Separator(self, orient="horizontal").pack(fill="x", pady=(4, 8))
+
+
+class IndicatorDot(tk.Canvas):
+    """Small coloured circle — green / red / amber."""
+
+    def __init__(self, parent, size=14, **kw):
+        super().__init__(parent, width=size, height=size,
+                         bg=MD_CARD, highlightthickness=0, **kw)
+        self._size = size
+        self._oval = self.create_oval(2, 2, size - 2, size - 2, fill=MD_TEXT_DARK, outline="")
+
+    def set_color(self, color: str):
+        self.itemconfig(self._oval, fill=color)
+
+
+# ---------------------------------------------------------------------------
+#  Per-instrument card panels
+# ---------------------------------------------------------------------------
+
+class VTRXCard(Card):
+    def __init__(self, parent, sim):
+        super().__init__(parent, title="VTRX — Vacuum System")
+        self.sim = sim
+        # Pressure readout
+        row = ttk.Frame(self, style="Card.TFrame")
+        row.pack(fill="x", pady=2)
+        ttk.Label(row, text="Pressure:", style="Card.TLabel").pack(side="left")
+        self.pressure_lbl = ttk.Label(row, text="—", style="Value.TLabel")
+        self.pressure_lbl.pack(side="right")
+
+        # Switch indicators
+        self.indicators: dict[str, tuple[IndicatorDot, ttk.Label]] = {}
+        switch_names = [
+            ("pumps_power", "Pumps Power"),
+            ("turbo_rotor", "Turbo Rotor"),
+            ("turbo_vent_open", "Turbo Vent"),
+            ("gauge_972b_power", "972b Gauge"),
+            ("turbo_gate_open", "Turbo Gate Open"),
+            ("argon_gate_open", "Argon Gate Open"),
+        ]
+        grid = ttk.Frame(self, style="Card.TFrame")
+        grid.pack(fill="x", pady=(8, 0))
+        for i, (key, label) in enumerate(switch_names):
+            r, c = divmod(i, 3)
+            f = ttk.Frame(grid, style="Card.TFrame")
+            f.grid(row=r, column=c, padx=6, pady=3, sticky="w")
+            dot = IndicatorDot(f)
+            dot.pack(side="left", padx=(0, 4))
+            lbl = ttk.Label(f, text=label, style="Card.TLabel")
+            lbl.pack(side="left")
+            self.indicators[key] = (dot, lbl)
+
+        # Pressure slider
+        ttk.Label(self, text="Set Pressure (log10 Torr):", style="CardSubtitle.TLabel").pack(anchor="w", pady=(8, 2))
+        self.pressure_scale = ttk.Scale(self, from_=-9, to=-1, orient="horizontal",
+                                         style="Card.Horizontal.TScale",
+                                         command=self._on_scale)
+        self.pressure_scale.set(-5.3)
+        self.pressure_scale.pack(fill="x")
+
+    def _on_scale(self, val):
+        p = 10 ** float(val)
+        with self.sim.lock:
+            self.sim.state["pressure"] = p
+
+    def refresh(self):
+        with self.sim.lock:
+            p = self.sim.state["pressure"]
+            for key, (dot, _) in self.indicators.items():
+                val = self.sim.state.get(key, False)
+                dot.set_color(MD_GREEN if val else MD_RED)
+        self.pressure_lbl.config(text=f"{p:.2E} Torr")
+
+
+class PSUCard(Card):
+    """Card for one BK Precision 9104 power supply simulator."""
+
+    def __init__(self, parent, sim, label: str):
+        super().__init__(parent, title=f"PSU — {label}")
+        self.sim = sim
+
+        # Output status
+        row = ttk.Frame(self, style="Card.TFrame")
+        row.pack(fill="x", pady=2)
+        ttk.Label(row, text="Output:", style="Card.TLabel").pack(side="left")
+        self.out_dot = IndicatorDot(row)
+        self.out_dot.pack(side="left", padx=4)
+        self.out_lbl = ttk.Label(row, text="OFF", style="Red.TLabel")
+        self.out_lbl.pack(side="left")
+
+        # Readings
+        for attr, unit in [("voltage", "V"), ("current", "A")]:
+            r = ttk.Frame(self, style="Card.TFrame")
+            r.pack(fill="x", pady=1)
+            ttk.Label(r, text=f"{attr.title()} Read:", style="Card.TLabel").pack(side="left")
+            lbl = ttk.Label(r, text="0.00", style="Value.TLabel")
+            lbl.pack(side="right")
+            setattr(self, f"{attr}_lbl", lbl)
+
+        # Setpoint display
+        for attr, unit in [("voltage_set", "V"), ("current_set", "A")]:
+            r = ttk.Frame(self, style="Card.TFrame")
+            r.pack(fill="x", pady=1)
+            nice = attr.replace("_", " ").title()
+            ttk.Label(r, text=f"{nice}:", style="CardSubtitle.TLabel").pack(side="left")
+            lbl = ttk.Label(r, text="0.00", style="Amber.TLabel")
+            lbl.pack(side="right")
+            setattr(self, f"{attr}_lbl", lbl)
+
+    def refresh(self):
+        with self.sim.lock:
+            s = dict(self.sim.state)
+        on = s.get("output_on", False)
+        self.out_dot.set_color(MD_GREEN if on else MD_RED)
+        self.out_lbl.config(text="ON" if on else "OFF",
+                            style="Green.TLabel" if on else "Red.TLabel")
+        self.voltage_lbl.config(text=f"{s.get('voltage_read', 0):.2f} V")
+        self.current_lbl.config(text=f"{s.get('current_read', 0):.3f} A")
+        self.voltage_set_lbl.config(text=f"{s.get('voltage_set', 0):.2f} V")
+        self.current_set_lbl.config(text=f"{s.get('current_set', 0):.2f} A")
+
+
+class E5CNCard(Card):
+    def __init__(self, parent, sim):
+        super().__init__(parent, title="E5CN — Temp Controllers")
+        self.sim = sim
+        self.temp_lbls = {}
+        self.scales = {}
+        names = {1: "Clamp A", 2: "Clamp B", 3: "Clamp C"}
+        for unit in (1, 2, 3):
+            r = ttk.Frame(self, style="Card.TFrame")
+            r.pack(fill="x", pady=2)
+            ttk.Label(r, text=f"{names[unit]}:", style="Card.TLabel").pack(side="left")
+            lbl = ttk.Label(r, text="—", style="Value.TLabel")
+            lbl.pack(side="right")
+            self.temp_lbls[unit] = lbl
+            sc = ttk.Scale(self, from_=-20, to=500, orient="horizontal",
+                            style="Card.Horizontal.TScale",
+                            command=lambda v, u=unit: self._on_scale(u, v))
+            sc.set(25)
+            sc.pack(fill="x", pady=(0, 4))
+            self.scales[unit] = sc
+
+    def _on_scale(self, unit, val):
+        with self.sim.lock:
+            self.sim.state[f"temp_{unit}"] = float(val)
+
+    def refresh(self):
+        with self.sim.lock:
+            for unit in (1, 2, 3):
+                t = self.sim.state.get(f"temp_{unit}", 0)
+                self.temp_lbls[unit].config(text=f"{t:.1f} °C")
+
+
+class InterlocksCard(Card):
+    def __init__(self, parent, sim):
+        super().__init__(parent, title="G9SP — Interlocks")
+        self.sim = sim
+        self.toggles: dict[str, tuple[IndicatorDot, tk.Button]] = {}
+        nice_names = {
+            "e_stop_int_a": "E-STOP Int A", "e_stop_int_b": "E-STOP Int B",
+            "e_stop_ext_a": "E-STOP Ext A", "e_stop_ext_b": "E-STOP Ext B",
+            "door_a": "Door A", "door_b": "Door B",
+            "vacuum_power": "Vacuum Power", "vacuum_pressure": "Vacuum Press.",
+            "high_oil": "High Oil", "low_oil": "Low Oil",
+            "water": "Water", "hvolt_on": "HVolt ON", "g9sp_active": "G9SP Active",
+        }
+        grid = ttk.Frame(self, style="Card.TFrame")
+        grid.pack(fill="x", pady=4)
+        for i, (key, label) in enumerate(nice_names.items()):
+            r, c = divmod(i, 3)
+            f = ttk.Frame(grid, style="Card.TFrame")
+            f.grid(row=r, column=c, padx=4, pady=3, sticky="w")
+            dot = IndicatorDot(f)
+            dot.pack(side="left", padx=(0, 4))
+            btn = tk.Button(f, text=label, bg=MD_CHIP_BG, fg=MD_TEXT,
+                            activebackground="#4A4A5C", activeforeground=MD_TEXT,
+                            relief="flat", font=("Segoe UI", 9), bd=0, padx=6, pady=2,
+                            command=lambda k=key: self._toggle(k))
+            btn.pack(side="left")
+            self.toggles[key] = (dot, btn)
+
+    def _toggle(self, key):
+        with self.sim.lock:
+            self.sim.state[key] = not self.sim.state.get(key, True)
+
+    def refresh(self):
+        with self.sim.lock:
+            for key, (dot, btn) in self.toggles.items():
+                val = self.sim.state.get(key, True)
+                dot.set_color(MD_GREEN if val else MD_RED)
+
+
+class DP16Card(Card):
+    def __init__(self, parent, sim):
+        super().__init__(parent, title="DP16 — Process Monitors")
+        self.sim = sim
+        self.temp_lbls = {}
+        names = {1: "Solenoid 1", 2: "Solenoid 2", 3: "Chamber Top",
+                 4: "Chamber Bot", 5: "Air Temp"}
+        for unit in range(1, 6):
+            r = ttk.Frame(self, style="Card.TFrame")
+            r.pack(fill="x", pady=1)
+            ttk.Label(r, text=f"{names[unit]}:", style="Card.TLabel").pack(side="left")
+            lbl = ttk.Label(r, text="—", style="Value.TLabel")
+            lbl.pack(side="right")
+            self.temp_lbls[unit] = lbl
+        ttk.Label(self, text="Adjust temps with slider:", style="CardSubtitle.TLabel").pack(anchor="w", pady=(6, 2))
+        self.offset_scale = ttk.Scale(self, from_=-20, to=80, orient="horizontal",
+                                       style="Card.Horizontal.TScale",
+                                       command=self._on_offset)
+        self.offset_scale.set(30)
+        self.offset_scale.pack(fill="x")
+
+    def _on_offset(self, val):
+        base = float(val)
+        with self.sim.lock:
+            self.sim.state["temp_1"] = base + 2
+            self.sim.state["temp_2"] = base + 3.5
+            self.sim.state["temp_3"] = base - 1
+            self.sim.state["temp_4"] = base
+            self.sim.state["temp_5"] = base - 8
+
+    def refresh(self):
+        with self.sim.lock:
+            for unit in range(1, 6):
+                t = self.sim.state.get(f"temp_{unit}", 0)
+                self.temp_lbls[unit].config(text=f"{t:.1f} °C")
+
+
+class BCONCard(Card):
+    def __init__(self, parent, sim):
+        super().__init__(parent, title="BCON — Beam Pulse Controller")
+        self.sim = sim
+        # System state
+        row = ttk.Frame(self, style="Card.TFrame")
+        row.pack(fill="x", pady=2)
+        ttk.Label(row, text="System State:", style="Card.TLabel").pack(side="left")
+        self.state_lbl = ttk.Label(row, text="READY", style="Green.TLabel")
+        self.state_lbl.pack(side="right")
+
+        row2 = ttk.Frame(self, style="Card.TFrame")
+        row2.pack(fill="x", pady=2)
+        ttk.Label(row2, text="Armed:", style="Card.TLabel").pack(side="left")
+        self.armed_dot = IndicatorDot(row2)
+        self.armed_dot.pack(side="right", padx=4)
+
+        row3 = ttk.Frame(self, style="Card.TFrame")
+        row3.pack(fill="x", pady=2)
+        ttk.Label(row3, text="Interlock:", style="Card.TLabel").pack(side="left")
+        self.il_dot = IndicatorDot(row3)
+        self.il_dot.pack(side="right", padx=4)
+        # Toggle interlock
+        btn = tk.Button(row3, text="Toggle", bg=MD_CHIP_BG, fg=MD_TEXT,
+                        activebackground="#4A4A5C", activeforeground=MD_TEXT,
+                        relief="flat", font=("Segoe UI", 9), bd=0, padx=6, pady=2,
+                        command=self._toggle_interlock)
+        btn.pack(side="right", padx=4)
+
+        # Per-channel
+        self.ch_lbls = {}
+        modes = {0: "OFF", 1: "DC", 2: "PULSE", 3: "TRAIN"}
+        for ch in (1, 2, 3):
+            f = ttk.Frame(self, style="Card.TFrame")
+            f.pack(fill="x", pady=2)
+            ttk.Label(f, text=f"CH{ch}:", style="Card.TLabel").pack(side="left")
+            mode_lbl = ttk.Label(f, text="OFF", style="Card.TLabel")
+            mode_lbl.pack(side="left", padx=8)
+            en_dot = IndicatorDot(f)
+            en_dot.pack(side="right", padx=4)
+            ttk.Label(f, text="EN:", style="CardSubtitle.TLabel").pack(side="right")
+            out_dot = IndicatorDot(f)
+            out_dot.pack(side="right", padx=4)
+            ttk.Label(f, text="OUT:", style="CardSubtitle.TLabel").pack(side="right")
+            self.ch_lbls[ch] = {"mode": mode_lbl, "en": en_dot, "out": out_dot}
+
+    def _toggle_interlock(self):
+        with self.sim.lock:
+            self.sim.state["interlock_ok"] = not self.sim.state.get("interlock_ok", True)
+
+    def refresh(self):
+        modes = {0: "OFF", 1: "DC", 2: "PULSE", 3: "TRAIN"}
+        sys_states = {0: ("READY", "Green.TLabel"), 1: ("SAFE_INTLK", "Amber.TLabel"),
+                      2: ("SAFE_WDG", "Amber.TLabel"), 3: ("FAULT", "Red.TLabel")}
+        with self.sim.lock:
+            s = dict(self.sim.state)
+        ss = s.get("sys_state", 0)
+        txt, sty = sys_states.get(ss, ("UNKNOWN", "Card.TLabel"))
+        self.state_lbl.config(text=txt, style=sty)
+        self.armed_dot.set_color(MD_GREEN if s.get("armed") else MD_TEXT_DARK)
+        self.il_dot.set_color(MD_GREEN if s.get("interlock_ok") else MD_RED)
+        for ch in (1, 2, 3):
+            m = s.get(f"ch{ch}_mode", 0)
+            self.ch_lbls[ch]["mode"].config(text=modes.get(m, "?"))
+            self.ch_lbls[ch]["en"].set_color(MD_GREEN if s.get(f"ch{ch}_enabled") else MD_TEXT_DARK)
+            self.ch_lbls[ch]["out"].set_color(
+                MD_AMBER if s.get(f"ch{ch}_output", 0) else MD_TEXT_DARK)
+
+
+# ---------------------------------------------------------------------------
+#  Main GUI window
+# ---------------------------------------------------------------------------
+
+class SimulatorGUI:
+    """Top-level Material-style simulator window."""
+
+    REFRESH_MS = 250
+
+    def __init__(self, simulators: dict):
+        """*simulators* is a dict name → BaseSimulator instance."""
+        self.simulators = simulators
+        self.root = tk.Tk()
+        self.root.title("EBEAM Hardware Simulator")
+        self.root.configure(bg=MD_BG)
+        self.root.geometry("1200x880")
+        self.root.minsize(900, 600)
+
+        _configure_styles()
+
+        # Header
+        header = ttk.Frame(self.root, style="Surface.TFrame")
+        header.pack(fill="x", padx=16, pady=(12, 0))
+        ttk.Label(header, text="⚡  EBEAM Hardware Simulator",
+                  style="Header.TLabel").pack(side="left")
+        ttk.Label(header, text="Material Dark  •  All instruments virtual",
+                  style="Subtitle.TLabel").pack(side="right")
+
+        # Port info bar
+        port_bar = ttk.Frame(self.root, style="Surface.TFrame")
+        port_bar.pack(fill="x", padx=16, pady=(4, 8))
+        port_text_parts = []
+        for name, sim in simulators.items():
+            port_text_parts.append(f"{name}: {sim.pair.slave_path}")
+        ttk.Label(port_bar, text="  |  ".join(port_text_parts),
+                  style="Subtitle.TLabel", wraplength=1160).pack(anchor="w")
+
+        # Scrollable card area
+        canvas = tk.Canvas(self.root, bg=MD_BG, highlightthickness=0)
+        vscroll = ttk.Scrollbar(self.root, orient="vertical", command=canvas.yview)
+        self.cards_frame = ttk.Frame(canvas, style="Surface.TFrame")
+        self.cards_frame.bind("<Configure>",
+                              lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+        canvas.create_window((0, 0), window=self.cards_frame, anchor="nw")
+        canvas.configure(yscrollcommand=vscroll.set)
+        vscroll.pack(side="right", fill="y")
+        canvas.pack(side="left", fill="both", expand=True, padx=8, pady=4)
+        # Mouse-wheel scroll
+        canvas.bind_all("<Button-4>", lambda e: canvas.yview_scroll(-3, "units"))
+        canvas.bind_all("<Button-5>", lambda e: canvas.yview_scroll(3, "units"))
+
+        self.cards: list = []
+        self._build_cards()
+        self._schedule_refresh()
+
+    # -- Build cards --------------------------------------------------------
+
+    def _build_cards(self):
+        sims = self.simulators
+        # Use a 2-column responsive grid
+        col = 0
+        row_idx = 0
+
+        def place(card_widget):
+            nonlocal col, row_idx
+            card_widget.grid(row=row_idx, column=col, padx=10, pady=8, sticky="nsew")
+            self.cards_frame.grid_columnconfigure(col, weight=1)
+            col += 1
+            if col >= 2:
+                col = 0
+                row_idx += 1
+
+        if "VTRX" in sims:
+            c = VTRXCard(self.cards_frame, sims["VTRX"])
+            place(c)
+            self.cards.append(c)
+
+        for key, label in [("CathodeA", "Cathode A"), ("CathodeB", "Cathode B"),
+                           ("CathodeC", "Cathode C")]:
+            if key in sims:
+                c = PSUCard(self.cards_frame, sims[key], label)
+                place(c)
+                self.cards.append(c)
+
+        if "E5CN" in sims:
+            c = E5CNCard(self.cards_frame, sims["E5CN"])
+            place(c)
+            self.cards.append(c)
+
+        if "G9SP" in sims:
+            c = InterlocksCard(self.cards_frame, sims["G9SP"])
+            place(c)
+            self.cards.append(c)
+
+        if "DP16" in sims:
+            c = DP16Card(self.cards_frame, sims["DP16"])
+            place(c)
+            self.cards.append(c)
+
+        if "BCON" in sims:
+            c = BCONCard(self.cards_frame, sims["BCON"])
+            place(c)
+            self.cards.append(c)
+
+    # -- Periodic refresh ---------------------------------------------------
+
+    def _schedule_refresh(self):
+        for card in self.cards:
+            try:
+                card.refresh()
+            except Exception:
+                pass
+        self.root.after(self.REFRESH_MS, self._schedule_refresh)
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def mainloop(self):
+        self.root.mainloop()

--- a/simulator/virtual_serial.py
+++ b/simulator/virtual_serial.py
@@ -1,0 +1,100 @@
+"""
+virtual_serial.py — Linux PTY-based virtual serial port pairs.
+
+Creates master/slave pseudo-terminal pairs.  The *slave* path is given to the
+dashboard (it looks like ``/dev/pts/XX`` — a normal serial device) while the
+*master* file-descriptor is used internally by the simulator threads.
+"""
+
+import os
+import pty
+import tty
+import threading
+import select
+
+
+class VirtualSerialPair:
+    """One PTY pair representing a virtual serial cable between simulator and dashboard."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.master_fd, self.slave_fd = pty.openpty()
+        # Put master in raw mode so the kernel doesn't interpret control chars.
+        tty.setraw(self.master_fd)
+        tty.setraw(self.slave_fd)
+        self.slave_path: str = os.ttyname(self.slave_fd)
+
+    # -- Simulator side (master fd) helpers ----------------------------------
+
+    def write(self, data: bytes) -> None:
+        """Write *data* from the simulator side to the dashboard side."""
+        try:
+            os.write(self.master_fd, data)
+        except OSError:
+            pass
+
+    def read(self, size: int = 1024, timeout: float = 0.1) -> bytes:
+        """Non-blocking read of up to *size* bytes from the dashboard side.
+
+        Returns ``b''`` if nothing is available within *timeout* seconds.
+        """
+        ready, _, _ = select.select([self.master_fd], [], [], timeout)
+        if ready:
+            try:
+                return os.read(self.master_fd, size)
+            except OSError:
+                return b""
+        return b""
+
+    def fileno(self) -> int:
+        return self.master_fd
+
+    def close(self) -> None:
+        for fd in (self.master_fd, self.slave_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    def __repr__(self) -> str:
+        return f"VirtualSerialPair({self.name!r}, slave={self.slave_path!r})"
+
+
+class PortManager:
+    """Creates and manages all virtual serial pairs needed by the simulator."""
+
+    # Map of logical port name → VirtualSerialPair
+    PORT_NAMES = [
+        "VTRXSubsystem",
+        "CathodeA PS",
+        "CathodeB PS",
+        "CathodeC PS",
+        "TempControllers",
+        "Interlocks",
+        "ProcessMonitors",
+        "BeamPulse",
+    ]
+
+    def __init__(self):
+        self.pairs: dict[str, VirtualSerialPair] = {}
+        for name in self.PORT_NAMES:
+            self.pairs[name] = VirtualSerialPair(name)
+
+    def com_ports(self) -> dict[str, str]:
+        """Return a dict compatible with the dashboard's *com_ports* mapping.
+
+        Values are slave PTY paths that the dashboard can open like real serial
+        ports.
+        """
+        return {name: pair.slave_path for name, pair in self.pairs.items()}
+
+    def get(self, name: str) -> VirtualSerialPair:
+        return self.pairs[name]
+
+    def close_all(self) -> None:
+        for pair in self.pairs.values():
+            pair.close()
+
+    def __repr__(self) -> str:
+        lines = [f"  {name}: {pair.slave_path}" for name, pair in self.pairs.items()]
+        return "PortManager(\n" + "\n".join(lines) + "\n)"

--- a/simulator/virtual_serial.py
+++ b/simulator/virtual_serial.py
@@ -1,43 +1,81 @@
 """
-virtual_serial.py — Linux PTY-based virtual serial port pairs.
+virtual_serial.py — Cross-platform virtual serial abstraction.
 
-Creates master/slave pseudo-terminal pairs.  The *slave* path is given to the
-dashboard (it looks like ``/dev/pts/XX`` — a normal serial device) while the
-*master* file-descriptor is used internally by the simulator threads.
+Linux/macOS:
+  Uses PTY master/slave pairs. The dashboard opens the slave path
+  (e.g. /dev/pts/12), while simulator threads read/write on the master fd.
+
+Windows:
+  Uses real COM null-modem pairs (typically provided by com0com).
+  The simulator opens one endpoint (sim side), while the dashboard opens the
+  paired endpoint (dashboard side).
+
+Windows port mapping priority:
+  1) EBEAM_SIM_PORT_MAP_FILE -> JSON file path
+  2) EBEAM_SIM_PORT_MAP      -> JSON string
+  3) Auto-detect com0com pairs CNCAx <-> CNCBx
+
+Mapping JSON format:
+{
+  "VTRXSubsystem": {"sim": "CNCA0", "dashboard": "CNCB0"},
+  "CathodeA PS":   {"sim": "CNCA1", "dashboard": "CNCB1"},
+  ...
+}
 """
 
+from __future__ import annotations
+
+import json
 import os
-import pty
-import tty
-import threading
 import select
+import threading
+from typing import Dict, Tuple
+
+if os.name != "nt":
+    import pty
+    import tty
+else:
+    pty = None
+    tty = None
+
+import serial
+import serial.tools.list_ports as list_ports
 
 
 class VirtualSerialPair:
-    """One PTY pair representing a virtual serial cable between simulator and dashboard."""
+    """Abstract pair API used by simulator backends."""
 
     def __init__(self, name: str):
         self.name = name
-        self.master_fd, self.slave_fd = pty.openpty()
-        # Put master in raw mode so the kernel doesn't interpret control chars.
-        tty.setraw(self.master_fd)
-        tty.setraw(self.slave_fd)
-        self.slave_path: str = os.ttyname(self.slave_fd)
-
-    # -- Simulator side (master fd) helpers ----------------------------------
+        self.slave_path: str = ""
 
     def write(self, data: bytes) -> None:
-        """Write *data* from the simulator side to the dashboard side."""
+        raise NotImplementedError
+
+    def read(self, size: int = 1024, timeout: float = 0.1) -> bytes:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+class PtyVirtualSerialPair(VirtualSerialPair):
+    """Linux/macOS PTY-backed virtual serial cable."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.master_fd, self.slave_fd = pty.openpty()
+        tty.setraw(self.master_fd)
+        tty.setraw(self.slave_fd)
+        self.slave_path = os.ttyname(self.slave_fd)
+
+    def write(self, data: bytes) -> None:
         try:
             os.write(self.master_fd, data)
         except OSError:
             pass
 
     def read(self, size: int = 1024, timeout: float = 0.1) -> bytes:
-        """Non-blocking read of up to *size* bytes from the dashboard side.
-
-        Returns ``b''`` if nothing is available within *timeout* seconds.
-        """
         ready, _, _ = select.select([self.master_fd], [], [], timeout)
         if ready:
             try:
@@ -45,9 +83,6 @@ class VirtualSerialPair:
             except OSError:
                 return b""
         return b""
-
-    def fileno(self) -> int:
-        return self.master_fd
 
     def close(self) -> None:
         for fd in (self.master_fd, self.slave_fd):
@@ -57,13 +92,74 @@ class VirtualSerialPair:
                 pass
 
     def __repr__(self) -> str:
-        return f"VirtualSerialPair({self.name!r}, slave={self.slave_path!r})"
+        return f"PtyVirtualSerialPair({self.name!r}, slave={self.slave_path!r})"
+
+
+class ComVirtualSerialPair(VirtualSerialPair):
+    """Windows COM null-modem-backed simulator endpoint."""
+
+    def __init__(self, name: str, sim_port: str, dashboard_port: str):
+        super().__init__(name)
+        self.sim_port = sim_port
+        self.slave_path = dashboard_port
+        self._lock = threading.Lock()
+        self._ser = serial.Serial(
+            port=self.sim_port,
+            baudrate=115200,
+            bytesize=serial.EIGHTBITS,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_ONE,
+            timeout=0,
+            write_timeout=0,
+        )
+
+    def write(self, data: bytes) -> None:
+        with self._lock:
+            try:
+                self._ser.write(data)
+            except Exception:
+                pass
+
+    def read(self, size: int = 1024, timeout: float = 0.1) -> bytes:
+        with self._lock:
+            try:
+                waiting = self._ser.in_waiting
+                if waiting > 0:
+                    return self._ser.read(min(size, waiting))
+            except Exception:
+                return b""
+
+        # mimic timeout behavior without busy spin
+        if timeout > 0:
+            import time
+            time.sleep(timeout)
+
+        with self._lock:
+            try:
+                waiting = self._ser.in_waiting
+                if waiting > 0:
+                    return self._ser.read(min(size, waiting))
+            except Exception:
+                return b""
+        return b""
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._ser.close()
+            except Exception:
+                pass
+
+    def __repr__(self) -> str:
+        return (
+            f"ComVirtualSerialPair({self.name!r}, sim={self.sim_port!r}, "
+            f"dashboard={self.slave_path!r})"
+        )
 
 
 class PortManager:
     """Creates and manages all virtual serial pairs needed by the simulator."""
 
-    # Map of logical port name → VirtualSerialPair
     PORT_NAMES = [
         "VTRXSubsystem",
         "CathodeA PS",
@@ -77,15 +173,84 @@ class PortManager:
 
     def __init__(self):
         self.pairs: dict[str, VirtualSerialPair] = {}
+
+        if os.name == "nt":
+            mapping = self._load_windows_mapping()
+            for name in self.PORT_NAMES:
+                pair = mapping.get(name)
+                if not pair:
+                    raise RuntimeError(
+                        f"Windows port map missing entry for '{name}'."
+                    )
+                self.pairs[name] = ComVirtualSerialPair(
+                    name=name,
+                    sim_port=pair[0],
+                    dashboard_port=pair[1],
+                )
+        else:
+            for name in self.PORT_NAMES:
+                self.pairs[name] = PtyVirtualSerialPair(name)
+
+    def _load_windows_mapping(self) -> Dict[str, Tuple[str, str]]:
+        # 1) Mapping file
+        map_file = os.environ.get("EBEAM_SIM_PORT_MAP_FILE", "").strip()
+        if map_file:
+            with open(map_file, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+            return self._normalize_mapping(raw)
+
+        # 2) Mapping json string
+        map_json = os.environ.get("EBEAM_SIM_PORT_MAP", "").strip()
+        if map_json:
+            raw = json.loads(map_json)
+            return self._normalize_mapping(raw)
+
+        # 3) Auto-detect com0com style CNCAx<->CNCBx
+        auto = self._autodetect_com0com_pairs()
+        if auto:
+            return auto
+
+        raise RuntimeError(
+            "Windows requires COM pair mapping. Install com0com and create "
+            "at least 8 CNCAx/CNCBx pairs, or set EBEAM_SIM_PORT_MAP_FILE / "
+            "EBEAM_SIM_PORT_MAP."
+        )
+
+    def _normalize_mapping(self, raw: dict) -> Dict[str, Tuple[str, str]]:
+        out: Dict[str, Tuple[str, str]] = {}
         for name in self.PORT_NAMES:
-            self.pairs[name] = VirtualSerialPair(name)
+            entry = raw.get(name)
+            if not isinstance(entry, dict):
+                continue
+            sim_port = str(entry.get("sim", "")).strip()
+            dashboard_port = str(entry.get("dashboard", "")).strip()
+            if sim_port and dashboard_port:
+                out[name] = (sim_port, dashboard_port)
+        return out
+
+    def _autodetect_com0com_pairs(self) -> Dict[str, Tuple[str, str]]:
+        ports = [p.device.upper() for p in list_ports.comports()]
+
+        # Build CNCAx/CNCBx index
+        a_ports: dict[str, str] = {}
+        b_ports: dict[str, str] = {}
+        for dev in ports:
+            if dev.startswith("CNCA"):
+                a_ports[dev[4:]] = dev
+            elif dev.startswith("CNCB"):
+                b_ports[dev[4:]] = dev
+
+        suffixes = sorted(set(a_ports.keys()) & set(b_ports.keys()), key=lambda s: (len(s), s))
+        if len(suffixes) < len(self.PORT_NAMES):
+            return {}
+
+        mapping: Dict[str, Tuple[str, str]] = {}
+        for i, name in enumerate(self.PORT_NAMES):
+            suf = suffixes[i]
+            mapping[name] = (a_ports[suf], b_ports[suf])
+        return mapping
 
     def com_ports(self) -> dict[str, str]:
-        """Return a dict compatible with the dashboard's *com_ports* mapping.
-
-        Values are slave PTY paths that the dashboard can open like real serial
-        ports.
-        """
         return {name: pair.slave_path for name, pair in self.pairs.items()}
 
     def get(self, name: str) -> VirtualSerialPair:

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -185,16 +185,18 @@ class BeamPulseSubsystem:
         bar = ttk.Frame(self.parent_frame)
         bar.pack(fill=tk.X, padx=5, pady=(5, 0))
 
+        MD_CARD = "#2A2A3C"
+
         # BCON connection indicator
         conn_frame = ttk.Frame(bar)
         conn_frame.pack(side=tk.LEFT, padx=(0, 10))
-        ttk.Label(conn_frame, text="BCON", font=("Arial", 9, "bold")).pack(side=tk.LEFT)
-        self.bcon_connection_canvas = tk.Canvas(conn_frame, width=15, height=15, highlightthickness=0)
+        ttk.Label(conn_frame, text="BCON", font=("Segoe UI", 9, "bold")).pack(side=tk.LEFT)
+        self.bcon_connection_canvas = tk.Canvas(conn_frame, width=15, height=15, highlightthickness=0, bg=MD_CARD)
         self.bcon_connection_canvas.pack(side=tk.LEFT, padx=(4, 0))
         self.bcon_connection_canvas.create_oval(2, 2, 13, 13, fill="red", outline="black", tags="indicator")
 
         # Safety / interlock label
-        self.safety_label = ttk.Label(bar, text="Interlock: --  Watchdog: --", font=("Arial", 8))
+        self.safety_label = ttk.Label(bar, text="Interlock: --  Watchdog: --", font=("Segoe UI", 8))
         self.safety_label.pack(side=tk.LEFT, padx=10)
 
         self.connect_btn = ttk.Button(bar, text="Connect", command=self._manual_connect)
@@ -203,14 +205,14 @@ class BeamPulseSubsystem:
         # System settings row (watchdog / telemetry)
         sys_frame = ttk.Frame(self.parent_frame)
         sys_frame.pack(fill=tk.X, padx=5, pady=(2, 0))
-        ttk.Label(sys_frame, text="Watchdog (ms):", font=("Arial", 8)).pack(side=tk.LEFT)
+        ttk.Label(sys_frame, text="Watchdog (ms):", font=("Segoe UI", 8)).pack(side=tk.LEFT)
         self.watchdog_entry = ttk.Entry(sys_frame, width=7)
         self.watchdog_entry.insert(0, "2000")  # safe default
         self.watchdog_entry.pack(side=tk.LEFT, padx=2)
         ttk.Button(sys_frame, text="Set", width=4, command=self._set_watchdog).pack(side=tk.LEFT, padx=(0, 8))
 
         # Log line
-        self.log_label = ttk.Label(sys_frame, text="Log: ready", font=("Arial", 8), foreground="gray")
+        self.log_label = ttk.Label(sys_frame, text="Log: ready", font=("Segoe UI", 8), foreground="gray")
         self.log_label.pack(side=tk.RIGHT, padx=4)
 
     # ----------------------------- Tab 1: Manual Separate Control --------- #
@@ -405,24 +407,28 @@ class BeamPulseSubsystem:
         if manual_panel_override is not None:
             self._ext_manual_frame = manual_panel_override
 
+            MD_CARD = "#2A2A3C"
+            MD_TEXT = "#E0E0E0"
+            MD_CARD_BORDER = "#3A3A4C"
+
             # --- Sync action row (appended below the CH Enable/Disable row) ---
-            self._sync_row = tk.Frame(manual_panel_override)
+            self._sync_row = tk.Frame(manual_panel_override, bg=MD_CARD)
             self._sync_row.pack(side="top", fill="x", pady=(4, 0))
             self._sync_row.grid_columnconfigure(0, weight=1, uniform="sbtn")
             self._sync_row.grid_columnconfigure(1, weight=1, uniform="sbtn")
 
             self.sync_start_btn = tk.Button(
                 self._sync_row, text="Sync Start",
-                bg="#1565C0", fg="white", font=("Helvetica", 9, "bold"),
-                state="disabled", command=self._sync_start,
+                bg="#1565C0", fg="white", font=("Segoe UI", 9, "bold"),
+                state="disabled", command=self._sync_start, relief="flat"
             )
             self.sync_start_btn.grid(row=0, column=0, sticky="ew", padx=(2, 1))
             self._armed_gated_buttons.append(self.sync_start_btn)
 
             self.sync_stop_btn = tk.Button(
                 self._sync_row, text="Sync Stop",
-                bg="#B71C1C", fg="white", font=("Helvetica", 9, "bold"),
-                state="normal", command=self._sync_stop_all,
+                bg="#B71C1C", fg="white", font=("Segoe UI", 9, "bold"),
+                state="normal", command=self._sync_stop_all, relief="flat"
             )
             self.sync_stop_btn.grid(row=0, column=1, sticky="ew", padx=(1, 2))
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -13,9 +13,26 @@ from instrumentctl.power_supply_9104.power_supply_9104 import PowerSupply9104
 from instrumentctl.E5CN_modbus.E5CN_modbus import E5CNModbus
 from utils import ToolTip
 import os, sys
+import platform
 import numpy as np
 from utils import LogLevel
 from decimal import Decimal
+import serial.tools.list_ports
+
+
+PLATFORM_SYSTEM = platform.system().lower()
+IS_WINDOWS = PLATFORM_SYSTEM == "windows"
+IS_LINUX = PLATFORM_SYSTEM == "linux"
+
+
+def list_serial_ports_by_os():
+    """Return available serial ports filtered for the current OS."""
+    ports = [p.device for p in serial.tools.list_ports.comports() if p.device]
+    if IS_WINDOWS:
+        ports = [port for port in ports if port.upper().startswith("COM")]
+    elif IS_LINUX:
+        ports = [port for port in ports if port.startswith("/dev/tty")]
+    return sorted(set(ports))
 
 def resource_path(relative_path):
     """
@@ -630,8 +647,7 @@ class CathodeHeatingSubsystem:
             bool: True if port is available
         """
         try:
-            import serial.tools.list_ports
-            available_ports = [p.device for p in serial.tools.list_ports.comports()]
+            available_ports = list_serial_ports_by_os()
             return port in available_ports
         except Exception as e:
             self.log(f"Error verifying port availability: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -203,7 +203,8 @@ class CathodeHeatingSubsystem:
         self.main_frame.pack(fill='both', expand=True)
 
         # Create a canvas and scrollbar for scrolling
-        self.canvas = tk.Canvas(self.main_frame)
+        MD_BG = "#1E1E2E"
+        self.canvas = tk.Canvas(self.main_frame, bg=MD_BG, highlightthickness=0)
         self.scrollbar = ttk.Scrollbar(self.main_frame, orient="vertical", command=self.canvas.yview)
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
 
@@ -355,15 +356,22 @@ class CathodeHeatingSubsystem:
             self.clamp_temp_labels.append(clamp_temp_label)
 
             # Create plot for each cathode
+            MD_CARD = "#2A2A3C"
+            MD_TEXT = "#E0E0E0"
+            MD_PRIMARY = "#7C4DFF"
             fig, ax = plt.subplots(figsize=(2.8, 1.3))
-            line, = ax.plot([], [])
+            fig.patch.set_facecolor(MD_CARD)
+            ax.set_facecolor(MD_CARD)
+            line, = ax.plot([], [], color=MD_PRIMARY)
             self.temperature_data[i].append(line)
-            ax.set_xlabel('Time', fontsize=8)
+            ax.set_xlabel('Time', fontsize=8, color=MD_TEXT)
             ax.set_ylim(15, 80)
             ax.xaxis.set_major_formatter(DateFormatter('%H:%M:%S'))
             ax.xaxis.set_major_locator(MaxNLocator(4))
-            ax.tick_params(axis='x', labelsize=6)
-            ax.tick_params(axis='y', labelsize=6)
+            ax.tick_params(axis='x', labelsize=6, colors=MD_TEXT)
+            ax.tick_params(axis='y', labelsize=6, colors=MD_TEXT)
+            for spine in ax.spines.values():
+                spine.set_color(MD_TEXT)
             fig.tight_layout(pad=0.01)
             fig.subplots_adjust(left=0.14, right=0.99, top=0.99, bottom=0.15)
             canvas = FigureCanvasTkAgg(fig, master=main_tab)

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -112,7 +112,8 @@ class InterlocksSubsystem:
 
     def _create_main_frame(self):
         """Create and configure the main container frame"""
-        self.interlocks_frame = tk.Frame(self.parent)
+        MD_CARD = "#2A2A3C"
+        self.interlocks_frame = tk.Frame(self.parent, bg=MD_CARD)
         self.interlocks_frame.pack(fill=tk.BOTH, expand=True)
         
         # Configure grid weights for responsive layout
@@ -124,7 +125,9 @@ class InterlocksSubsystem:
 
     def _create_interlocks_frame(self):
         """Create the frame that will contain the interlock indicators"""
-        interlocks_frame = tk.Frame(self.interlocks_frame, highlightbackground="black")
+        MD_CARD = "#2A2A3C"
+        MD_CARD_BORDER = "#3A3A4C"
+        interlocks_frame = tk.Frame(self.interlocks_frame, bg=MD_CARD, highlightbackground=MD_CARD_BORDER)
         interlocks_frame.grid(row=0, column=0, padx=0, pady=0, sticky="nsew")
         
         # Configure columns for indicator pairs (label + light)
@@ -145,16 +148,19 @@ class InterlocksSubsystem:
         Returns:
             tuple: (canvas, oval_id) for the created indicator
         """
-        canvas = tk.Canvas(frame, width=30, height=30, highlightthickness=0)
+        MD_CARD = "#2A2A3C"
+        canvas = tk.Canvas(frame, width=30, height=30, highlightthickness=0, bg=MD_CARD)
         canvas.grid(sticky='nsew')
         oval_id = canvas.create_oval(5, 5, 25, 25, fill=color, outline="black")
         return canvas, oval_id
 
     def _create_indicators(self, frame):
         """Create all indicator lights and their labels"""
+        MD_CARD = "#2A2A3C"
+        MD_TEXT = "#E0E0E0"
         for i, (name, _) in enumerate(self.INDICATORS.items()):
             # Create label
-            tk.Label(frame, text=name, anchor="center").grid(
+            tk.Label(frame, text=name, anchor="center", bg=MD_CARD, fg=MD_TEXT, font=("Segoe UI", 8)).grid(
                 row=0, column=i*2, sticky='ew'
             )
             

--- a/subsystem/oil_system/oil_system.py
+++ b/subsystem/oil_system/oil_system.py
@@ -17,9 +17,10 @@ class OilSubsystem:
 
     def setup_gui(self):
         """Creates and packs UI elements inside the given parent (horizontally)."""
-        self.frame = tk.Frame(self.parent)
+        MD_CARD = "#2A2A3C"
+        self.frame = tk.Frame(self.parent, bg=MD_CARD)
         self.frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
-        self.info_frame = tk.Frame(self.frame)
+        self.info_frame = tk.Frame(self.frame, bg=MD_CARD)
         self.info_frame.pack(fill=tk.X, expand=True)
 
         self.create_sensor_frame("Temperature", f"{self.temperature:.1f}°C", "temp_label")
@@ -31,11 +32,14 @@ class OilSubsystem:
 
     def create_sensor_frame(self, title, default_text, label_attr):
         """Creates a horizontally aligned sensor frame."""
-        frame = tk.Frame(self.info_frame, padx=20)
+        MD_CARD = "#2A2A3C"
+        MD_TEXT = "#E0E0E0"
+        MD_ENTRY_BG = "#353548"
+        frame = tk.Frame(self.info_frame, padx=20, bg=MD_CARD)
         frame.pack(side=tk.LEFT, fill=tk.Y, expand=True)
         
-        tk.Label(frame, text=title, font=("Helvetica", 10, "bold")).pack()
-        label = tk.Label(frame, text=default_text, font=('Helvetica', 10), bg = "#d3d3d3", fg = "black", padx = 5, pady = 2)
+        tk.Label(frame, text=title, font=("Segoe UI", 10, "bold"), bg=MD_CARD, fg=MD_TEXT).pack()
+        label = tk.Label(frame, text=default_text, font=('Segoe UI', 10), bg=MD_ENTRY_BG, fg=MD_TEXT, padx=5, pady=2)
         label.pack()
         
         setattr(self, label_attr, label)

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -264,38 +264,39 @@ class ProcessMonitorSubsystem:
                         self.last_error_time = current_time
                 else:
                     # Update each temperature bar
+                    environment_pass = True
                     for name, unit in self.thermometer_map.items():
                         temp = temps.get(unit)
                         self.log(f"Processing temperature for {name} (unit {unit}): {temp}", LogLevel.VERBOSE)
-                        temp = temps.get(unit)
                         if temp is None:
                             self.temp_bars[name].update_value(name, TemperatureBar.DISCONNECTED)
-                            self.active['Environment Pass'] = False
+                            environment_pass = False
                         elif temp == self.monitor.SENSOR_ERROR:
                             self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
-                            self.active['Environment Pass'] = False
+                            environment_pass = False
                         elif temp == self.monitor.DISCONNECTED:
                             self.temp_bars[name].update_value(name, TemperatureBar.DISCONNECTED)
-                            self.active['Environment Pass'] = False
+                            environment_pass = False
                         elif isinstance(temp, (int, float)):
                             try:
                                 temp_value = float(temp)
                                 if -90 <= temp_value <= 500:  # Valid temperature range
                                     self.temp_bars[name].update_value(name, temp_value)
-                                    self.active['Environment Pass'] = True # Update Machine Status Progress Bar
                                     self.log(f"Temperature update - {name}: {temp_value:.1f}C", LogLevel.VERBOSE)
                                 else:
                                     self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                                     self.log(f"Temperature out of range - {name}: {temp_value}", LogLevel.WARNING)
-                                    self.active['Environment Pass'] = False
+                                    environment_pass = False
                             except (ValueError, TypeError):
                                 self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                                 self.log(f"Invalid temperature value - {name}: {temp}", LogLevel.WARNING)
-                                self.active['Environment Pass'] = False
+                                environment_pass = False
                         else:
                             self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                             self.log(f"Invalid temperature type - {name}: {type(temp)}", LogLevel.WARNING)
-                            self.active['Environment Pass'] = False
+                            environment_pass = False
+
+                    self.active['Environment Pass'] = environment_pass
 
         except Exception as e:
             self.log(f"DP16 exception details: {type(e).__name__}: {str(e)}", LogLevel.DEBUG)
@@ -305,8 +306,7 @@ class ProcessMonitorSubsystem:
                 
         finally:
             # Schedule next update
-            if self.monitor:
-                self.parent.after(self.update_interval, self.update_temperatures)
+            self.parent.after(self.update_interval, self.update_temperatures)
 
     def _set_all_temps_error(self):
         """Set all temperature bars to error state"""

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -20,19 +20,22 @@ class TemperatureBar(tk.Canvas):
     }
 
     def __init__(self, parent, name: str, height: int = 400, width: int = 40):
-        super().__init__(parent, height=height, width=width)
+        MD_CARD = "#2A2A3C"
+        super().__init__(parent, height=height, width=width, bg=MD_CARD, highlightthickness=0)
         self.name = name
         self.height = height
         self.width = width
         self.bar_width = 15
         self.value = 0
         
+        MD_TEXT = "#E0E0E0"
         # Create title
         self.create_text(
             width//2, 
             75, 
             text=name, 
-            font=('Arial', 8, 'bold'), 
+            font=('Segoe UI', 8, 'bold'), 
+            fill=MD_TEXT,
             anchor='n',
             angle=90  # Rotate text 90 degrees
         )
@@ -41,13 +44,14 @@ class TemperatureBar(tk.Canvas):
         self.create_scale()
         
     def create_scale(self):
+        MD_TEXT = "#E0E0E0"
         # Scale line
         scale_x = self.width - 20
         top_y = 35
         bottom_y = self.height - 20
         scale_height = bottom_y - top_y
         
-        self.create_line(scale_x, top_y, scale_x, bottom_y)
+        self.create_line(scale_x, top_y, scale_x, bottom_y, fill=MD_TEXT)
 
         # Determine scale based on name
         if 'Solenoid' in self.name:
@@ -66,13 +70,14 @@ class TemperatureBar(tk.Canvas):
         for i in range(self.temp_min, self.temp_max + 1, 10):    
             relative_pos = (i - self.temp_min) / temp_range
             y = bottom_y - (relative_pos * scale_height)
-            self.create_line(scale_x-2, y, scale_x+2, y)
+            self.create_line(scale_x-2, y, scale_x+2, y, fill=MD_TEXT)
             self.create_text(
                 scale_x-6, 
                 y, 
                 text=str(i), 
                 anchor='w', 
-                font=('Arial', 7),
+                font=('Segoe UI', 7),
+                fill=MD_TEXT,
                 angle=90,
                 tags='scale_labels'
             )
@@ -126,12 +131,13 @@ class TemperatureBar(tk.Canvas):
 
         # Update value label
         self.delete('value')
+        MD_TEXT = "#E0E0E0"
         self.create_text(
             self.width//2,
             self.height-5,
             text=value_text,
-            font=('Arial', 9, 'bold'),
-            fill='#808080' if value == self.DISCONNECTED else 'black',
+            font=('Segoe UI', 9, 'bold'),
+            fill='#808080' if value == self.DISCONNECTED else MD_TEXT,
             tags='value'
         )
         
@@ -209,7 +215,8 @@ class ProcessMonitorSubsystem:
         self.update_temperatures()
 
     def setup_gui(self):
-        self.frame = tk.Frame(self.parent)
+        MD_CARD = "#2A2A3C"
+        self.frame = tk.Frame(self.parent, bg=MD_CARD)
         self.frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
         # Configure grid weights for responsive layout

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -159,7 +159,8 @@ class VTRXSubsystem:
                 time.sleep(1)
 
     def _create_indicator_circle(self, parent_frame, color="grey"):
-        canvas = tk.Canvas(parent_frame, width=30, height=30, highlightthickness=0)
+        MD_CARD = "#2A2A3C"
+        canvas = tk.Canvas(parent_frame, width=30, height=30, highlightthickness=0, bg=MD_CARD)
         oval_id = canvas.create_oval(2, 2, 28, 28, fill=color, outline="black")
         canvas._oval_id = oval_id
         canvas.bind('<Configure>', lambda e: self._resize_indicator(canvas, e))
@@ -280,11 +281,17 @@ class VTRXSubsystem:
         - Pressure label and control buttons
         - Real-time pressure plot with logarithmic scale
         """
-        layout_frame = tk.Frame(self.parent)
+        MD_CARD = "#2A2A3C"
+        MD_TEXT = "#E0E0E0"
+        MD_ENTRY_BG = "#353548"
+        MD_CARD_BORDER = "#3A3A4C"
+        MD_PRIMARY = "#7C4DFF"
+
+        layout_frame = tk.Frame(self.parent, bg=MD_CARD)
         layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
         # Formatting status indicators
-        switches_frame = tk.Frame(layout_frame)
+        switches_frame = tk.Frame(layout_frame, bg=MD_CARD)
         switches_frame.pack(side=tk.LEFT, fill=tk.Y, expand=True, padx=5)
 
         # Distribute vertical space
@@ -306,7 +313,7 @@ class VTRXSubsystem:
         label_width = 15
 
         for idx, switch in enumerate(switch_labels):
-            label = tk.Label(switches_frame, text=switch, anchor='center', width=label_width)
+            label = tk.Label(switches_frame, text=switch, anchor='center', width=label_width, bg=MD_CARD, fg=MD_TEXT, font=("Segoe UI", 8))
             label.grid(row=idx, column=0, sticky='nsew', pady=2, padx=(0, 1))
             
             canvas, oval_id = self._create_indicator_circle(switches_frame, color='grey')
@@ -314,7 +321,7 @@ class VTRXSubsystem:
             self.circle_indicators.append((canvas, oval_id))
 
         # Pressure label setup
-        pressure_frame = tk.Frame(switches_frame)
+        pressure_frame = tk.Frame(switches_frame, bg=MD_CARD)
         pressure_frame.grid(row=len(switch_labels), column=0, columnspan=2, sticky='nsew', pady=1)
         # Configure columns to center the label
         pressure_frame.grid_columnconfigure(0, weight=1) 
@@ -325,22 +332,22 @@ class VTRXSubsystem:
             pressure_frame,
             text="No data...", 
             anchor='center',
-            font=('Helvetica', 11, 'bold'), 
+            font=('Segoe UI', 11, 'bold'), 
             relief='ridge', 
-            bg='white',
-            fg='black', 
+            bg=MD_ENTRY_BG,
+            fg=MD_TEXT, 
             padx=3, pady=2
         )
         self.label_pressure.grid(row=0, column=1, ipady=2, pady=(0,2))
 
         # Buttons frame
-        button_frame = tk.Frame(switches_frame)
+        button_frame = tk.Frame(switches_frame, bg=MD_CARD)
         button_frame.grid(row=len(switch_labels)+1, column=0, columnspan=2, sticky='nsew', pady=1)
         button_frame.bind("<Configure>", self._on_button_frame_resize)
 
         self.button_frame = button_frame
     
-        timeframe_frame = tk.Frame(button_frame)
+        timeframe_frame = tk.Frame(button_frame, bg=MD_CARD)
         timeframe_frame.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=5)
         
         times = [
@@ -371,24 +378,29 @@ class VTRXSubsystem:
         time_dropdown.bind('<<ComboboxSelected>>', 
             lambda _: self.update_time_window(dict(times)[self.time_window_var.get()]))
         
-        self.save_button = tk.Button(button_frame, text="Save Plot", command=self.save_plot)
+        self.save_button = tk.Button(button_frame, text="Save Plot", command=self.save_plot, bg=MD_CARD_BORDER, fg=MD_TEXT, relief="flat", font=("Segoe UI", 8))
         self.save_button.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=5)
 
         # Plot frame
-        plot_frame = tk.Frame(layout_frame)
+        plot_frame = tk.Frame(layout_frame, bg=MD_CARD)
         plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=1) 
         self.fig, self.ax = plt.subplots()
+        self.fig.patch.set_facecolor(MD_CARD)
+        self.ax.set_facecolor(MD_CARD)
         self.fig.subplots_adjust(left=0.15, right=0.99, top=0.99, bottom=0.05)
-        self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
+        self.line, = self.ax.plot(self.x_data, self.y_data, color=MD_PRIMARY)
         self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
         self.fig.autofmt_xdate()  
         self.ax.set_title('')
-        self.ax.set_xlabel('Time', fontsize=8)
-        self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
+        self.ax.set_xlabel('Time', fontsize=8, color=MD_TEXT)
+        self.ax.set_ylabel('Pressure [mbar]', fontsize=8, color=MD_TEXT)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
-        self.ax.tick_params(axis='x', labelsize=6, pad=1)
-        self.ax.grid(True)
+        self.ax.tick_params(axis='x', labelsize=6, pad=1, colors=MD_TEXT)
+        self.ax.tick_params(axis='y', labelsize=6, colors=MD_TEXT)
+        for spine in self.ax.spines.values():
+            spine.set_color(MD_TEXT)
+        self.ax.grid(True, color=MD_CARD_BORDER)
 
         self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
         self.canvas.draw()

--- a/utils.py
+++ b/utils.py
@@ -113,8 +113,16 @@ class MessagesFrame:
     MAX_LINES = 100  # Maximum number of lines to keep in the widget at a time
 
     def __init__(self, parent, width=300, height=200):
+        # Material Dark Theme Palette
+        MD_BG           = "#1E1E2E"
+        MD_CARD         = "#2A2A3C"
+        MD_CARD_BORDER  = "#3A3A4C"
+        MD_PRIMARY      = "#7C4DFF"
+        MD_TEXT         = "#E0E0E0"
+        MD_ENTRY_BG     = "#353548"
+
         # Create the frame with a strict size
-        self.frame = tk.Frame(parent, borderwidth=2, relief="solid", width=width, height=height)
+        self.frame = tk.Frame(parent, bg=MD_CARD, highlightbackground=MD_CARD_BORDER, highlightthickness=1, width=width, height=height)
         
         # Prevent resizing of frame contents
         self.frame.pack_propagate(False)
@@ -124,33 +132,46 @@ class MessagesFrame:
         self.frame.pack(fill=tk.NONE)  
 
         # Add a title to the Messages & Errors frame
-        label = tk.Label(self.frame, text="Messages & Errors", font=("Helvetica", 8, "bold"))
-        label.grid(row=0, column=0, columnspan=4, sticky="ew", padx=5, pady=5)  # Reduce padding
+        label = tk.Label(self.frame, text="Messages & Errors", font=("Segoe UI", 12, "bold"), bg=MD_CARD, fg=MD_PRIMARY)
+        label.grid(row=0, column=0, columnspan=4, sticky="w", padx=10, pady=(5, 0))
+        
+        sep = ttk.Separator(self.frame, orient="horizontal")
+        sep.grid(row=1, column=0, columnspan=4, sticky="ew", padx=10, pady=(4, 8))
 
         # Configure grid so that widgets can resize proportionally
         self.frame.columnconfigure(0, weight=1)
         self.frame.columnconfigure(1, weight=1)
         self.frame.columnconfigure(2, weight=1)
         self.frame.columnconfigure(3, weight=0)
-        self.frame.rowconfigure(1, weight=1)  # Allow text widget to expand
+        self.frame.rowconfigure(2, weight=1)  # Allow text widget to expand
 
         # Create a Text widget for logs
-        self.text_widget = tk.Text(self.frame, wrap=tk.WORD, font=("Helvetica", 7), width=(width // 10 if width else 30), height=(height // 30 if height else 10))
-        self.text_widget.grid(row=1, column=0, columnspan=4, sticky="nsew", padx=5, pady=5)
+        self.text_widget = tk.Text(
+            self.frame,
+            wrap=tk.WORD,
+            font=("Consolas", 9),
+            bg=MD_ENTRY_BG,
+            fg=MD_TEXT,
+            insertbackground=MD_TEXT,
+            relief="flat",
+            width=(max(1, int(width / 10)) if width else 30),
+            height=(max(1, int(height / 30)) if height else 10),
+        )
+        self.text_widget.grid(row=2, column=0, columnspan=4, sticky="nsew", padx=10, pady=5)
 
         # Create a button to clear the text widget
-        self.clear_button = tk.Button(self.frame, text="Clear", command=self.confirm_clear, font=("Helvetica", 10))
-        self.clear_button.grid(row=2, column=0, sticky="ew", padx=2, pady=5)
+        self.clear_button = tk.Button(self.frame, text="Clear", command=self.confirm_clear, font=("Segoe UI", 10), bg=MD_CARD_BORDER, fg=MD_TEXT, relief="flat")
+        self.clear_button.grid(row=3, column=0, sticky="ew", padx=2, pady=5)
 
-        self.export_button = tk.Button(self.frame, text="Export", command=self.export_log, font=("Helvetica", 10))
-        self.export_button.grid(row=2, column=1, sticky="ew", padx=2, pady=5)
+        self.export_button = tk.Button(self.frame, text="Export", command=self.export_log, font=("Segoe UI", 10), bg=MD_CARD_BORDER, fg=MD_TEXT, relief="flat")
+        self.export_button.grid(row=3, column=1, sticky="ew", padx=2, pady=5)
 
-        self.toggle_file_logging_button = tk.Button(self.frame, text="Log: ON", command=self.toggle_file_logging, font=("Helvetica", 10))
-        self.toggle_file_logging_button.grid(row=2, column=2, sticky="ew", padx=2, pady=5)
+        self.toggle_file_logging_button = tk.Button(self.frame, text="Log: ON", command=self.toggle_file_logging, font=("Segoe UI", 10), bg=MD_CARD_BORDER, fg=MD_TEXT, relief="flat")
+        self.toggle_file_logging_button.grid(row=3, column=2, sticky="ew", padx=2, pady=5)
 
         # Circular indicator for log writing state (unchanged size)
-        self.logging_indicator_canvas = tk.Canvas(self.frame, width=12, height=12, highlightthickness=0)
-        self.logging_indicator_canvas.grid(row=2, column=3, padx=(2, 5), pady=5)
+        self.logging_indicator_canvas = tk.Canvas(self.frame, width=12, height=12, highlightthickness=0, bg=MD_CARD)
+        self.logging_indicator_canvas.grid(row=3, column=3, padx=(2, 10), pady=5)
         self.logging_indicator_circle = self.logging_indicator_canvas.create_oval(
             2, 2, 10, 10, fill="#00FF24", outline="black"
         )
@@ -274,11 +295,15 @@ class SetupScripts:
         self.setup_gui()
 
     def setup_gui(self):
-        self.frame = tk.Frame(self.parent)
+        MD_CARD = "#2A2A3C"
+        MD_TEXT = "#E0E0E0"
+        MD_CARD_BORDER = "#3A3A4C"
+
+        self.frame = tk.Frame(self.parent, bg=MD_CARD)
         self.frame.pack(pady=10, fill=tk.X)
 
         # Label
-        tk.Label(self.frame, text="Script:").pack(side=tk.LEFT)
+        tk.Label(self.frame, text="Script:", bg=MD_CARD, fg=MD_TEXT, font=("Segoe UI", 10)).pack(side=tk.LEFT)
 
         # Dropdown Menu for selecting a script
         self.script_var = tk.StringVar()
@@ -287,7 +312,7 @@ class SetupScripts:
         self.populate_dropdown()
 
         # Execute Button
-        self.execute_button = tk.Button(self.frame, text="Execute", command=self.execute_script)
+        self.execute_button = tk.Button(self.frame, text="Execute", command=self.execute_script, bg=MD_CARD_BORDER, fg=MD_TEXT, relief="flat", font=("Segoe UI", 10))
         self.execute_button.pack(side=tk.RIGHT, padx=5)
 
     def populate_dropdown(self):
@@ -405,7 +430,15 @@ class MachineStatus():
 
     def setup_gui(self):
         """Setup the GUI for the Machine Status Panel"""
-        self.machine_status_frame = tk.Frame(self.parent, bg="#dbd9d9")
+        # Material Dark Theme Palette
+        MD_BG           = "#1E1E2E"
+        MD_CARD         = "#2A2A3C"
+        MD_CARD_BORDER  = "#3A3A4C"
+        MD_PRIMARY      = "#7C4DFF"
+        MD_TEXT         = "#E0E0E0"
+        MD_ACTIVE       = "#00B0FF" # Cyan for active status
+
+        self.machine_status_frame = tk.Frame(self.parent, bg=MD_CARD)
         self.machine_status_frame.pack(fill=tk.BOTH, expand=True)
 
         # Configure columns for each individual machine status
@@ -415,21 +448,21 @@ class MachineStatus():
             self.machine_status_frame.grid_columnconfigure(i * 2 + 1, weight=0)  # Thin separator line
         
         for i, (name, _) in enumerate(self.MACHINE_STATUS.items()):
-            bg_color = "black" if name == "Machine Status" else "#dbd9d9"
-            fg_color = "white" if name == "Machine Status" else "black"
+            bg_color = MD_BG if name == "Machine Status" else MD_CARD
+            fg_color = MD_PRIMARY if name == "Machine Status" else MD_TEXT
 
             label = tk.Label(
                 self.machine_status_frame, text=name, anchor="w", padx=5,
                 bg=bg_color, fg=fg_color, width=12, height=2,
-                wraplength=80, justify="left"
+                wraplength=80, justify="left", font=("Segoe UI", 8)
             )
             label.grid(row=0, column=i * 2, sticky='ew')
 
             self.status_labels[name] = label
 
-            # Add a **very thin** black separator frame (1px wide)
+            # Add a **very thin** separator frame (1px wide)
             if i < len(self.MACHINE_STATUS) - 1:
-                separator = tk.Frame(self.machine_status_frame, bg="black", width=1)  # 1px width black separator
+                separator = tk.Frame(self.machine_status_frame, bg=MD_CARD_BORDER, width=1)  # 1px width separator
                 separator.grid(row=0, column=i * 2 + 1, sticky="ns")
 
     def update_status(self, status_dict=None):
@@ -458,7 +491,12 @@ class MachineStatus():
         self.parent.after(self.update_interval, self.update_status)  # Schedule the next update
 
     def update_labels(self, status_dict):
-            for name, is_active in status_dict.items():
-                if name in self.status_labels and name != "Machine Status":  # Don't change main label
-                    new_color = "#57cce7" if is_active else "#dbd9d9"
-                    self.status_labels[name].config(bg=new_color)
+        MD_CARD = "#2A2A3C"
+        MD_ACTIVE = "#00B0FF"
+        MD_TEXT = "#E0E0E0"
+        MD_BG = "#1E1E2E"
+        for name, is_active in status_dict.items():
+            if name in self.status_labels and name != "Machine Status":  # Don't change main label
+                new_color = MD_ACTIVE if is_active else MD_CARD
+                fg_color = MD_BG if is_active else MD_TEXT
+                self.status_labels[name].config(bg=new_color, fg=fg_color)

--- a/utils.py
+++ b/utils.py
@@ -55,10 +55,14 @@ class Logger:
             timestamp = datetime.datetime.now().strftime("%H:%M:%S")
             formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
             
-            # Write to text widget
-            self.text_widget.insert(tk.END, formatted_message, ("log",))
-            self.text_widget.tag_config("log", font=("Helvetica", 9))  # Set font size
-            self.text_widget.see(tk.END)
+            # Write to text widget (guard against widget already being destroyed)
+            try:
+                self.text_widget.insert(tk.END, formatted_message, ("log",))
+                self.text_widget.tag_config("log", font=("Helvetica", 9))  # Set font size
+                self.text_widget.see(tk.END)
+            except tk.TclError:
+                # Widget destroyed (e.g. app is shutting down) — log to stdout only
+                print(formatted_message, end="")
 
             # write to log flie if enabled
             if self.log_to_file:


### PR DESCRIPTION
- Implemented run_simulator.py to launch the EBEAM hardware simulator.
- Created virtual serial port pairs for communication between simulator and dashboard.
- Developed sim_gui.py for a Material-style dark-themed GUI to display live status of simulated instruments.
- Introduced virtual_serial.py to manage PTY-based virtual serial port pairs.
- Added various instrument simulator classes for VTRX, Power Supply, E5CN, G9 Driver, DP16 Process Monitor, and BCON.
- Enabled dashboard launch option and JSON port mapping output.