### PR TITLE
Bugfix: CCS Invalid Temperature Readings

### DIFF
--- a/citestfiles/CathodeHeating/read_temperature_test.py
+++ b/citestfiles/CathodeHeating/read_temperature_test.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from subsystem.cathode_heating.cathode_heating import CathodeHeatingSubsystem
+
+
+class FakeStringVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def set(self, value):
+        self.value = value
+
+
+class TestReadTemperature(unittest.TestCase):
+    def setUp(self):
+        self.subsys = object.__new__(CathodeHeatingSubsystem)
+        self.subsys.temperature_controller = MagicMock()
+        self.subsys.temperature_controller.connected = True
+        self.subsys.clamp_temperature_vars = [FakeStringVar("--") for _ in range(3)]
+        self.subsys.set_plot_color = MagicMock()
+        self.subsys.log = MagicMock()
+
+    def test_cached_string_error_displays_err_without_fallthrough(self):
+        self.subsys.temperature_controller.temperatures = ["ERROR", None, None]
+
+        temperature = self.subsys.read_temperature(0)
+
+        self.assertIsNone(temperature)
+        self.assertEqual(self.subsys.clamp_temperature_vars[0].value, "ERR")
+        self.subsys.set_plot_color.assert_called_once_with(0, 'ERROR')
+
+    def test_missing_temperature_data_displays_blank_reading(self):
+        self.subsys.temperature_controller.temperatures = [None, None, None]
+
+        temperature = self.subsys.read_temperature(0)
+
+        self.assertIsNone(temperature)
+        self.assertEqual(self.subsys.clamp_temperature_vars[0].value, "-- C")
+        self.subsys.set_plot_color.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/citestfiles/E5CNModbus/E5CNModbus_test.py
+++ b/citestfiles/E5CNModbus/E5CNModbus_test.py
@@ -70,6 +70,23 @@ class TestE5CNModbus(unittest.TestCase):
             slave=1
         )
 
+    def test_read_temperature_above_hard_max_returns_error(self):
+        """Test impossible E5CN readings are reported as sensor errors."""
+        mock_response = MagicMock()
+        mock_response.isError.return_value = False
+        mock_response.registers = [0, 13000]  # Represents 1300.0 C
+
+        self.device.client.is_socket_open.return_value = True
+        self.device.client.read_holding_registers.return_value = mock_response
+
+        temperature = self.device.read_temperature(1)
+
+        self.assertEqual(temperature, self.device.SENSOR_ERROR)
+        self.assertTrue(any(
+            "exceeds hard maximum" in str(call)
+            for call in self.mock_logger.log.call_args_list
+        ))
+
     def test_read_temperature_connection_retry(self):
         """Test temperature reading with connection retry"""
 

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import math
 from queue import Queue, Empty
 from pymodbus.client import ModbusSerialClient as ModbusClient
 from utils import LogLevel  # Ensure this module is correctly implemented
@@ -7,6 +8,8 @@ from utils import LogLevel  # Ensure this module is correctly implemented
 class E5CNModbus:
     TEMPERATURE_ADDRESS = 0x0000  # Address for reading temperature, page 92
     UNIT_NUMBERS = [1, 2, 3]       # Unit numbers for each controller
