### PR TITLE
Fix for CCS logging and re-add serial lock for power supplies

### DIFF
--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -2,6 +2,7 @@ import serial
 import threading
 import time
 import math
+from queue import Queue, Empty
 from utils import LogLevel
 
 class PowerSupply9104:
@@ -15,6 +16,8 @@ class PowerSupply9104:
         self.timeout = timeout
         self.logger = logger
         self.debug_mode = debug_mode
+        self._main_thread_ident = threading.get_ident()
+        self._log_queue = Queue()
         # self.serial_lock = threading.Lock()
         self.setup_serial()
         self.stop_event = threading.Event()  # Stop flag for threads
@@ -745,9 +748,29 @@ class PowerSupply9104:
             self.log(f"Closed serial port {self.port}", LogLevel.INFO)
         else:
             self.log(f"{self.port} port already closed", LogLevel.INFO)
+        self.flush_queued_logs()
 
     def log(self, message, level=LogLevel.INFO):
-        if self.logger:
+        if not self.logger:
+            print(f"{level.name}: {message}")
+            return
+
+        # Tkinter-backed loggers must only be touched from the main GUI thread.
+        # Queue logs from ramp/background threads and let cathode_heating flush them.
+        if threading.get_ident() == self._main_thread_ident:
             self.logger.log(message, level)
         else:
-            print(f"{level.name}: {message}")
+            self._log_queue.put((message, level))
+
+    def flush_queued_logs(self, max_messages=200):
+        """Flush queued worker-thread log messages on the calling thread."""
+        if not self.logger:
+            return
+        processed = 0
+        while processed < max_messages:
+            try:
+                message, level = self._log_queue.get_nowait()
+            except Empty:
+                break
+            self.logger.log(message, level)
+            processed += 1

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -18,12 +18,18 @@ class PowerSupply9104:
         self.debug_mode = debug_mode
         self._main_thread_ident = threading.get_ident()
         self._log_queue = Queue()
-        # self.serial_lock = threading.Lock()
+        self.serial_lock = threading.Lock()
         self.setup_serial()
         self.stop_event = threading.Event()  # Stop flag for threads
         self.ramp_thread = None  # Track the ramping thread
 
+    # Public serial interface methods with locking to ensure thread safety
     def setup_serial(self):
+        with self.serial_lock:
+            self._setup_serial_unlocked()
+    
+    # The unlocked version of setup_serial, should only be called within a serial_lock context like in setup_serial or update_com_port
+    def _setup_serial_unlocked(self):
         try:
             self.ser = serial.Serial(self.port, self.baudrate, timeout=self.timeout)
             self.log(f"Serial connection established on {self.port}", LogLevel.INFO)
@@ -34,23 +40,37 @@ class PowerSupply9104:
     def update_com_port(self, new_port):
         self.log(f"Updating COM port from {self.port} to {new_port}", LogLevel.INFO)
         
-        # Close existing serial connection if it exists
-        if self.ser is not None:
-            self.ser.close()
-            self.ser = None
+        with self.serial_lock:
+            # Close existing serial connection if it exists
+            if self.ser is not None:
+                self.ser.close()
+                self.ser = None
 
-        self.port = new_port
-        self.setup_serial()
+            self.port = new_port
+            self._setup_serial_unlocked()
+            connected = self.ser is not None
 
-        if self.ser is not None:
+        if connected:
             self.log(f"Successfully updated COM port to {new_port}", LogLevel.INFO)
         else:
             self.log(f"Failed to establish connection on new port {new_port}", LogLevel.ERROR)
 
+    # Thread-safe method to check connection status
     def is_connected(self):
+        with self.serial_lock:
+            return self._is_connected_unlocked()
+
+    # Unlocked version of is_connected, should only be called within a serial_lock context like in is_connected or send_command
+    def _is_connected_unlocked(self):
         return self.ser is not None and self.ser.is_open
 
+    # Thread-safe method to flush serial input buffer
     def flush_serial(self):
