### PR TITLE
SIC: Change fallback payload to match successful

### DIFF
--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -100,7 +100,15 @@ class G9Driver:
         self.ser = None
 
     def _update_queue(self, response=None):
-        data = response if response else ([0] * 13, [0] * 13, 0)
+        data = response if response else (
+            [0] * self.NUMIN,                    # sitsf_bits
+            [0] * self.NUMIN,                    # sitdf_bits
+            0,                                   # g9_active
+            {},                                  # unit_status
+            bytearray(10),                       # input_terms
+            bytearray(10),                       # output_terms
+            {'sotdf': [0] * 7, 'sitdf': [0] * self.NUMIN}  # debug_data
+        )
         if self._response_queue.full():
             self._response_queue.get_nowait()
         self._response_queue.put(data)


### PR DESCRIPTION
Issue #96 summary:

The contract between g9_driver.py:142 and interlocks.py:275 is a 7-item status tuple.
On timeout/parse failure, the fallback in g9_driver.py:102 was pushing only 3 items into the queue.
The next poll in interlocks.py:275 unpacks 7 values, causing ValueError, which drops into the generic exception path and hides the intended degraded-status behavior.

To fix this we can change the fallback payload to send 7 elements instead of 3 matching the expected format.

**Requires testing on hardware before merge.** 