### PR TITLE
Bugfix: G9SP Label

### DIFF
--- a/citestfiles/G9Driver/g9driver_test.py
+++ b/citestfiles/G9Driver/g9driver_test.py
@@ -55,7 +55,7 @@ class TestG9Driver(unittest.TestCase):
         self.driver.ser.read_until.return_value = msg_with_checksum
         
         try:
-            sitsf, sitdf, g9Active, _ , _, _, _ = self.driver._process_response(msg_with_checksum)
+            sitsf, sitdf, g9Output, _ , _, _, _ = self.driver._process_response(msg_with_checksum)
             self.assertEqual(len(sitsf), self.driver.NUMIN)
             self.assertEqual(len(sitdf), self.driver.NUMIN)
             self.assertTrue(all(bit == 1 for bit in sitsf))

--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -103,7 +103,7 @@ class G9Driver:
         data = response if response else (
             [0] * self.NUMIN,                    # sitsf_bits
             [0] * self.NUMIN,                    # sitdf_bits
-            0,                                   # g9_active
+            0,                                   # g9_output
             {},                                  # unit_status
             bytearray(10),                       # input_terms
             bytearray(10),                       # output_terms
@@ -258,7 +258,7 @@ class G9Driver:
         unit_flags = {self.US_STATUS[k] : unit_status_flags[k] for k in self.US_STATUS.keys()}
 
         return (binary_data['sitsf'], binary_data['sitdf'],                 # sitsf_bits , sitdf_bits
-                    binary_data['sotsf'][4] & binary_data['sotdf'][4],      # g9_active
+                    binary_data['sotsf'][4] & binary_data['sotdf'][4],      # g9_output
                     unit_flags,                                             # unit_status
                     data[self.SITEC_OFFSET:self.SITEC_OFFSET + 24][-10:],   # input 
                     data[self.SOTEC_OFFSET:self.SOTEC_OFFSET + 16][-10:],   # output

--- a/subsystem/interlocks/README.md
+++ b/subsystem/interlocks/README.md
@@ -52,7 +52,7 @@ The “INDICATORS” dictionary contains the Tkinter indicator components for ea
 
 sitsf_bits - These should always be 1s, if they are not their should be an error being raised, or an input is off
 sitdf_bits - First 11 bits repersent the interlocks, where 1 means good and 0 indicates an off/error, bit 12 repersents the HVOLT which 0 indicates good/error and 1 indicates off, bit 13 represents the enable button's state(thus need to look at the output data so see if that buttom was pressed)
-g9_output - bit 4 of the output data that indicates weather the g9 enable buttom had been pressed previously
+g9_output - bit 4 of the output data that indicates whether the g9 enable buttom had been pressed previously
 
 ### FlowChart
 ```mermaid

--- a/subsystem/interlocks/README.md
+++ b/subsystem/interlocks/README.md
@@ -52,7 +52,7 @@ The “INDICATORS” dictionary contains the Tkinter indicator components for ea
 
 sitsf_bits - These should always be 1s, if they are not their should be an error being raised, or an input is off
 sitdf_bits - First 11 bits repersent the interlocks, where 1 means good and 0 indicates an off/error, bit 12 repersents the HVOLT which 0 indicates good/error and 1 indicates off, bit 13 represents the enable button's state(thus need to look at the output data so see if that buttom was pressed)
-g9_active - bit 4 of the output data that indicates weather the g9 enable buttom had been pressed previously
+g9_output - bit 4 of the output data that indicates weather the g9 enable buttom had been pressed previously
 
 ### FlowChart
 ```mermaid

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -21,7 +21,7 @@ class InterlocksSubsystem:
         9 : "Low Oil", # Oil Low
         10 : "Water", # Water
         11 : "HVolt ON", # HVolt ON
-        12 : "G9SP Active" # G9SP Active
+        12 : "G9_SP Output" # G9_SP Output
     }
 
     INDICATORS = {
@@ -34,7 +34,7 @@ class InterlocksSubsystem:
         'E-STOP Int': None,
         'E-STOP Ext': None,
         'All Interlocks': None,
-        'G9SP Active': None,
+        'G9_SP Output': None,
         'HVolt ON': None
     }
 
@@ -281,7 +281,7 @@ class InterlocksSubsystem:
                         self._adjust_update_interval(success=False)
                         return
                 
-                sitsf_bits, sitdf_bits, g9_active, unit_status, input_terms, output_terms, debug_data = status
+                sitsf_bits, sitdf_bits, g9_output, unit_status, input_terms, output_terms, debug_data = status
 
                 # Log debug data for web monitor
                 self.log(f"Safety Output Terminal Data Flags: {debug_data['sotdf']}", LogLevel.DEBUG)
@@ -338,10 +338,10 @@ class InterlocksSubsystem:
                     self.update_interlock(self.INPUTS[11], True, False)
 
                 # make sure that the data output indicates button and been pressed and the input is not off/error
-                if g9_active == sitsf_bits[12] == 1:
-                    self.update_interlock("G9SP Active", True, all_good)
+                if g9_output == sitsf_bits[12] == 1:
+                    self.update_interlock("G9_SP Output", True, all_good)
                 else:
-                    self.update_interlock("G9SP Active", False, all_good)
+                    self.update_interlock("G9_SP Output", False, all_good)
 
                 self._adjust_update_interval(success=True)
 

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -34,7 +34,7 @@ class InterlocksSubsystem:
         'E-STOP Int': None,
         'E-STOP Ext': None,
         'All Interlocks': None,
-        'G9_SP Output': None,
+        'G9SP Output': None,
         'HVolt ON': None
     }
 

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -21,7 +21,7 @@ class InterlocksSubsystem:
         9 : "Low Oil", # Oil Low
         10 : "Water", # Water
         11 : "HVolt ON", # HVolt ON
-        12 : "G9_SP Output" # G9_SP Output
+        12 : "G9SP Output" # G9SP Output
     }
 
     INDICATORS = {
@@ -339,9 +339,9 @@ class InterlocksSubsystem:
 
                 # make sure that the data output indicates button and been pressed and the input is not off/error
                 if g9_output == sitsf_bits[12] == 1:
-                    self.update_interlock("G9_SP Output", True, all_good)
+                    self.update_interlock("G9SP Output", True, all_good)
                 else:
-                    self.update_interlock("G9_SP Output", False, all_good)
+                    self.update_interlock("G9SP Output", False, all_good)
 
                 self._adjust_update_interval(success=True)
 


### PR DESCRIPTION
The indicator at the top of the dashboard said G9SP Active which was a bit confusing since it should really be G9SP Output