+        with self.serial_lock:
+            self._flush_serial_unlocked()
+
+    # Unlocked version of flush_serial, should only be called within a serial_lock context like in flush_serial or send_command
+    def _flush_serial_unlocked(self):
         if self.ser and self.ser.is_open:
             self.log("Flushing serial input buffer", LogLevel.DEBUG)
             self.ser.reset_input_buffer()
@@ -58,46 +78,47 @@ class PowerSupply9104:
             self.log("Serial port is not open. Cannot flush.", LogLevel.WARNING)
 
     def send_command(self, command):
-        """Send a command to the power supply and read the response."""
-        try:
-            if not self.is_connected():
-                self.log("Serial port is not open. Cannot send command.", LogLevel.ERROR)
-                return None # return immediately to prevent blocking GUI on serial read
-            
-            self.flush_serial()
-            
-            self.log(f"Sending command: {command}", LogLevel.DEBUG)
-            self.ser.write(f"{command}\r\n".encode())
-            
-            response = self.ser.read_until(b'\r').decode()
-
-            if 'OK' not in response:
-                additional = self.ser.read_until(b'\r').decode().strip()
-                response = f"{response}\r{additional}"
-
-            if not response:
-                raise ValueError("No response received from 9104 supply")
-            if 'OK' not in response:
-                self.log(f"Acknowledgement not in 9104 supply response")
-
-            self.log(f"Response: {response}", LogLevel.DEBUG)
-                
-            return response.strip()
-        except serial.SerialException as e:
-            self.log(f"Serial error: {e}", LogLevel.ERROR)
-            # Mark port as dead so subsequent calls in this cycle fail fast
+        """Send a command to the power supply and read the response. """
+        with self.serial_lock:
             try:
-                if self.ser:
-                    self.ser.close()
-            except Exception:
-                pass
-            self.ser = None
-            return None
-        except ValueError as e:
-            self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
-            return None
-        except Exception as e:
-            self.log(f"Critical Error", LogLevel.ERROR)
+                if not self._is_connected_unlocked():
+                    self.log("Serial port is not open. Cannot send command.", LogLevel.ERROR)
+                    return None # return immediately to prevent blocking GUI on serial read
+                
+                self._flush_serial_unlocked()
+                
+                self.log(f"Sending command: {command}", LogLevel.DEBUG)
+                self.ser.write(f"{command}\r\n".encode())
+                
+                response = self.ser.read_until(b'\r').decode()
+
+                if 'OK' not in response:
+                    additional = self.ser.read_until(b'\r').decode().strip()
+                    response = f"{response}\r{additional}"
+
+                if not response:
+                    raise ValueError("No response received from 9104 supply")
+                if 'OK' not in response:
+                    self.log(f"Acknowledgement not in 9104 supply response")
+
+                self.log(f"Response: {response}", LogLevel.DEBUG)
+                    
+                return response.strip()
+            except serial.SerialException as e:
+                self.log(f"Serial error: {e}", LogLevel.ERROR)
+                # Mark port as dead so subsequent calls in this cycle fail fast
+                try:
+                    if self.ser:
+                        self.ser.close()
+                except Exception:
+                    pass
+                self.ser = None
+                return None
+            except ValueError as e:
+                self.log(f"Error processing response for command '{command}': {str(e)}", LogLevel.ERROR)
+                return None
+            except Exception as e:
+                self.log(f"Critical Error", LogLevel.ERROR)
 
     def set_output(self, state):
         """Set the output on/off."""
@@ -743,11 +764,12 @@ class PowerSupply9104:
             self.log("Ramping thread terminated.", LogLevel.INFO)
 
         # Close the serial connection
