### PR TITLE
Bugfix: Cathode Logger Schema check

### DIFF
--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -460,6 +460,22 @@ class TestDictLoggerFieldManagement(unittest.TestCase):
         self.assertIn("nonexistent_field", str(ctx.exception))
         self.assertIn("is not a valid key", str(ctx.exception))
 
+    def test_update_field_rejects_cathode_key_without_corrupting_schema(self):
+        with self.assertRaises(KeyError) as ctx:
+            self.logger.update_field("cathode", None)
+        self.assertIn("cathode", str(ctx.exception))
+        self.assertIn("update_cathode_field", str(ctx.exception))
+
+        self.assertIsInstance(self.logger.dict_logger["cathode"], dict)
+        self.logger.update_cathode_field("A", "clamp_temperature", 42.0)
+        self.assertEqual(self.logger.dict_logger["cathode"]["A"]["clamp_temperature"], 42.0)
+
+    def test_update_cathode_field_raises_clear_error_for_corrupted_cathode_schema(self):
+        self.logger.dict_logger["cathode"] = None
+        with self.assertRaises(TypeError) as ctx:
+            self.logger.update_cathode_field("A", "clamp_temperature", 42.0)
+        self.assertIn("cathode schema is corrupted", str(ctx.exception))
+
     def test_clear_value_sets_field_to_none(self):
         self.logger.dict_logger["pressure"] = 5.0
         self.logger.clear_value("pressure")

--- a/utils.py
+++ b/utils.py
@@ -147,6 +147,8 @@ class Logger:
             except Exception as e:
                 print(f"Error writing to log file: {str(e)}")   
     def update_field(self, field, value):
+        if field == "cathode":
+            raise KeyError("'cathode' cannot be updated with update_field; use update_cathode_field for cathode subfields.")
         if field in self.dict_logger:
             self.dict_logger[field] = value
             self.log_dict_update(self.dict_logger)
@@ -154,6 +156,8 @@ class Logger:
             raise KeyError(f"'{field}' is not a valid key in status dict.")
     def update_cathode_field(self, cathode_label, subfield, value):
         cathode = self.dict_logger["cathode"]
+        if not isinstance(cathode, dict):
+            raise TypeError("Logger cathode schema is corrupted; expected 'cathode' to be a dict.")
         if cathode_label not in cathode:
             raise KeyError(f"'{cathode_label}' is not a valid cathode label. Expected one of {list(cathode.keys())}.")
         if subfield not in cathode[cathode_label]:


### PR DESCRIPTION
This PR addresses Issue #123 . It has very simple changes to utils:
1. Adds check that prevents field == "cathode" in update_field(). update_cathode_field() should be used instead.
2. Adds check that ensures the "cathode" dict has not been corrupted.
3. Adds a regression test that tests the above two changes. 