### PR TITLE
Normalize BeamPulse COM port key

### DIFF
--- a/citestfiles/startup_logging_test.py
+++ b/citestfiles/startup_logging_test.py
@@ -9,11 +9,7 @@ from unittest.mock import MagicMock, patch
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from utils import Logger, LogLevel
-from usr.com_port_config import (
-    get_beam_pulse_com_port,
-    load_com_ports,
-    save_com_ports,
-)
+from usr.com_port_config import load_com_ports, save_com_ports
 from usr.panel_config import load_pane_states
 
 TEST_TMP_ROOT = os.path.join(os.path.dirname(__file__), "_tmp")
@@ -127,22 +123,6 @@ class TestComPortConfigLogging(unittest.TestCase):
         self.assertEqual(loaded, {})
         self.assertIn("Error loading COM ports", logger.error.call_args[0][0])
         mock_print.assert_not_called()
-
-    def test_get_beam_pulse_com_port_prefers_canonical_key(self):
-        com_ports = {
-            "BeamPulse": "COM7",
-            "Beam Pulse": "COM8",
-        }
-
-        self.assertEqual(get_beam_pulse_com_port(com_ports), "COM7")
-
-    def test_get_beam_pulse_com_port_accepts_legacy_key(self):
-        com_ports = {"Beam Pulse": "COM8"}
-
-        self.assertEqual(get_beam_pulse_com_port(com_ports), "COM8")
-
-    def test_get_beam_pulse_com_port_defaults_to_blank(self):
-        self.assertEqual(get_beam_pulse_com_port({}), "")
 
 class TestPanelConfigLogging(unittest.TestCase):
     def setUp(self):

--- a/dashboard.py
+++ b/dashboard.py
@@ -7,7 +7,6 @@ from tkinter import ttk
 from tkinter import messagebox
 import time
 from utils import MessagesFrame, SetupScripts, LogLevel, MachineStatus
-from usr.com_port_config import get_beam_pulse_com_port
 from usr.panel_config import save_pane_states, load_pane_states
 import serial.tools.list_ports
 
@@ -1045,7 +1044,7 @@ class EBEAMSystemDashboard:
 
         # Beam Pulse subsystem (BCON)
         try:
-            bp_port = get_beam_pulse_com_port(self.com_ports)
+            bp_port = self.com_ports.get('BeamPulse', '')
             # Host Beam Pulse UI inside the merged pane
             parent = self.frames.get('Beam Steering/Pulse', self.frames.get('Beam Pulse'))
             beam_pulse_subsystem = subsystem.BeamPulseSubsystem(
@@ -1194,7 +1193,7 @@ class EBEAMSystemDashboard:
             frame = ttk.Frame(self.com_port_menu)
             frame.pack(fill=tk.X, padx=5, pady=2)
             ttk.Label(frame, text="Beam Pulse:").pack(side=tk.LEFT)
-            port_var = tk.StringVar(value=get_beam_pulse_com_port(self.com_ports))
+            port_var = tk.StringVar(value=self.com_ports.get('BeamPulse', ''))
             self.port_selections['BeamPulse'] = port_var
             dropdown = ttk.Combobox(frame, textvariable=port_var)
             dropdown.pack(side=tk.RIGHT)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from tkinter import ttk, messagebox
 import serial.tools.list_ports
 
 from dashboard import EBEAMSystemDashboard
-from usr.com_port_config import get_beam_pulse_com_port, save_com_ports, load_com_ports
+from usr.com_port_config import save_com_ports, load_com_ports
 from utils import Logger, LogLevel
 
 
@@ -247,11 +247,7 @@ def config_com_ports(saved_com_ports, logger=None):
         label.pack(side=tk.LEFT, padx=(0, 10))
 
         # Default to a previously saved port if available, otherwise blank
-        if subsystem == 'BeamPulse':
-            saved_port = get_beam_pulse_com_port(saved_com_ports)
-        else:
-            saved_port = saved_com_ports.get(subsystem, '')
-        selected_port = tk.StringVar(value=saved_port)
+        selected_port = tk.StringVar(value=saved_com_ports.get(subsystem, ''))
 
         combobox = ttk.Combobox(
             frame, 

--- a/usr/com_port_config.py
+++ b/usr/com_port_config.py
@@ -4,11 +4,6 @@ import os
 
 CONFIG_FILE = 'usr/usr_data/com_ports.json'
 
-
-def get_beam_pulse_com_port(com_ports):
-    """Return the Beam Pulse COM port, accepting the legacy display key."""
-    return com_ports.get('BeamPulse', com_ports.get('Beam Pulse', ''))
-
 def save_com_ports(com_ports, filepath=CONFIG_FILE, logger=None):
     """Save COM port selections to a JSON file."""
     os.makedirs(os.path.dirname(filepath), exist_ok=True)


### PR DESCRIPTION
## Summary

- Removes legacy `"Beam Pulse"` COM-port key compatibility.
- Uses `BeamPulse` as the single canonical saved config key in startup and dashboard COM-port handling.
- Keeps the dashboard label readable while storing selections under `BeamPulse`.
- Removes tests that existed only for the legacy fallback helper.

## Why

The branch was carrying a special compatibility helper for an old key shape that we no longer want to support. This keeps the COM-port config path consistent with `main.py`'s existing `SUBSYSTEMS` key, `BeamPulse`, instead of preserving two spellings.

## Validation

- Passed: focused `BeamPulse` save/load round-trip check.
- Passed: `python -m py_compile usr/com_port_config.py main.py dashboard.py citestfiles/startup_logging_test.py`.
- Passed: `git diff --check`.
- Blocked: `python -m unittest citestfiles.startup_logging_test` fails during import because this Python environment is missing `matplotlib`, imported by `utils.py` before the tests run (`ModuleNotFoundError: No module named 'matplotlib'`).