### PR TITLE
Update Test Environment to Use Windows and Python 3.11.9

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.11' 
+        python-version: '3.11.9' 
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-2025
     
     steps:
     - uses: actions/checkout@v3
@@ -16,12 +16,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.12.4' 
+        python-version: '3.11' 
         
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if (Test-Path requirements.txt) { pip install -r requirements.txt }
         
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ The `main` branch contains the latest production code.
 
 #### Development Process 
 Clone the repo to your machine. Current libraries require the use of Python version 3.11.
+
+> Note: Python 3.11 is in the security-fix-only phase and is scheduled to reach End of Life (EOL) on 2027-10-31. The PSF support window for each major release is five years, typically split into bugfix and security phases. See https://devguide.python.org/versions/ and https://endoflife.date/python.
+
 ```
 git clone https://github.com/bwalkerMIR/EBEAM_dashboard.git
 ```


### PR DESCRIPTION
This PR is a test to see if we can use a windows environment and Python 3.11.9 for the automated tests, instead of Ubuntu, and python 3.12.4, which we are not using. On this repository, we need to make a pull request in order to trigger automated tests for a particular branch.

GIthub Actions supports WIndows Server Edition, which for Server 2025, uses the same kernel as the laptop windows version (WIndows 11 Education). This works for the Python Unit Tests we are running in out Actions Environment.

I also added a notice to the README that the Python Foundation will end security support of Python 3.11 on Ocober 2027. This will be important for whoever is working on this code at that time.