### PR TITLE
Default file log is now verbose on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-__pycache__/
+﻿__pycache__/
 usr/usr_data/
 venv/
 build/
 dist/
 EBEAM-Dashboard-Logs/
 EBEAM-Dashboard-WMLogs/
+citestfiles/_tmp/

--- a/citestfiles/startup_logging_test.py
+++ b/citestfiles/startup_logging_test.py
@@ -1,0 +1,177 @@
+import json
+import os
+import shutil
+import sys
+import unittest
+import uuid
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utils import Logger, LogLevel
+from usr.com_port_config import load_com_ports, save_com_ports
+from usr.panel_config import load_pane_states
+
+TEST_TMP_ROOT = os.path.join(os.path.dirname(__file__), "_tmp")
+os.makedirs(TEST_TMP_ROOT, exist_ok=True)
+
+
+class FakeTextWidget:
+    def __init__(self):
+        self.messages = []
+        self.tag_configs = []
+
+    def insert(self, _index, message, _tags=None):
+        self.messages.append(message)
+
+    def tag_config(self, tag, **kwargs):
+        self.tag_configs.append((tag, kwargs))
+
+    def see(self, _index):
+        pass
+
+    def getvalue(self):
+        return "".join(self.messages)
+
+
+class TestStartupLogger(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = os.path.join(TEST_TMP_ROOT, f"case_{uuid.uuid4().hex}")
+        os.makedirs(self.tempdir, exist_ok=False)
+        self.expanduser_patcher = patch("utils.os.path.expanduser", return_value=self.tempdir)
+        self.expanduser_patcher.start()
+
+    def tearDown(self):
+        self.expanduser_patcher.stop()
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_logger_creates_file_and_persists_early_messages_without_widget(self):
+        logger = Logger(text_widget=None, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+        self.addCleanup(logger.close)
+
+        logger.info("Process launch")
+
+        self.assertTrue(os.path.exists(logger.log_filepath))
+        with open(logger.log_filepath, "r") as file:
+            contents = file.read()
+
+        self.assertIn("Log file created at", contents)
+        self.assertIn("WebMonitor log file created at", contents)
+        self.assertIn("Process launch", contents)
+
+    def test_attach_text_widget_replays_buffer_without_creating_second_file(self):
+        logger = Logger(text_widget=None, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+        self.addCleanup(logger.close)
+
+        logger.info("Early startup milestone")
+        original_log_path = logger.log_filepath
+        widget = FakeTextWidget()
+
+        logger.attach_text_widget(widget)
+        logger.info("Post-attach milestone")
+
+        self.assertEqual(original_log_path, logger.log_filepath)
+        self.assertEqual(len(os.listdir(os.path.dirname(logger.log_filepath))), 1)
+
+        widget_text = widget.getvalue()
+        self.assertIn("Early startup milestone", widget_text)
+        self.assertIn("Post-attach milestone", widget_text)
+        self.assertLess(widget_text.index("Early startup milestone"), widget_text.index("Post-attach milestone"))
+
+
+class TestComPortConfigLogging(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = os.path.join(TEST_TMP_ROOT, f"case_{uuid.uuid4().hex}")
+        os.makedirs(self.tempdir, exist_ok=False)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_save_and_load_com_ports_with_logger_avoid_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "usr_data", "com_ports.json")
+        expected = {"VTRXSubsystem": "COM1", "Interlocks": "COM2"}
+
+        with patch("builtins.print") as mock_print:
+            save_com_ports(expected, filepath=filepath, logger=logger)
+            loaded = load_com_ports(filepath=filepath, logger=logger)
+
+        self.assertEqual(loaded, expected)
+        logger.info.assert_any_call(f"COM ports saved to {filepath}.")
+        logger.info.assert_any_call(f"COM ports loaded from {filepath}.")
+        mock_print.assert_not_called()
+
+    def test_load_com_ports_missing_logs_without_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "missing_com_ports.json")
+
+        with patch("builtins.print") as mock_print:
+            loaded = load_com_ports(filepath=filepath, logger=logger)
+
+        self.assertEqual(loaded, {})
+        logger.info.assert_called_with("No COM port configuration file found.")
+        mock_print.assert_not_called()
+
+    def test_load_com_ports_invalid_json_logs_error_without_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "broken_com_ports.json")
+        with open(filepath, "w") as file:
+            file.write("{invalid json")
+
+        with patch("builtins.print") as mock_print:
+            loaded = load_com_ports(filepath=filepath, logger=logger)
+
+        self.assertEqual(loaded, {})
+        self.assertIn("Error loading COM ports", logger.error.call_args[0][0])
+        mock_print.assert_not_called()
+
+
+class TestPanelConfigLogging(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = os.path.join(TEST_TMP_ROOT, f"case_{uuid.uuid4().hex}")
+        os.makedirs(self.tempdir, exist_ok=False)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_load_pane_states_success_logs_without_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "pane_state.json")
+        expected = {"Interlocks": [100, 200]}
+        with open(filepath, "w") as file:
+            json.dump(expected, file)
+
+        with patch("builtins.print") as mock_print:
+            loaded = load_pane_states(filepath=filepath, logger=logger)
+
+        self.assertEqual(loaded, expected)
+        logger.info.assert_called_with(f"Pane state loaded from {filepath}.")
+        mock_print.assert_not_called()
+
+    def test_load_pane_states_missing_logs_without_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "missing_pane_state.json")
+
+        with patch("builtins.print") as mock_print:
+            loaded = load_pane_states(filepath=filepath, logger=logger)
+
+        self.assertIsNone(loaded)
+        logger.info.assert_called_with("No previous pane state saved.")
+        mock_print.assert_not_called()
+
+    def test_load_pane_states_invalid_json_logs_error_without_print(self):
+        logger = MagicMock()
+        filepath = os.path.join(self.tempdir, "broken_pane_state.json")
+        with open(filepath, "w") as file:
+            file.write("{invalid json")
+
+        with patch("builtins.print") as mock_print:
+            loaded = load_pane_states(filepath=filepath, logger=logger)
+
+        self.assertIsNone(loaded)
+        self.assertIn("Failed to load pane states", logger.error.call_args[0][0])
+        mock_print.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dashboard.py
+++ b/dashboard.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import ttk
 from tkinter import messagebox
 from utils import MessagesFrame, SetupScripts, LogLevel, MachineStatus
