### PR TITLE
Bugfix: PMON Thread Leak

### DIFF
--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -53,7 +53,7 @@ class DP16ProcessMonitor:
         self.last_good_readings = {unit: None for unit in self.unit_numbers}
         self.consecutive_connection_errors = 0
 
-        self._is_running = True
+        self._stop_event = threading.Event()
         self._thread = None
         self.response_lock = Lock()
         self.last_critical_error_time = 0
@@ -187,7 +187,7 @@ class DP16ProcessMonitor:
         
     def poll_all_units(self):
         """Single polling loop with each unit independent"""
-        while self._is_running:
+        while not self._stop_event.is_set():
             current_time = time.time()
             try:
                 # Check if client is still connected
@@ -204,15 +204,19 @@ class DP16ProcessMonitor:
                         if current_time - self.last_critical_error_time >= self.ERROR_LOG_INTERVAL:
                             self.log("Failed to reconnect to PMON", LogLevel.ERROR)
                             self.last_critical_error_time = current_time
-                        time.sleep(1)  # Delay before next attempt
+                        if self._stop_event.wait(1):
+                            break  # Delay before next attempt
                         continue
                 
                 # Poll each unit individually
                 for unit in sorted(self.unit_numbers):
+                    if self._stop_event.is_set():
+                        break
                     try:
                         self._poll_single_unit(unit) 
                         self.consecutive_connection_errors = 0  # Reset on successful poll
-                        time.sleep(0.1)
+                        if self._stop_event.wait(0.1):
+                            break
                     except ModbusIOException as e:
                         self._handle_poll_error(unit, e)
                         
@@ -221,8 +225,12 @@ class DP16ProcessMonitor:
                             self.log(f"Error polling unit {unit}: {e}", LogLevel.ERROR)
                             self.last_critical_error_time = current_time
 
+                if self._stop_event.is_set():
+                    break
+
                 if self.consecutive_connection_errors == 0:
-                    time.sleep(self.BASE_DELAY)
+                    if self._stop_event.wait(self.BASE_DELAY):
+                        break
                     
             except Exception as e:
                 self.consecutive_connection_errors += 1
@@ -233,7 +241,7 @@ class DP16ProcessMonitor:
 
     def _poll_single_unit(self, unit):
         """Poll a single unit atomically"""
-        if not self._is_running:
+        if self._stop_event.is_set():
             return
 
         with self.modbus_lock:
@@ -335,9 +343,9 @@ class DP16ProcessMonitor:
 
     def disconnect(self):
         # Stop polling thread
-        # self._is_running = False
-        # if self._thread and self._thread.is_alive():
-        #     self._thread.join()
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join()
         
         # Close connection
         # with self.modbus_lock:

--- a/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
+++ b/instrumentctl/DP16_process_monitor/DP16_process_monitor.py
@@ -1,6 +1,7 @@
 import time
 import threading
 from threading import Lock
+from queue import Queue, Empty
 import struct
 from utils import LogLevel
 from pymodbus.client import ModbusSerialClient as ModbusClient
@@ -44,6 +45,8 @@ class DP16ProcessMonitor:
         self.unit_numbers = set(unit_numbers)
         self.modbus_lock = Lock()
         self.logger = logger
+        self._main_thread_ident = threading.get_ident()
+        self._log_queue = Queue()
 
         self.temperature_readings = {unit: None for unit in unit_numbers}
         self.consecutive_error_counts = {unit: 0 for unit in self.unit_numbers}
@@ -343,10 +346,30 @@ class DP16ProcessMonitor:
             self.log("Disconnected from DP16 Process Monitors", LogLevel.INFO)
         else:
             self.log("No active connection to DP16 Process Monitors", LogLevel.INFO)
+        self.flush_queued_logs()
 
     def log(self, message, level=LogLevel.INFO):
         """Log a message with the specified level if a logger is configured."""
-        if self.logger:
+        if not self.logger:
+            print(f"{level.name}: {message}")
+            return
+
+        # Tkinter widgets must only be modified on the main GUI thread.
+        if threading.get_ident() == self._main_thread_ident:
             self.logger.log(message, level)
         else:
-            print(f"{level.name}: {message}")
+            self._log_queue.put((message, level))
+
+    def flush_queued_logs(self, max_messages=200):
+        """Flush queued worker-thread log messages on the calling thread."""
+        if not self.logger:
+            return
+
+        processed = 0
+        while processed < max_messages:
+            try:
+                message, level = self._log_queue.get_nowait()
+            except Empty:
+                break
+            self.logger.log(message, level)
+            processed += 1

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -225,6 +225,8 @@ class ProcessMonitorSubsystem:
     def update_temperatures(self):
         current_time = time.time()
         try:
+            if self.monitor and hasattr(self.monitor, "flush_queued_logs"):
+                self.monitor.flush_queued_logs()
             if not self.monitor:
                 self.log("Checking DP16 monitor connection status", LogLevel.DEBUG)
                 if current_time - self.last_error_time > (self.update_interval / 1000):


### PR DESCRIPTION
<h2>Overview</h2>
Refactors the logging that is done by the daemon thread responsible for polling the PMON CI. Previously, this logging was done from the background thread, which is not best practice with Tkinter. Logging now uses a queue that the background thread pushes logs to, and the main thread flushes this queue every time the Dashboard updates its values.

<h3>New Behavior</h3>

No TclErrors from the "poll_all_units" thread are printed to the console on Dashboard shutdown. Additionally, since the daemon thread closes cleanly, this PR mitigates concerns with the thread holding on to resources, such as COM port.

<h3>Tests Run</h3>

TODO: run a full hardware test, results will be here: https://docs.google.com/document/d/1HeVK_dALBxRzzOwoVtnQJUaDIUz10hf4UFXZV0RhCP8/edit?tab=t.0