-        if self.ser and self.ser.is_open:
-            self.ser.close()
-            self.log(f"Closed serial port {self.port}", LogLevel.INFO)
-        else:
-            self.log(f"{self.port} port already closed", LogLevel.INFO)
+        with self.serial_lock:
+            if self.ser and self.ser.is_open:
+                self.ser.close()
+                self.log(f"Closed serial port {self.port}", LogLevel.INFO)
+            else:
+                self.log(f"{self.port} port already closed", LogLevel.INFO)
         self.flush_queued_logs()
 
     def log(self, message, level=LogLevel.INFO):

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1696,6 +1696,7 @@ class CathodeHeatingSubsystem:
         # Flush any queued logs from controllers to ensure log is up to date before processing new data
         if self.temperature_controller and hasattr(self.temperature_controller, "flush_queued_logs"):
             self.temperature_controller.flush_queued_logs()
+        # Flush logs for each power supply as well to capture any recent communication issues or status changes before we read new data
         for power_supply in self.power_supplies:
             if power_supply and hasattr(power_supply, "flush_queued_logs"):
                 power_supply.flush_queued_logs()

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1693,8 +1693,12 @@ class CathodeHeatingSubsystem:
         current_time = datetime.datetime.now()
         plot_this_cycle = (current_time - self.last_plot_time) >= self.plot_interval
 
+        # Flush any queued logs from controllers to ensure log is up to date before processing new data
         if self.temperature_controller and hasattr(self.temperature_controller, "flush_queued_logs"):
             self.temperature_controller.flush_queued_logs()
+        for power_supply in self.power_supplies:
+            if power_supply and hasattr(power_supply, "flush_queued_logs"):
+                power_supply.flush_queued_logs()
 
         for i in range(3):
             self.log(f"Processing Cathode {['A', 'B', 'C'][i]}", LogLevel.VERBOSE)


### PR DESCRIPTION
Fix for issue #95. Tkinter does not like when you make GUI changes from background threads. This PR pushes all background thread logging from the 9104 power supply drivers to a queue to be processed and output from the main GUI thread. The strategy used mimics the log changes made by Daniel to CCS E5CN modbus temp drivers in PR#119.

By fixing logging this allowed us to re-introduce the serial lock around all serial communication to the power supply handling any race conditions. Outside of send_command there are three other public helper commands that directly send serial communication to the power supplies (setup_serial, is_connected, flush_serial). Unlocked versions of these helpers were made specifically for when called within the context of a serial_lock in send_command and update_com_ports.

# PR Review Checklist

- [x] Check merging to correct branch
- [x] Confirm latest develop branch has been merged into PR
- [x] Confirm any merge conflicts are resolved
- [x] Confirm you have written (using AI) code logic and hardware tests and drafted clear test results so less human final review needed. Your PR should say where the test document is with results so final review can examine.
- [x] Run new branch code and confirm works when attached to real hardware, document results in a test document for the final reviewer
- [x] In VSCode with Codex/Claude extension make sure you are not committing white space changes:
  - [x] Make sure this branch doesn't have white space, EOL, etc. so that the diff only shows true logic changes and not lines that otherwise look identical apart from white space or hidden characters. Preserve existing line endings and formatting in this file. Do not change LF/CRLF line endings.
- [x] In VSCode with Codex/Claude extension review your own branch with multiple prompts similar to:
  - [x] *"I want your assessment if this code is good to go. Tell me if the code is ready to merge into the develop branch. Is there anything critical that needs to change before merging? Will it break develop in any way? What do the changes in the new code do and are they good changes? Point out any critical errors, in particular logic errors or anything that might break the dashboard. Make sure you do a diff of this branch relative to develop."*
- [x] Run `@codex review` from PR
- [x] Look through questions asked in the conversation and resolve any code questions (highlighting from files changed as needed) or comment why you're not addressing a question
- [x] Review Checks to confirm CI tests pass
- [x] Review entire "Files Changed" manually aided by AI:
  - [x] Confirm that `.gitignore` files were not committed
  - [x] Confirm that no unnecessary development comments were committed
  - [x] Confirm only changes within the scope of this PR were committed
  - [x] Confirm no non-functional unnecessary changes were committed (e.g. needlessly adding extra space or something like that that just pollutes the PR review)
  - [x] Confirm new functional code makes sense
  - [x] Confirm hardware test
- [x] Let the final reviewer know ready for final review