-from usr.panel_config import save_pane_states, load_pane_states, saveFileExists
+from usr.panel_config import save_pane_states, load_pane_states
 import serial.tools.list_ports
 
 frames_config = [
@@ -62,17 +62,20 @@ class EBEAMSystemDashboard:
         "safetyInputStatusFlags"
     ]}
 
-    def __init__(self, root, com_ports):
+    def __init__(self, root, com_ports, logger=None):
         self.root = root
         self.com_ports = com_ports
+        self.logger = logger
         self.root.title("EBEAM Control System Dashboard")
 
         self.set_com_ports = set(serial.tools.list_ports.comports())
         
         
-        # if save file exists call it and open it
-        if saveFileExists():
-             self.load_saved_pane_state()
+        if self.load_saved_pane_state():
+            if self.logger is not None:
+                self.logger.info("Pane-state restore result: restored saved pane state")
+        elif self.logger is not None:
+            self.logger.info("Pane-state restore result: no saved pane state applied")
 
         # Initialize the frames dictionary to store various GUI components
         self.frames = {}
@@ -90,9 +93,13 @@ class EBEAMSystemDashboard:
         self.create_machine_status_frame()
 
         # Set up different subsystems within their respective frames
+        if self.logger is not None:
+            self.logger.info("Subsystem initialization start")
         self.create_subsystems()
 
         self._check_ports()
+        if self.logger is not None:
+            self.logger.info("Dashboard ready")
 
     def cleanup(self):
         """Closes all open com ports before quitting the application."""
@@ -246,12 +253,13 @@ class EBEAMSystemDashboard:
 
     # gets data in save config file (as dict) and updates the global var of frames_config
     def load_saved_pane_state(self):
-        savedData = load_pane_states()
-
+        savedData = load_pane_states(logger=self.logger)
+        if not savedData:
+            return False
         for i in range(len(frames_config)):
             if frames_config[i][0] in savedData:
                 frames_config[i] = (frames_config[i][0], frames_config[i][1], savedData[frames_config[i][0]][0],savedData[frames_config[i][0]][1])
-        savedData = load_pane_states()
+        return True
 
     def create_log_level_dropdown(self, parent_frame):
         log_level_frame = ttk.Frame(parent_frame)
@@ -345,7 +353,7 @@ class EBEAMSystemDashboard:
 
     def create_messages_frame(self):
         """Create a scrollable frame for displaying system messages and errors."""
