### PR TITLE
Skip DP16 driver if dummy port detected

### DIFF
--- a/citestfiles/ProcessMonitor/process_monitor_test.py
+++ b/citestfiles/ProcessMonitor/process_monitor_test.py
@@ -1,0 +1,138 @@
+import enum
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+PROCESS_MONITOR_PATH = os.path.join(
+    REPO_ROOT,
+    "subsystem",
+    "process_monitor",
+    "process_monitor.py",
+)
+
+
+class FakeLogLevel(enum.IntEnum):
+    VERBOSE = 0
+    DEBUG = 1
+    INFO = 2
+    WARNING = 3
+    ERROR = 4
+    CRITICAL = 5
+
+
+def load_process_monitor_module():
+    instrumentctl_pkg = types.ModuleType("instrumentctl")
+    dp16_pkg = types.ModuleType("instrumentctl.DP16_process_monitor")
+    dp16_module = types.ModuleType("instrumentctl.DP16_process_monitor.DP16_process_monitor")
+    utils_module = types.ModuleType("utils")
+
+    class StubDP16ProcessMonitor:
+        DISCONNECTED = -1
+        SENSOR_ERROR = -2
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    dp16_module.DP16ProcessMonitor = StubDP16ProcessMonitor
+    dp16_pkg.DP16_process_monitor = dp16_module
+    instrumentctl_pkg.DP16_process_monitor = dp16_pkg
+    utils_module.LogLevel = FakeLogLevel
+
+    module_name = "citest_process_monitor_module"
+    spec = importlib.util.spec_from_file_location(module_name, PROCESS_MONITOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "instrumentctl": instrumentctl_pkg,
+            "instrumentctl.DP16_process_monitor": dp16_pkg,
+            "instrumentctl.DP16_process_monitor.DP16_process_monitor": dp16_module,
+            "utils": utils_module,
+        },
+    ):
+        spec.loader.exec_module(module)
+
+    return module
+
+
+class TestProcessMonitorSubsystem(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.process_monitor_module = load_process_monitor_module()
+
+    def setUp(self):
+        self.parent = MagicMock()
+        self.logger = MagicMock()
+        self.active = {"Environment Pass": True}
+
+    def test_dummy_port_skips_driver_and_marks_disconnected(self):
+        module = self.process_monitor_module
+
+        with patch.object(module.ProcessMonitorSubsystem, "setup_gui", autospec=True), \
+             patch.object(module.ProcessMonitorSubsystem, "_set_all_temps_disconnected", autospec=True) as set_disconnected, \
+             patch.object(module.ProcessMonitorSubsystem, "update_temperatures", autospec=True) as update_temperatures, \
+             patch.object(module, "DP16ProcessMonitor", autospec=True) as driver_cls:
+            subsystem = module.ProcessMonitorSubsystem(
+                self.parent,
+                com_port="DUMMY_COM7",
+                active=self.active,
+                logger=self.logger,
+            )
+
+        self.assertIsNone(subsystem.monitor)
+        driver_cls.assert_not_called()
+        set_disconnected.assert_called_once_with(subsystem)
+        update_temperatures.assert_not_called()
+        self.assertFalse(self.active["Environment Pass"])
+        self.logger.clear_value.assert_called_once_with("temperatures")
+        self.parent.after.assert_not_called()
+
+    def test_empty_port_uses_disconnected_dummy_behavior(self):
+        module = self.process_monitor_module
+
+        with patch.object(module.ProcessMonitorSubsystem, "setup_gui", autospec=True), \
+             patch.object(module.ProcessMonitorSubsystem, "_set_all_temps_disconnected", autospec=True), \
+             patch.object(module.ProcessMonitorSubsystem, "update_temperatures", autospec=True), \
+             patch.object(module, "DP16ProcessMonitor", autospec=True) as driver_cls:
+            subsystem = module.ProcessMonitorSubsystem(
+                self.parent,
+                com_port="",
+                active=self.active,
+                logger=self.logger,
+            )
+
+        self.assertIsNone(subsystem.monitor)
+        driver_cls.assert_not_called()
+        self.assertFalse(self.active["Environment Pass"])
+
+    def test_real_port_initializes_driver(self):
+        module = self.process_monitor_module
+        driver_instance = MagicMock()
+
+        with patch.object(module.ProcessMonitorSubsystem, "setup_gui", autospec=True), \
+             patch.object(module.ProcessMonitorSubsystem, "update_temperatures", autospec=True) as update_temperatures, \
+             patch.object(module, "DP16ProcessMonitor", autospec=True, return_value=driver_instance) as driver_cls:
+            subsystem = module.ProcessMonitorSubsystem(
+                self.parent,
+                com_port="COM7",
+                active=self.active,
+                logger=self.logger,
+            )
+
+        self.assertIs(subsystem.monitor, driver_instance)
+        driver_cls.assert_called_once_with(
+            port="COM7",
+            unit_numbers=[1, 2, 3, 4, 5, 6],
+            logger=self.logger,
+        )
+        update_temperatures.assert_called_once_with(subsystem)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -169,6 +169,8 @@ class TemperatureBar(tk.Canvas):
 
 
 class ProcessMonitorSubsystem:
+    DUMMY_PORT_PREFIX = "DUMMY_COM"
+
     def __init__(self, parent, com_port, active, logger=None):
         self.parent = parent
         self.logger = logger
@@ -190,10 +192,11 @@ class ProcessMonitorSubsystem:
 
         self.setup_gui()
         self.monitor = None
+        if self._is_dummy_port(com_port):
+            self._enter_dummy_mode()
+            return
+
         try:
-            if not com_port:
-                raise ValueError("No COM port provided for ProcessMonitor")
-            # Instantiate PMON driver
             self.monitor = DP16ProcessMonitor(
                 port=com_port,
                 unit_numbers=list(self.thermometer_map.values()),
@@ -202,7 +205,9 @@ class ProcessMonitorSubsystem:
         except Exception as e:
             self.monitor = None
             self.log(f"Failed to initialize DP16ProcessMonitor: {str(e)}", LogLevel.ERROR)
+            self._set_environment_pass(False)
             self._set_all_temps_error()
+            return
         
         # start the callback method
         self.update_temperatures()
@@ -229,6 +234,7 @@ class ProcessMonitorSubsystem:
                 self.log("Checking DP16 monitor connection status", LogLevel.DEBUG)
                 if current_time - self.last_error_time > (self.update_interval / 1000):
                     self._set_all_temps_disconnected()
+                    self._set_environment_pass(False)
                     if self.logger and hasattr(self.logger, "clear_value"):
                         self.logger.clear_value("temperatures")
                     self.log("DP16 monitor not connected", LogLevel.WARNING)
@@ -257,7 +263,7 @@ class ProcessMonitorSubsystem:
                         self._set_all_temps_disconnected()
                         if self.logger and hasattr(self.logger, "clear_value"):
                             self.logger.clear_value("temperatures")
-                        self.active['Environment Pass'] = False
+                        self._set_environment_pass(False)
                         self.log("No temperature data available from DP16", LogLevel.ERROR)
                         self.last_error_time = current_time
                 else:
@@ -268,32 +274,32 @@ class ProcessMonitorSubsystem:
                         temp = temps.get(unit)
                         if temp is None:
                             self.temp_bars[name].update_value(name, TemperatureBar.DISCONNECTED)
-                            self.active['Environment Pass'] = False
+                            self._set_environment_pass(False)
                         elif temp == self.monitor.SENSOR_ERROR:
                             self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
-                            self.active['Environment Pass'] = False
+                            self._set_environment_pass(False)
                         elif temp == self.monitor.DISCONNECTED:
                             self.temp_bars[name].update_value(name, TemperatureBar.DISCONNECTED)
-                            self.active['Environment Pass'] = False
+                            self._set_environment_pass(False)
                         elif isinstance(temp, (int, float)):
                             try:
                                 temp_value = float(temp)
                                 if -90 <= temp_value <= 500:  # Valid temperature range
                                     self.temp_bars[name].update_value(name, temp_value)
-                                    self.active['Environment Pass'] = True # Update Machine Status Progress Bar
+                                    self._set_environment_pass(True) # Update Machine Status Progress Bar
                                     self.log(f"Temperature update - {name}: {temp_value:.1f}C", LogLevel.VERBOSE)
                                 else:
                                     self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                                     self.log(f"Temperature out of range - {name}: {temp_value}", LogLevel.WARNING)
-                                    self.active['Environment Pass'] = False
+                                    self._set_environment_pass(False)
                             except (ValueError, TypeError):
                                 self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                                 self.log(f"Invalid temperature value - {name}: {temp}", LogLevel.WARNING)
-                                self.active['Environment Pass'] = False
+                                self._set_environment_pass(False)
                         else:
                             self.temp_bars[name].update_value(name, TemperatureBar.SENSOR_ERROR)
                             self.log(f"Invalid temperature type - {name}: {type(temp)}", LogLevel.WARNING)
-                            self.active['Environment Pass'] = False
+                            self._set_environment_pass(False)
 
         except Exception as e:
             self.log(f"DP16 exception details: {type(e).__name__}: {str(e)}", LogLevel.DEBUG)
@@ -317,6 +323,27 @@ class ProcessMonitorSubsystem:
         if hasattr(self, 'temp_bars'):
             for name in self.temp_bars:
                 self.temp_bars[name].update_value(name, TemperatureBar.DISCONNECTED)
+
+    def _enter_dummy_mode(self):
+        self.monitor = None
+        self._set_all_temps_disconnected()
+        self._set_environment_pass(False)
+        if self.logger and hasattr(self.logger, "clear_value"):
+            self.logger.clear_value("temperatures")
+        self.log(
+            f"PMON running in disconnected dummy mode on port {self.com_port}",
+            LogLevel.INFO
+        )
+
+    def _is_dummy_port(self, com_port):
+        if com_port is None:
+            return True
+        normalized_port = str(com_port).strip().upper()
+        return not normalized_port or normalized_port.startswith(self.DUMMY_PORT_PREFIX)
+
+    def _set_environment_pass(self, value):
+        if self.active is not None:
+            self.active['Environment Pass'] = value
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""


### PR DESCRIPTION
This is an alternative attempt to get rid of the dummy com port errors on the terminal when running the dashboard with dummy ports instead of real serial ports. 

A separate PR https://github.com/uw-loci/EBEAM_dashboard/pull/77 Bugfix/dummy port console error attempts to fix this error by rerouting stderr during connection attempts, but that would reroute any writes to stderr to the log file in an unpredictable way depending on the error status of PMON. 

This new PR instead has the PMON subsystem first detect if there is a dummy com port (or no port) and skips instantiating a DP16 driver object if there is no real serial device. The driver file is untouched. This does not affect reconnect attempts if com was later lost with a real serial port because the DP16 driver would have already been recreated and will try to reconnect. This only deals with whether the DP16 driver object is created in the first place when there is only a dummy or no port. 