### PR TITLE
Enable state behavior fix given any STOP case

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -719,12 +719,11 @@ class EBEAMSystemDashboard:
                                 text="ARM BEAMS",
                                 bg="sky blue"
                             )
-                        # Disable beam toggle buttons, enable toggle buttons and reset states
-                        self.update_beam_toggle_states(enabled=False, reset=True)
-                        self._update_enable_toggle_states(enabled=False)
                         self.logger.info("Beams disarmed via Beams E-stop button")
                     else:
                         self.logger.error("Failed to disarm beams via Beams E-stop")
+                self.update_beam_toggle_states(enabled=False, reset=True)
+                self._update_enable_toggle_states(enabled=False)
         except Exception as e:
             self.logger.error(f"Error in handle_beams_off: {str(e)}")
 
@@ -964,8 +963,8 @@ class EBEAMSystemDashboard:
 
     def _update_enable_toggle_states(self, enabled=True):
         """Enable or disable the CH Enable toggle buttons based on armed status.
-        When disabling (disarmed / E-STOP), preserve the last hardware-backed
-        Enabled/Disabled appearance but prevent interaction.
+        When disabling, mirror the firmware safety contract: all channel
+        enable latches are cleared by STOP/disconnect paths.
         """
         try:
             if not hasattr(self, 'enable_toggle_buttons'):
@@ -975,7 +974,13 @@ class EBEAMSystemDashboard:
                     btn.config(state="normal")
                 else:
                     # Disarmed — force all to Disabled appearance and reset tracking
-                    btn.config(state="disabled")
+                    if hasattr(self, '_ch_enable_states') and i < len(self._ch_enable_states):
+                        self._ch_enable_states[i] = False
+                    btn.config(
+                        state="disabled",
+                        bg="#888888",
+                        text=f"CH {channel_label(i)}: Disabled",
+                    )
         except Exception as e:
             self.logger.error(f"Error updating enable toggle states: {str(e)}")
 

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -966,6 +966,12 @@ class BeamPulseSubsystem:
         if typ == "connected":
             ok = msg[1]
             self.bcon_connection_status = ok
+            if not ok:
+                self.beams_armed_status = False
+                self.beam_on_status = [False, False, False]
+                self._active_channels.clear()
+                self._update_armed_button_states(False)
+                self._notify_all_channel_enables(False)
             self.update_bcon_connection_status()
         elif typ == "regs":
             regs = msg[1]
@@ -1395,6 +1401,18 @@ class BeamPulseSubsystem:
         """Register callback(ch, enabled) invoked on every register poll."""
         self._channel_enable_status_callback = callback
 
+    def _notify_all_channel_enables(self, enabled: bool) -> None:
+        """Mirror a known all-channel enable state to dashboard controls."""
+        if self.bcon_driver:
+            self.bcon_driver.reset_channel_enable_cache(enabled)
+        if not callable(getattr(self, '_channel_enable_status_callback', None)):
+            return
+        for ch in range(3):
+            try:
+                self._channel_enable_status_callback(ch, enabled)
+            except Exception:
+                pass
+
     def set_dashboard_beam_callback(self, callback):
         self._dashboard_beam_callback = callback
         self._log("Dashboard beam callback registered", LogLevel.DEBUG)
@@ -1427,8 +1445,8 @@ class BeamPulseSubsystem:
         self.beam_on_status = [False, False, False]
         self._active_channels.clear()
         self._update_armed_button_states(False)
+        self._notify_all_channel_enables(False)
         if self.bcon_driver:
-            self.bcon_driver.reset_channel_enable_cache()
             self.bcon_driver.disconnect()
 
     def close_com_ports(self) -> None:
@@ -1472,6 +1490,7 @@ class BeamPulseSubsystem:
     def stop_all_channels(self) -> bool:
         if self.bcon_driver:
             self.bcon_driver.stop_all()
+            self._notify_all_channel_enables(False)
             return True
         return False
 
@@ -1489,6 +1508,7 @@ class BeamPulseSubsystem:
         self.set_all_beams_status(False)
         if self.bcon_driver:
             self.bcon_driver.stop_all()
+        self._notify_all_channel_enables(False)
         self._log("Beams DISARMED", LogLevel.INFO)
         self._update_armed_button_states(False)
         return True


### PR DESCRIPTION
Fix for issue #107. During testing it was noted that the enable state buttons were not correctly updating to match any E-STOP condition. This was a result of firmware killing pulser output manually without also clearing the enable state latch register for all channels. This PR facilitates the expected GUI behavior with the firmware bugfix.

# PR Review Checklist

- [x] Check merging to correct branch
- [x] Confirm latest develop branch has been merged into PR
- [x] Confirm any merge conflicts are resolved
- [x] Confirm you have written (using AI) code logic and hardware tests and drafted clear test results so less human final review needed. Your PR should say where the test document is with results so final review can examine.
- [x] Run new branch code and confirm works when attached to real hardware, document results in a test document for the final reviewer
- [x] In VSCode with Codex/Claude extension make sure you are not committing white space changes:
  - [x] Make sure this branch doesn't have white space, EOL, etc. so that the diff only shows true logic changes and not lines that otherwise look identical apart from white space or hidden characters. Preserve existing line endings and formatting in this file. Do not change LF/CRLF line endings.
- [x] In VSCode with Codex/Claude extension review your own branch with multiple prompts similar to:
  - [x] *"I want your assessment if this code is good to go. Tell me if the code is ready to merge into the develop branch. Is there anything critical that needs to change before merging? Will it break develop in any way? What do the changes in the new code do and are they good changes? Point out any critical errors, in particular logic errors or anything that might break the dashboard. Make sure you do a diff of this branch relative to develop."*
- [x] Run `@codex review` from PR
- [x] Look through questions asked in the conversation and resolve any code questions (highlighting from files changed as needed) or comment why you're not addressing a question
- [x] Review Checks to confirm CI tests pass
- [x] Review entire "Files Changed" manually aided by AI:
  - [x] Confirm that `.gitignore` files were not committed
  - [x] Confirm that no unnecessary development comments were committed
  - [x] Confirm only changes within the scope of this PR were committed
  - [x] Confirm no non-functional unnecessary changes were committed (e.g. needlessly adding extra space or something like that that just pollutes the PR review)
  - [x] Confirm new functional code makes sense
  - [x] Confirm hardware test
- [x] Let the final reviewer know ready for final review