-        self.messages_frame = MessagesFrame(self.rows[3], width = frames_config[-2][2], height = frames_config[-2][3])
+        self.messages_frame = MessagesFrame(self.rows[3], width = frames_config[-2][2], height = frames_config[-2][3], logger=self.logger)
         self.logger = self.messages_frame.logger
 
     def create_machine_status_frame(self):

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import serial.tools.list_ports
 
 from dashboard import EBEAMSystemDashboard
 from usr.com_port_config import save_com_ports, load_com_ports
+from utils import Logger, LogLevel
 
 
 SUBSYSTEMS = [
@@ -36,12 +37,15 @@ def create_dummy_ports(subsystems):
     """
     return {subsystem: f"DUMMY_COM{i+1}" for i, subsystem in enumerate(subsystems)}
 
-def start_main_app(com_ports):
+def start_main_app(com_ports, logger=None):
     """
     Create and start the main EBEAM System Dashboard application.
 
     :param com_ports: Dict mapping subsystems to their selected COM ports.
     """
+    if logger is None:
+        logger = Logger(text_widget=None, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+    logger.info("Dashboard init start")
     root = tk.Tk()
     root.title("EBEAM System Dashboard")
     root.state('zoomed')
@@ -168,12 +172,11 @@ def start_main_app(com_ports):
     root.bind('<Escape>', escape_handler)       # Exit fullscreen
     root.bind('<Control-m>', toggle_maximize)   # Toggle maximize  
     root.bind('<Control-s>', save_logs)         # Save log file
-  
 
-    app = EBEAMSystemDashboard(root, com_ports)
+    app = EBEAMSystemDashboard(root, com_ports, logger=logger)
     root.mainloop()
 
-def config_com_ports(saved_com_ports):
+def config_com_ports(saved_com_ports, logger=None):
     """
     Display a configuration GUI for selecting COM ports for each subsystem.
     Users can choose from available real COM ports or dummy ports.
@@ -257,11 +260,13 @@ def config_com_ports(saved_com_ports):
                 return  # Stay on the configuration window
         
         # save final selections
-        save_com_ports(selected_ports)
+        save_com_ports(selected_ports, logger=logger)
+        if logger is not None:
+            logger.info(f"COM-port selection submitted: {selected_ports}")
         config_root.destroy()
         
         # Launch the main application
-        start_main_app(selected_ports)
+        start_main_app(selected_ports, logger=logger)
 
     submit_button = tk.Button(config_root, text="Submit", command=on_submit)
     submit_button.pack(pady=20)
@@ -271,8 +276,12 @@ def config_com_ports(saved_com_ports):
 
 
 if __name__ == "__main__":
+    bootstrap_logger = Logger(text_widget=None, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+    bootstrap_logger.info("Process launch")
+
     # Load previously saved COM ports, if any
-    saved_com_ports = load_com_ports()
+    saved_com_ports = load_com_ports(logger=bootstrap_logger)
+    bootstrap_logger.info(f"COM-port config load result: {len(saved_com_ports)} saved selection(s) available")
 
     # Prompt the user to confirm or change COM ports
-    config_com_ports(saved_com_ports)
+    config_com_ports(saved_com_ports, logger=bootstrap_logger)

--- a/usr/com_port_config.py
+++ b/usr/com_port_config.py
@@ -4,27 +4,42 @@ import os
 
 CONFIG_FILE = 'usr/usr_data/com_ports.json'
 
-def save_com_ports(com_ports, filepath=CONFIG_FILE):
+def save_com_ports(com_ports, filepath=CONFIG_FILE, logger=None):
     """Save COM port selections to a JSON file."""
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
     try:
         with open(filepath, 'w') as file:
             json.dump(com_ports, file, indent=4)
-        print(f"COM ports saved to {filepath}.")
+        if logger is not None:
+            logger.info(f"COM ports saved to {filepath}.")
+        else:
+            print(f"COM ports saved to {filepath}.")
     except Exception as e:
-        print(f"Error saving COM ports: {e}")
+        if logger is not None:
+            logger.error(f"Error saving COM ports: {e}")
+        else:
+            print(f"Error saving COM ports: {e}")
 
-def load_com_ports(filepath=CONFIG_FILE):
+def load_com_ports(filepath=CONFIG_FILE, logger=None):
     """Load COM port selections from a JSON file."""
     if not os.path.exists(filepath):
-        print("No COM port configuration file found.")
+        if logger is not None:
+            logger.info("No COM port configuration file found.")
+        else:
+            print("No COM port configuration file found.")
         return {}
     try:
         with open(filepath, 'r') as file:
             com_ports = json.load(file)
-        print(f"COM ports loaded from {filepath}.")
+        if logger is not None:
+            logger.info(f"COM ports loaded from {filepath}.")
+        else:
+            print(f"COM ports loaded from {filepath}.")
         return com_ports
     except Exception as e:
-        print(f"Error loading COM ports: {e}")
+        if logger is not None:
+            logger.error(f"Error loading COM ports: {e}")
+        else:
+            print(f"Error loading COM ports: {e}")
         return {}

--- a/usr/panel_config.py
+++ b/usr/panel_config.py
@@ -17,15 +17,23 @@ def save_pane_states(config, frames, pane, filepath=CONFIG_FILE):
         json.dump(data, file)
 
 # reads in file and passes the config file back as a dict
-def load_pane_states(filepath=CONFIG_FILE):
+def load_pane_states(filepath=CONFIG_FILE, logger=None):
     try:
         with open(filepath, 'r') as file:
             data = json.load(file)
+        if logger is not None:
+            logger.info(f"Pane state loaded from {filepath}.")
         return dict(data)
     except FileNotFoundError:
-        print("No previous pane state saved.")
+        if logger is not None:
+            logger.info("No previous pane state saved.")
+        else:
+            print("No previous pane state saved.")
     except Exception as e:
-        print(f"Failed to load pane states: {e}")
+        if logger is not None:
+            logger.error(f"Failed to load pane states: {e}")
+        else:
+            print(f"Failed to load pane states: {e}")
 
 # checks to see if that config file exists
 def saveFileExists(filepath=CONFIG_FILE):

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import enum
 import json
+from collections import deque
 
 class LogLevel(enum.IntEnum):
     VERBOSE = 0
@@ -19,6 +20,8 @@ class LogLevel(enum.IntEnum):
     CRITICAL = 5
 
 class Logger:
+    STARTUP_BUFFER_MAX = 500
+
     def __init__(self, text_widget, file_log_level = LogLevel.VERBOSE, log_level=LogLevel.INFO, log_to_file=False):
         self.text_widget = text_widget
         self.file_log_level = file_log_level
@@ -30,6 +33,7 @@ class Logger:
         self.webMonitor_log_start_time = None
         self.log_filepath = None
         self.webMonitor_log_filepath = None
+        self._pending_widget_messages = deque(maxlen=self.STARTUP_BUFFER_MAX)
         self.dict_logger = {
             "pressure": None,
             "safetyOutputDataFlags": None,
@@ -52,12 +56,25 @@ class Logger:
             self.setup_log_file()
             self.setup_wm_logfile()
 
+    def _get_dashboard_base_path(self):
+        return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
+
+    def _write_to_text_widget(self, formatted_message):
+        if self.text_widget is None:
+            return
+        self.text_widget.insert(tk.END, formatted_message, ("log",))
+        self.text_widget.tag_config("log", font=("Helvetica", 9))
+        self.text_widget.see(tk.END)
+
+    def attach_text_widget(self, text_widget):
+        self.text_widget = text_widget
+        while self._pending_widget_messages:
+            self._write_to_text_widget(self._pending_widget_messages.popleft())
+
     def setup_log_file(self):
         """Setup a new log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
         try:
-            # Use the EBEAM_dashboard directory
-            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-            log_dir = os.path.join(base_path, "EBEAM-Dashboard-Logs")
+            log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Logs")
             os.makedirs(log_dir, exist_ok=True)
             
             # Create the log file with the old naming pattern
@@ -66,27 +83,27 @@ class Logger:
             if self.log_file != None:
                 self.log_file.close()
 
-            self.log_file = open(os.path.join(log_dir, log_file_name), 'w')
+            self.log_filepath = os.path.join(log_dir, log_file_name)
+            self.log_file = open(self.log_filepath, 'w')
             self.log_start_time = datetime.datetime.now()
-            print(f"Log file created at {os.path.join(log_dir, log_file_name)}")
+            self.info(f"Log file created at {self.log_filepath}")
         except Exception as e:
             print(f"Error creating log file: {str(e)}")
 
     def setup_wm_logfile(self):
         """Setup a new web monitor log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
         try:
-            # Use the EBEAM_dashboard directory
-            base_path = os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
-            wm_log_dir = os.path.join(base_path, "EBEAM-Dashboard-WMLogs")
+            wm_log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-WMLogs")
             os.makedirs(wm_log_dir, exist_ok=True)
             
             # Create the web monitor log file with the old naming pattern
             webMonitor_log_file_name = f"webMonitor_log.txt"
             if self.webMonitor_log_file != None:
                 self.webMonitor_log_file.close()
-            self.webMonitor_log_file = open(os.path.join(wm_log_dir, webMonitor_log_file_name), 'w')
+            self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
+            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
             self.webMonitor_log_start_time = datetime.datetime.now()
-            print(f"WebMonitor Log File created at {os.path.join(wm_log_dir, webMonitor_log_file_name)}")
+            self.info(f"WebMonitor log file created at {self.webMonitor_log_filepath}")
         except Exception as e:
             print(f"Error creating web monitor log file: {str(e)}")
 
@@ -94,11 +111,11 @@ class Logger:
         """ Log a message to the text widget and optionally to local file """
         timestamp = datetime.datetime.now().strftime("%H:%M:%S")
         formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
-        if level >= self.log_level and self.text_widget is not None:
-            # Write to text widget
-            self.text_widget.insert(tk.END, formatted_message, ("log",))
-            self.text_widget.tag_config("log", font=("Helvetica", 9))  # Set font size
-            self.text_widget.see(tk.END)
+        if level >= self.log_level:
+            if self.text_widget is not None:
+                self._write_to_text_widget(formatted_message)
+            else:
+                self._pending_widget_messages.append(formatted_message)
         # return early if file logging is disabled
         if not self.log_to_file:
             return
@@ -108,6 +125,8 @@ class Logger:
             # close the log file at intervals of 8 hours and create a new one
             if self.log_start_time == None or (now - self.log_start_time).total_seconds() > 8*60*60:
                 self.setup_log_file()
+            if self.log_file is None:
+                return
             try:
                 file_formatted_message = f"[{timestamp}] - {level.name}: {msg}\n"
                 self.log_file.write(file_formatted_message)
@@ -137,6 +156,8 @@ class Logger:
                 if self.webMonitor_log_file:
                     self.webMonitor_log_file.close()
                 self.setup_wm_logfile()
+            if self.webMonitor_log_file is None:
+                return
             entry = {
                 "timestamp": now.strftime("%Y-%m-%d %H:%M:%S"),
                 "status": update_dict
@@ -173,6 +194,12 @@ class Logger:
                 self.log_file = None
             except Exception as e:
                 print(f"Error closing log file {str(e)}")
+        if self.webMonitor_log_file:
+            try:
+                self.webMonitor_log_file.close()
+                self.webMonitor_log_file = None
+            except Exception as e:
+                print(f"Error closing web monitor log file {str(e)}")
 
 import tkinter as tk
 import sys
@@ -180,7 +207,7 @@ import sys
 class MessagesFrame:
     MAX_LINES = 100  # Maximum number of lines to keep in the widget at a time
 
-    def __init__(self, parent, width=300, height=200):
+    def __init__(self, parent, width=300, height=200, logger=None):
         # Create the frame with a strict size
         self.frame = tk.Frame(parent, borderwidth=2, relief="solid", width=width, height=height)
         
@@ -223,15 +250,17 @@ class MessagesFrame:
             2, 2, 10, 10, fill="#00FF24", outline="black"
         )
 
-        self.file_logging_enabled = True
-        self.logger = Logger(self.text_widget, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+        if logger is None:
+            self.logger = Logger(self.text_widget, log_level=LogLevel.DEBUG, file_log_level=LogLevel.VERBOSE, log_to_file=True)
+        else:
+            self.logger = logger
+            self.logger.attach_text_widget(self.text_widget)
+
+        self.file_logging_enabled = self.logger.log_to_file
+        self.logger.info("Messages pane attached to logger")
 
         # Redirect stdout to the text widget
         sys.stdout = TextRedirector(self.text_widget, "stdout")
-
-        # Ensure that the log directory exists
-        self.ensure_log_directory()
-        self.ensure_wm_log_directory()
 
     def write(self, msg):
         """ Write message to the text widget and trim if necessary. """


### PR DESCRIPTION
Small change so that when the dashboard boots it it creates a verbose file log. Before this, it was impossible to capture detailed verbose information and errors on dashboard booting because it defaults to DEBUG log level on boot and could only later be switched to verbose once running. Now boots in verbose.