### PR TITLE
Bugfix: E5CN TempReader Thread Leak

### DIFF
--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from queue import Queue, Empty
 from pymodbus.client import ModbusSerialClient as ModbusClient
 from utils import LogLevel  # Ensure this module is correctly implemented
 
@@ -31,6 +32,8 @@ class E5CNModbus:
         self.is_initialized = threading.Event()
         self.port = port
         self.connected = False
+        self._main_thread_ident = threading.get_ident()
+        self._log_queue = Queue()
         self.log(f"Initializing E5CNModbus with port: {port}", LogLevel.DEBUG)
 
         # Initialize Modbus client without 'method' parameter
@@ -115,6 +118,7 @@ class E5CNModbus:
                 self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
                 
         self.is_initialized.clear()
+        self.flush_queued_logs()
 
     def connect(self):
         """
@@ -200,7 +204,26 @@ class E5CNModbus:
         return None
 
     def log(self, message, level=LogLevel.INFO):
-        if self.logger:
+        if not self.logger:
+            print(f"{level.name}: {message}")
+            return
+
+        # Tkinter widgets must only be modified from the main GUI thread.
+        # Queue logs from worker threads and flush them on the main thread.
+        if threading.get_ident() == self._main_thread_ident:
             self.logger.log(message, level)
         else:
-            print(f"{level.name}: {message}")
+            self._log_queue.put((message, level))
+
+    def flush_queued_logs(self, max_messages=200):
+        """Flush queued worker-thread log messages on the calling thread."""
+        if not self.logger:
+            return
+        processed = 0
+        while processed < max_messages:
+            try:
+                message, level = self._log_queue.get_nowait()
+            except Empty:
+                break
+            self.logger.log(message, level)
+            processed += 1

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1693,6 +1693,9 @@ class CathodeHeatingSubsystem:
         current_time = datetime.datetime.now()
         plot_this_cycle = (current_time - self.last_plot_time) >= self.plot_interval
 
+        if self.temperature_controller and hasattr(self.temperature_controller, "flush_queued_logs"):
+            self.temperature_controller.flush_queued_logs()
+
         for i in range(3):
             self.log(f"Processing Cathode {['A', 'B', 'C'][i]}", LogLevel.VERBOSE)
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2990,7 +2990,8 @@ class CathodeHeatingSubsystem:
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
-               # self.temperature_controller.stop_reading()
+                self.temperature_controller.stop_reading()
+                self.temp_controllers_connected = False
                 self.temperature_controller.disconnect()
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)


### PR DESCRIPTION
<h2>Overview</h2>
Refactors the logging that is done by the 3 daemon threads responsible for polling the E5CN temperature sensors. Previously, this logging was done from the background threads, which is not best practice with Tkinter. Logging now uses a queue that each background thread pushes logs to, and the main thread flushes this queue every time the Dashboard updates its values.

<h3>New Behavior</h3>

No TclErrors from the TempReader threads are printed to the console on Dashboard shutdown. Additionally, since the daemon threads close cleanly, this PR mitigates concerns with a thread holding on to resources, such as COM ports. 

<h3>Tests Run</h3>

Full hardware test documented here (pp. 3-4): https://docs.google.com/document/d/1HeVK_dALBxRzzOwoVtnQJUaDIUz10hf4UFXZV0RhCP8/edit?tab=t.0

>Note: This PR was not tested with PMON operational. During testing, a DUMMY_COM port was used for PMON, with the same threading errors occurring as when PMON operates normally. This PR does not touch the PMON subsystem.