+    MAX_VALID_TEMPERATURE_C = 999.9
+    SENSOR_ERROR = "ERROR"
 
     def __init__(self, port, baudrate=9600, timeout=1, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
         """
@@ -85,10 +88,18 @@ class E5CNModbus:
         while not self.stop_event.is_set():
             try:
                 temperature = self.read_temperature(unit)
-                if temperature is not None:
+                if isinstance(temperature, (int, float)):
                     with self.temperatures_lock:
                         self.temperatures[unit - 1] = temperature
                         self.log(f"Unit {unit} Temperature: {temperature} C", LogLevel.INFO)
+                elif temperature == self.SENSOR_ERROR:
+                    with self.temperatures_lock:
+                        self.temperatures[unit - 1] = temperature
+                    self.log(f"Unit {unit} temperature reading is invalid", LogLevel.ERROR)
+                elif temperature is not None:
+                    with self.temperatures_lock:
+                        self.temperatures[unit - 1] = temperature
+                    self.log(f"Unit {unit} returned unexpected temperature value: {temperature}", LogLevel.ERROR)
                 else:
                     self.log(f"Unit {unit} is reading null", LogLevel.ERROR)
                 time.sleep(0.5)  # small delay between reads
@@ -189,12 +200,19 @@ class E5CNModbus:
                     if response and not response.isError():
                         self.connected = True
                         temperature = response.registers[1] / 10.0
+                        if not math.isfinite(temperature) or temperature > self.MAX_VALID_TEMPERATURE_C:
+                            self.log(
+                                f"Invalid temperature from unit {unit}: {temperature:.2f} C "
+                                f"exceeds hard maximum {self.MAX_VALID_TEMPERATURE_C:.2f} C",
+                                LogLevel.ERROR
+                            )
+                            return self.SENSOR_ERROR
                         self.log(f"Temperature from unit {unit}: {temperature:.2f} C", LogLevel.INFO)
                         return temperature
                     else:
                         self.log(f"Error reading temperature from unit {unit}: {response}", LogLevel.ERROR)
                         attempts -= 1
-                        return "ERROR"
+                        return self.SENSOR_ERROR
 
             except Exception as e:
                 self.log(f"Unexpected error for unit {unit}: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1680,7 +1680,7 @@ class CathodeHeatingSubsystem:
                 elif isinstance(temperature, str):
                     self.clamp_temperature_vars[index].set("ERR")
                     self.set_plot_color(index, 'ERROR')
-                    self.log(f"Reading temperature for cathode {index+1} returned an error",
+                    self.log(f"Reading temperature for cathode {index+1} returned an error: {temperature}",
                               LogLevel.ERROR)
                 else:
                     self.log(f"No temperature data for cathode {index+1}", LogLevel.WARNING)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1703,6 +1703,7 @@ class CathodeHeatingSubsystem:
                     self.set_plot_color(index, 'ERROR')
                     self.log(f"Reading temperature for cathode {index+1} returned an error: {temperature}",
                               LogLevel.ERROR)
+                    return None
                 else:
                     self.log(f"No temperature data for cathode {index+1}", LogLevel.WARNING)
             except Exception as e:

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1656,7 +1656,18 @@ class CathodeHeatingSubsystem:
             try:
                 # Attempt to read temperature from the connected temperature controller
                 temperature = self.temperature_controller.temperatures[index]
-                if isinstance(temperature, float):
+                if isinstance(temperature, (int, float)):
+                    temperature = float(temperature)
+                    if temperature > E5CNModbus.MAX_VALID_TEMPERATURE_C:
+                        self.clamp_temperature_vars[index].set("ERR")
+                        self.set_plot_color(index, 'ERROR')
+                        self.log(
+                            f"Invalid temperature for cathode {index+1}: {temperature:.2f} C "
+                            f"exceeds hard maximum {E5CNModbus.MAX_VALID_TEMPERATURE_C:.2f} C",
+                            LogLevel.ERROR
+                        )
+                        return None
+
                     self.clamp_temperature_vars[index].set(f"{temperature:.2f} C")
 
                     # Check for overtemperature condition
@@ -1667,7 +1678,7 @@ class CathodeHeatingSubsystem:
 
                     return temperature
                 elif isinstance(temperature, str):
-                    self.clamp_temperature_vars[index].set("-- C")
+                    self.clamp_temperature_vars[index].set("ERR")
                     self.set_plot_color(index, 'ERROR')
                     self.log(f"Reading temperature for cathode {index+1} returned an error",
                               LogLevel.ERROR)
@@ -1775,12 +1786,6 @@ class CathodeHeatingSubsystem:
 
             if isinstance(temperature, float):
                 self.clamp_temperature_vars[i].set(f"{temperature:.2f} C")
-            elif isinstance(temperature, str):
-                self.clamp_temperature_vars[i].set("-- C")
-                self.clamp_temp_labels[i].config(foreground='oragne')
-            else:
-                self.clamp_temperature_vars[i].set("-- C")
-                self.clamp_temp_labels[i].config(foreground='black')
 
             if plot_this_cycle:
                 self.time_data[i] = np.append(self.time_data[i], current_time)


### PR DESCRIPTION
This PR addresses issue #118 . Previously if the E5CN temperature sensors were not properly hooked up to the thermocouple they could return ~1300 degrees instead of Err. This messes up graphing and visual displays. 

This PR sets a max temperature value that if exceeded returns ERR and displays '--' instead of the invalid temperature. This PR also adds a unit test in E5CNModbus_test.py to test to see that this works properly. 

