### PR TITLE
Bugfix: Interlocks Thread Leak

### DIFF
--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -146,6 +146,11 @@ class G9Driver:
 
             time.sleep(0.1)  # minimum sleep between successful reads
 
+    def stop_thread(self):
+        """Stops the communication thread"""
+        self._running = False
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
 
     def get_interlock_status(self):
         """

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -359,8 +359,9 @@ class InterlocksSubsystem:
         """
         Closes the serial port connection upon quitting the application.
         """
-        self.driver.stop_thread()
-        if self.driver and hasattr(self.driver, 'ser'):
+        if hasattr(self, 'driver') and self.driver:
+            self.driver.stop_thread()
+        if hasattr(self, 'driver') and self.driver and hasattr(self.driver, 'ser'):
             if self.driver.ser and self.driver.ser.is_open:
                 self.driver.ser.close()
                 self.log(f"Closed serial port {self.com_port}", LogLevel.INFO)

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -359,6 +359,7 @@ class InterlocksSubsystem:
         """
         Closes the serial port connection upon quitting the application.
         """
+        self.driver.stop_thread()
         if self.driver and hasattr(self.driver, 'ser'):
             if self.driver.ser and self.driver.ser.is_open:
                 self.driver.ser.close()


### PR DESCRIPTION
<h2>Overview</h2>
Adds clean thread join behavior to the daemon communication thread that updates the Dashboard to reflect the most recent interlocks data from the G9SP.

<h3>New Behavior</h3>

No Exceptions will occur originating from the `communication_thread` in `g9_driver.py`.

<h3>Tests Run</h3>

Full hardware test documented here (pp. 5-7): https://docs.google.com/document/d/1HeVK_dALBxRzzOwoVtnQJUaDIUz10hf4UFXZV0RhCP8/edit?tab=t.0

