### PR TITLE
Feature: Laser Monitor Integration

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -18,6 +18,11 @@ def resource_path(relative_path):
     return os.path.join(base_path, relative_path)
 
 
+def _is_configured_real_com_port(port):
+    port_text = str(port or "").strip()
+    return bool(port_text) and not port_text.upper().startswith("DUMMY_COM")
+
+
 # Total row width = 1916. Vertical guides (from left):
 #   x = w_be     — Oil | Process Monitor  lines up with  Beam Energy | Cathode Heating
 #   x = w_bp     — Process Monitor | Messages  lines up with  Beam Pulse | Main Control
@@ -439,13 +444,14 @@ class EBEAMSystemDashboard:
             self.main_control.wire_beam_energy(self.subsystems.get('Beam Energy'))
 
         laser_monitor_port = str(self.com_ports.get('Laser Monitor', '') or '').strip()
-        try:
-            self.subsystems['Laser Monitor'] = LaserMonitorDriver(laser_monitor_port)
-            self.logger.info(f"Laser Monitor driver started for port {laser_monitor_port}")
-        except Exception as e:
+        if _is_configured_real_com_port(laser_monitor_port):
+            try:
+                self.subsystems['Laser Monitor'] = LaserMonitorDriver(laser_monitor_port)
+                self.logger.info(f"Laser Monitor driver started for port {laser_monitor_port}")
+            except Exception as e:
                 self.logger.error(f"Failed to start Laser Monitor driver on port {laser_monitor_port}: {e}")
         else:
-            self.logger.info("Laser Monitor driver not started; no COM port configured")
+            self.logger.info("Laser Monitor driver not started; no real COM port configured")
 
         # Beam Pulse subsystem (BCON)
         try:
@@ -461,6 +467,13 @@ class EBEAMSystemDashboard:
             )
 
             self.subsystems['Beam Pulse'] = beam_pulse_subsystem
+            laser_monitor = self.subsystems.get('Laser Monitor')
+            if (
+                laser_monitor is not None
+                and hasattr(laser_monitor, 'set_beams_on')
+                and hasattr(beam_pulse_subsystem, 'set_beam_activity_callback')
+            ):
+                beam_pulse_subsystem.set_beam_activity_callback(laser_monitor.set_beams_on)
             if hasattr(self, "main_control"):
                 self.main_control.subsystems = self.subsystems
                 self.main_control.wire_beam_pulse(beam_pulse_subsystem)

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,6 +3,7 @@ import os
 import subsystem
 import tkinter as tk
 from tkinter import ttk
+from instrumentctl.laser_monitor import LaserMonitorDriver
 from subsystem.main_control import MainControlPanel
 from utils import MessagesFrame, MachineStatus
 from usr.panel_config import save_pane_states, load_pane_states
@@ -436,6 +437,15 @@ class EBEAMSystemDashboard:
         if hasattr(self, "main_control"):
             self.main_control.subsystems = self.subsystems
             self.main_control.wire_beam_energy(self.subsystems.get('Beam Energy'))
+
+        laser_monitor_port = str(self.com_ports.get('Laser Monitor', '') or '').strip()
+        try:
+            self.subsystems['Laser Monitor'] = LaserMonitorDriver(laser_monitor_port)
+            self.logger.info(f"Laser Monitor driver started for port {laser_monitor_port}")
+        except Exception as e:
+                self.logger.error(f"Failed to start Laser Monitor driver on port {laser_monitor_port}: {e}")
+        else:
+            self.logger.info("Laser Monitor driver not started; no COM port configured")
 
         # Beam Pulse subsystem (BCON)
         try:

--- a/dashboard.py
+++ b/dashboard.py
@@ -18,11 +18,6 @@ def resource_path(relative_path):
     return os.path.join(base_path, relative_path)
 
 
-def _is_configured_real_com_port(port):
-    port_text = str(port or "").strip()
-    return bool(port_text) and not port_text.upper().startswith("DUMMY_COM")
-
-
 # Total row width = 1916. Vertical guides (from left):
 #   x = w_be     — Oil | Process Monitor  lines up with  Beam Energy | Cathode Heating
 #   x = w_bp     — Process Monitor | Messages  lines up with  Beam Pulse | Main Control
@@ -444,14 +439,25 @@ class EBEAMSystemDashboard:
             self.main_control.wire_beam_energy(self.subsystems.get('Beam Energy'))
 
         laser_monitor_port = str(self.com_ports.get('Laser Monitor', '') or '').strip()
-        if _is_configured_real_com_port(laser_monitor_port):
-            try:
-                self.subsystems['Laser Monitor'] = LaserMonitorDriver(laser_monitor_port)
-                self.logger.info(f"Laser Monitor driver started for port {laser_monitor_port}")
-            except Exception as e:
+        try:
+            self.subsystems['Laser Monitor'] = LaserMonitorDriver(laser_monitor_port)
+            self.logger.info(f"Laser Monitor driver started for port {laser_monitor_port}")
+        except Exception as e:
                 self.logger.error(f"Failed to start Laser Monitor driver on port {laser_monitor_port}: {e}")
         else:
             self.logger.info("Laser Monitor driver not started; no real COM port configured")
+
+        beam_energy = self.subsystems.get('Beam Energy')
+        laser_monitor = self.subsystems.get('Laser Monitor')
+        if (
+            beam_energy is not None
+            and laser_monitor is not None
+            and hasattr(beam_energy, 'set_radiation_indicator_callback')
+            and hasattr(laser_monitor, 'set_radiation_indicator')
+        ):
+            beam_energy.set_radiation_indicator_callback(
+                laser_monitor.set_radiation_indicator
+            )
 
         # Beam Pulse subsystem (BCON)
         try:

--- a/instrumentctl/laser_monitor/README.md
+++ b/instrumentctl/laser_monitor/README.md
@@ -1,0 +1,1 @@
+# laser-monitor-driver

--- a/instrumentctl/laser_monitor/README.md
+++ b/instrumentctl/laser_monitor/README.md
@@ -1,1 +1,142 @@
-# laser-monitor-driver
+# Laser Monitor Driver
+
+Dashboard-side USB serial driver for the EBEAM Laser Monitor indicator.
+
+This module complements the `ebeam-laser-monitor` Arduino firmware. The
+firmware drives the physical radiation and beams-on indicator outputs; this
+dashboard driver owns the host-side serial connection, periodically verifies
+that the Arduino is alive, and sends state changes from the dashboard
+subsystems.
+
+## System Overview
+
+The Laser Monitor system has two parts:
+
+- `ebeam-laser-monitor` firmware runs on an Arduino Uno and drives two digital
+  outputs:
+  - radiation indicator
+  - beams-on indicator
+- `instrumentctl.laser_monitor` runs in the dashboard process and communicates
+  with the Arduino over USB serial.
+
+The dashboard creates `LaserMonitorDriver(port)` using the configured `Laser
+Monitor` COM port. Once started, the driver runs a background worker thread that
+owns all serial I/O. Dashboard callbacks only update desired state; they do not
+write directly to the serial port.
+
+Current dashboard wiring:
+
+- `Beam Energy` calls `set_radiation_indicator(active)` when the +20 kV readback
+  crosses the radiation indicator threshold.
+- `Beam Pulse` calls `set_beams_on(active)` when any live beam pulse channel is
+  active.
+
+## Runtime Dependency
+
+The driver requires `pyserial`:
+
+```powershell
+python -m pip install pyserial
+```
+
+If `pyserial` is not installed, constructing `LaserMonitorDriver` raises a
+runtime error with the same install command.
+
+## Serial Settings
+
+The driver opens the Arduino USB serial port with the settings expected by the
+firmware:
+
+| Setting | Value |
+| --- | --- |
+| Baud rate | `9600` |
+| Data bits | `8` |
+| Parity | `None` |
+| Stop bits | `1` |
+| Read timeout | `0.25 s` |
+| Write timeout | `0.5 s` |
+| Line ending | `\n` |
+| Encoding | ASCII |
+
+Opening an Arduino Uno serial port resets the board, so the driver waits `2.0 s`
+after connecting before flushing serial buffers and starting normal polling.
+
+## Communication Protocol
+
+All messages are ASCII and newline-delimited. The driver uses a strict
+request/response exchange: every command must receive the expected response, or
+the connection is treated as unhealthy and the worker reconnects.
+
+### Poll
+
+Sent every `0.5 s`:
+
+```text
+PING
+```
+
+Expected response:
+
+```text
+PONG
+```
+
+Successful polls set `is_connected()` to `True`.
+
+### State Update
+
+Sent after reconnect and whenever either desired indicator value changes:
+
+```text
+STATE beams=<0|1> radiation=<0|1>
+```
+
+Expected response:
+
+```text
+OK
+```
+
+Examples:
+
+```text
+STATE beams=0 radiation=0
+STATE beams=1 radiation=0
+STATE beams=0 radiation=1
+STATE beams=1 radiation=1
+```
+
+## Driver Lifecycle
+
+`LaserMonitorDriver(port)` starts its worker thread immediately.
+
+Public API:
+
+- `set_beams_on(active)` updates the desired beams-on indicator state.
+- `set_radiation_indicator(active)` updates the desired radiation indicator
+  state.
+- `is_connected()` reports whether the most recent poll exchange succeeded.
+- `last_error` returns the most recent connection or protocol error text.
+- `disconnect()`, `close()`, and `close_com_ports()` stop the worker and close
+  the serial port.
+
+On disconnect, the driver first attempts to send `beams=0` while preserving the
+last desired radiation indicator state. This leaves the physical beams-on
+indicator off during dashboard shutdown when the Arduino is still reachable.
+
+## Reconnect and Failure Behavior
+
+The worker handles serial failures without blocking dashboard callbacks:
+
+1. If the port is closed or a transaction fails, mark the driver disconnected.
+2. Close the serial object.
+3. Reconnect with exponential backoff from `0.5 s` up to `5.0 s`.
+4. After a successful reconnect, send the latest desired state again.
+
+Unexpected responses, missing responses, write failures, and decode issues are
+recorded in `last_error`.
+
+The firmware also has its own dashboard communication watchdog. If it receives
+no valid dashboard message for 4 seconds, it forces only the beams-on output LOW
+and leaves the radiation indicator unchanged. The driver therefore polls every
+500 ms to keep the firmware watchdog satisfied during normal operation.

--- a/instrumentctl/laser_monitor/__init__.py
+++ b/instrumentctl/laser_monitor/__init__.py
@@ -1,0 +1,5 @@
+from .laser_monitor_driver import LaserMonitorDriver
+
+__all__ = [
+    "LaserMonitorDriver",
+]

--- a/instrumentctl/laser_monitor/laser-monitor-driver.py
+++ b/instrumentctl/laser_monitor/laser-monitor-driver.py
@@ -1,0 +1,1 @@
+# laser monitor

--- a/instrumentctl/laser_monitor/laser-monitor-driver.py
+++ b/instrumentctl/laser_monitor/laser-monitor-driver.py
@@ -1,1 +1,0 @@
-# laser monitor

--- a/instrumentctl/laser_monitor/laser_monitor_driver.py
+++ b/instrumentctl/laser_monitor/laser_monitor_driver.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import threading
+import time
+
+# Laser Monitor driver
+#
+# This driver talks to an Arduino Uno over USB serial. The Arduino drives the physical
+# beam/laser indicator LEDs. The dashboard will later call set_beams_on() and set_voltage_active();
+
+try:
+    import serial
+except ImportError:  # pragma: no cover - handled at runtime with a clear error
+    serial = None
+
+
+# Serial timing and reconnect settings
+BAUDRATE = 9600
+POLL_INTERVAL_SECONDS = 0.5
+SERIAL_TIMEOUT_SECONDS = 0.25
+WRITE_TIMEOUT_SECONDS = 0.5
+ARDUINO_BOOT_DELAY_SECONDS = 2.0
+RECONNECT_BACKOFF_INITIAL_SECONDS = 0.5
+RECONNECT_BACKOFF_MAX_SECONDS = 5.0
+THREAD_JOIN_TIMEOUT_SECONDS = 2.0
+
+# Line-delimited ASCII protocol:
+#   Host -> Arduino:  PING
+#   Arduino -> Host:  PONG
+#   Host -> Arduino:  STATE beams=<0|1> voltage=<0|1>
+#   Arduino -> Host:  OK
+PING_COMMAND = "PING\n"
+PONG_RESPONSE = "PONG"
+STATE_OK_RESPONSE = "OK"
+ENCODING = "ascii"
+
+
+class LaserMonitorProtocolError(RuntimeError):
+    """Raised when the Arduino returns an unexpected serial response."""
+
+
+class LaserMonitorDriver:
+    """
+    USB-serial driver for the Arduino Laser Monitor indicator.
+
+    The worker thread owns all serial I/O. Public setters only update desired
+    state; the worker pushes the latest state to the Arduino after successful
+    communication polling.
+    """
+
+    def __init__(self, port):
+        if serial is None:
+            raise RuntimeError(
+                "pyserial is not installed. Install with: python -m pip install pyserial"
+            )
+
+        self.port = port
+        self._serial = None
+
+        # Locks split responsibility:
+        # - serial lock: protects the pyserial object
+        # - state lock: protects desired dashboard state
+        # - status lock: protects connection/error status read by other threads
+        self._serial_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._status_lock = threading.Lock()
+
+        # Desired output state. These values are updated by public setters and
+        # sent by the worker thread after a successful communication poll.
+        self._beams_on = False
+        self._voltage_active = False
+        self._last_sent_state = None
+
+        # Status state. These values are intentionally separate from desired
+        # output state so callers can distinguish "what should be displayed"
+        # from "is the Arduino currently reachable".
+        self._connected = False
+        self._last_error = None
+
+        # One worker thread owns all serial I/O. This avoids direct serial
+        # writes from Tk callbacks or future dashboard status handlers.
+        self._stop_event = threading.Event()
+        self._worker_thread = threading.Thread(
+            target=self._worker_loop,
+            name=f"LaserMonitorDriver[{self.port}]",
+            daemon=True,
+        )
+        self._worker_thread.start()
+
+    def set_beams_on(self, active: bool) -> None:
+        """Update the desired beams-on state for the next worker-cycle send."""
+        with self._state_lock:
+            self._beams_on = bool(active)
+
+    def set_voltage_active(self, active: bool) -> None:
+        """Update the desired voltage-active state for the next worker-cycle send."""
+        with self._state_lock:
+            self._voltage_active = bool(active)
+
+    def is_connected(self) -> bool:
+        """Return True when the most recent poll exchange succeeded."""
+        with self._status_lock:
+            return self._connected
+
+    def disconnect(self) -> None:
+        """Stop the worker thread and close the serial connection."""
+        self._stop_event.set()
+        if self._worker_thread and self._worker_thread.is_alive():
+            self._worker_thread.join(timeout=THREAD_JOIN_TIMEOUT_SECONDS)
+
+        self._set_connected(False)
+        self._close_serial()
+
+    def close(self) -> None:
+        """Compatibility alias for disconnect()."""
+        self.disconnect()
+
+    def close_com_ports(self) -> None:
+        """Dashboard cleanup hook."""
+        self.disconnect()
+
+    @property
+    def last_error(self):
+        """Most recent connection/protocol error text, or None."""
+        with self._status_lock:
+            return self._last_error
+
+    def _worker_loop(self) -> None:
+        # Main lifecycle loop:
+        # 1. Connect/reconnect if needed.
+        # 2. Poll Arduino with PING/PONG every 500 ms.
+        # 3. Send STATE after reconnect or when desired state changes.
+        reconnect_backoff = RECONNECT_BACKOFF_INITIAL_SECONDS
+        next_reconnect_time = 0.0
+
+        while not self._stop_requested():
+            try:
+                if not self._serial_is_open():
+                    self._set_connected(False)
+
+                    now = time.monotonic()
+                    if now < next_reconnect_time:
+                        wait_time = min(POLL_INTERVAL_SECONDS, next_reconnect_time - now)
+                        self._sleep_or_stop(wait_time)
+                        continue
+
+                    if not self._connect():
+                        next_reconnect_time = time.monotonic() + reconnect_backoff
+                        reconnect_backoff = min(
+                            reconnect_backoff * 2,
+                            RECONNECT_BACKOFF_MAX_SECONDS,
+                        )
+                        continue
+
+                    reconnect_backoff = RECONNECT_BACKOFF_INITIAL_SECONDS
+                    next_reconnect_time = 0.0
+                    self._last_sent_state = None
+
+                self._send_ping()
+                self._set_connected(True)
+
+                if self._state_needs_send():
+                    self._send_state()
+
+                self._sleep_or_stop(POLL_INTERVAL_SECONDS)
+
+            except Exception as exc:
+                self._record_error(exc)
+                self._set_connected(False)
+                self._close_serial()
+                next_reconnect_time = time.monotonic() + reconnect_backoff
+                reconnect_backoff = min(
+                    reconnect_backoff * 2,
+                    RECONNECT_BACKOFF_MAX_SECONDS,
+                )
+
+        self._set_connected(False)
+        self._close_serial()
+
+    def _connect(self) -> bool:
+        # Opening an Arduino Uno USB serial port resets the board. Wait before
+        # flushing buffers so setup() has time to start reading commands.
+        self._close_serial()
+
+        try:
+            ser = serial.Serial(
+                port=self.port,
+                baudrate=BAUDRATE,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=SERIAL_TIMEOUT_SECONDS,
+                write_timeout=WRITE_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            self._record_error(exc)
+            return False
+
+        with self._serial_lock:
+            self._serial = ser
+
+        if self._sleep_or_stop(ARDUINO_BOOT_DELAY_SECONDS):
+            self._close_serial()
+            return False
+
+        try:
+            with self._serial_lock:
+                if self._serial is not ser or not ser.is_open:
+                    return False
+                ser.reset_input_buffer()
+                ser.reset_output_buffer()
+        except Exception as exc:
+            self._record_error(exc)
+            self._close_serial()
+            return False
+
+        with self._status_lock:
+            self._last_error = None
+        return True
+
+    def _send_ping(self) -> None:
+        self._write_line_expect(PING_COMMAND, PONG_RESPONSE)
+
+    def _send_state(self) -> None:
+        state = self._get_state()
+        command = self._build_state_command(*state)
+        self._write_line_expect(command, STATE_OK_RESPONSE)
+        self._last_sent_state = state
+
+    def _write_line_expect(self, command: str, expected_response: str) -> None:
+        # Serial transactions are intentionally request/response. A missing or
+        # unexpected response is treated as a lost connection and handled by the
+        # worker reconnect loop.
+        with self._serial_lock:
+            ser = self._serial
+            if ser is None or not ser.is_open:
+                raise LaserMonitorProtocolError("Serial port is not open")
+
+            ser.reset_input_buffer()
+            ser.write(command.encode(ENCODING))
+            ser.flush()
+
+            response = ser.readline().decode(ENCODING, errors="replace").strip()
+
+        if response != expected_response:
+            raise LaserMonitorProtocolError(
+                f"Expected {expected_response!r}, received {response!r}"
+            )
+
+    def _state_needs_send(self) -> bool:
+        return self._last_sent_state != self._get_state()
+
+    def _get_state(self):
+        with self._state_lock:
+            return self._beams_on, self._voltage_active
+
+    @staticmethod
+    def _build_state_command(beams_on: bool, voltage_active: bool) -> str:
+        beams_value = 1 if beams_on else 0
+        voltage_value = 1 if voltage_active else 0
+        return f"STATE beams={beams_value} voltage={voltage_value}\n"
+
+    def _serial_is_open(self) -> bool:
+        with self._serial_lock:
+            return self._serial is not None and self._serial.is_open
+
+    def _close_serial(self) -> None:
+        with self._serial_lock:
+            ser = self._serial
+            self._serial = None
+
+        if ser is None:
+            return
+
+        try:
+            ser.close()
+        except Exception as exc:
+            self._record_error(exc)
+
+    def _set_connected(self, connected: bool) -> None:
+        with self._status_lock:
+            self._connected = connected
+
+    def _record_error(self, exc) -> None:
+        with self._status_lock:
+            self._last_error = str(exc)
+
+    def _stop_requested(self) -> bool:
+        return self._stop_event.is_set()
+
+    def _sleep_or_stop(self, seconds: float) -> bool:
+        # Interruptible sleep: returns early when disconnect() requests shutdown.
+        return self._stop_event.wait(max(0.0, seconds))

--- a/instrumentctl/laser_monitor/laser_monitor_driver.py
+++ b/instrumentctl/laser_monitor/laser_monitor_driver.py
@@ -6,7 +6,7 @@ import time
 # Laser Monitor driver
 #
 # This driver talks to an Arduino Uno over USB serial. The Arduino drives the physical
-# beam/laser indicator LEDs. The dashboard will later call set_beams_on() and set_voltage_active();
+# beam/laser indicator LEDs. The dashboard calls set_beams_on() and set_radiation_indicator().
 
 try:
     import serial
@@ -27,7 +27,7 @@ THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 # Line-delimited ASCII protocol:
 #   Host -> Arduino:  PING
 #   Arduino -> Host:  PONG
-#   Host -> Arduino:  STATE beams=<0|1> voltage=<0|1>
+#   Host -> Arduino:  STATE beams=<0|1> radiation=<0|1>
 #   Arduino -> Host:  OK
 PING_COMMAND = "PING\n"
 PONG_RESPONSE = "PONG"
@@ -68,7 +68,7 @@ class LaserMonitorDriver:
         # Desired output state. These values are updated by public setters and
         # sent by the worker thread after a successful communication poll.
         self._beams_on = False
-        self._voltage_active = False
+        self._radiation_indicator = False
         self._last_sent_state = None
 
         # Status state. These values are intentionally separate from desired
@@ -92,10 +92,10 @@ class LaserMonitorDriver:
         with self._state_lock:
             self._beams_on = bool(active)
 
-    def set_voltage_active(self, active: bool) -> None:
-        """Update the desired voltage-active state for the next worker-cycle send."""
+    def set_radiation_indicator(self, active: bool) -> None:
+        """Update the desired radiation-indicator state for the next worker-cycle send."""
         with self._state_lock:
-            self._voltage_active = bool(active)
+            self._radiation_indicator = bool(active)
 
     def is_connected(self) -> bool:
         """Return True when the most recent poll exchange succeeded."""
@@ -252,13 +252,13 @@ class LaserMonitorDriver:
 
     def _get_state(self):
         with self._state_lock:
-            return self._beams_on, self._voltage_active
+            return self._beams_on, self._radiation_indicator
 
     @staticmethod
-    def _build_state_command(beams_on: bool, voltage_active: bool) -> str:
+    def _build_state_command(beams_on: bool, radiation_indicator: bool) -> str:
         beams_value = 1 if beams_on else 0
-        voltage_value = 1 if voltage_active else 0
-        return f"STATE beams={beams_value} voltage={voltage_value}\n"
+        radiation_value = 1 if radiation_indicator else 0
+        return f"STATE beams={beams_value} radiation={radiation_value}\n"
 
     def _serial_is_open(self) -> bool:
         with self._serial_lock:

--- a/instrumentctl/laser_monitor/laser_monitor_driver.py
+++ b/instrumentctl/laser_monitor/laser_monitor_driver.py
@@ -103,7 +103,20 @@ class LaserMonitorDriver:
             return self._connected
 
     def disconnect(self) -> None:
-        """Stop the worker thread and close the serial connection."""
+        """Set beams off, stop the worker thread, and close the serial connection."""
+        with self._state_lock:
+            radiation_indicator = self._radiation_indicator
+            self._beams_on = False
+
+        if self._serial_is_open():
+            state = (False, radiation_indicator)
+            try:
+                command = self._build_state_command(*state)
+                self._write_line_expect(command, STATE_OK_RESPONSE)
+                self._last_sent_state = state
+            except Exception as exc:
+                self._record_error(exc)
+
         self._stop_event.set()
         if self._worker_thread and self._worker_thread.is_alive():
             self._worker_thread.join(timeout=THREAD_JOIN_TIMEOUT_SECONDS)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ SUBSYSTEMS = [
     'ProcessMonitors',
     'KnobBox', 
     'BeamPulse',
+    'Laser Monitor',
 ]
 
 def create_dummy_port_labels(subsystems):

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -30,6 +30,9 @@ class BeamEnergySubsystem:
     ESTOP_TEXT_COLOR = "red"
     WARNING_TEXT_COLOR = "#FF8000"
     NORMAL_TEXT_COLOR = "black"
+
+    RADIATION_INDICATOR_THRESHOLD_V = 10000.0
+
     warning_limit_fields = (
         ("max_voltage_v", "Max V", "V"),
         ("min_voltage_v", "Min V", "V"),
@@ -108,6 +111,10 @@ class BeamEnergySubsystem:
             value=self._format_beams_estop_current_limit_setting()
         )
         self.beams_estop_callback = None
+        # Dashboard wires this to LaserMonitorDriver.set_radiation_indicator().
+        # The last-sent value prevents repeated sends during unchanged 500 ms polls.
+        self.radiation_indicator_callback = None
+        self._radiation_indicator_sent = None
         self.warning_limit_entry_vars = [
             {field: tk.StringVar(value="") for field, _label, _unit in self.warning_limit_fields}
             for _ in self.power_supplies
@@ -588,6 +595,35 @@ class BeamEnergySubsystem:
         except Exception:
             _recheck()
 
+    def set_radiation_indicator_callback(self, callback):
+        """Register callback(active) for the Laser Monitor radiation indicator."""
+        self.radiation_indicator_callback = callback
+        self._radiation_indicator_sent = None
+        self._update_radiation_indicator(
+            self.latest_actual_voltage_values[self._get_pos20kv_index()]
+        )
+
+    def _update_radiation_indicator(self, voltage):
+        # Missing/invalid +20kV readback clears the indicator; valid readings
+        # at or above the threshold assert it.
+        voltage = self._coerce_reading(voltage)
+        active = (
+            voltage is not None
+            and voltage >= self.RADIATION_INDICATOR_THRESHOLD_V
+        )
+        if active == getattr(self, "_radiation_indicator_sent", None):
+            return
+
+        callback = getattr(self, "radiation_indicator_callback", None)
+        if not callable(callback):
+            return
+
+        try:
+            callback(active)
+            self._radiation_indicator_sent = active
+        except Exception as e:
+            self.log(f"Radiation indicator callback failed: {e}", LogLevel.ERROR)
+
     def _log_warning_breach(self, index, reading_type, value):
         if value is None:
             return
@@ -624,6 +660,9 @@ class BeamEnergySubsystem:
         self.latest_actual_current_values[index] = current
 
         supply_key = self._get_supply_key(index)
+        if supply_key == POS20KV_SUPPLY_KEY:
+            self._update_radiation_indicator(voltage)
+
         limits = self.warning_limits[supply_key]
         voltage_value = self._comparison_value(supply_key, voltage)
         current_value = self._comparison_value(supply_key, current)

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -113,6 +113,8 @@ class BeamPulseSubsystem:
         # Dashboard integration callbacks
         self._action_feedback_callback = None
         self._armed_status_callback = None
+        self._beam_activity_callback = None
+        self._last_beam_activity_sent = None
         self._pending_firmware_acks = deque()
         self._last_send_failure_message = ""
         self._host_toplevel = None
@@ -1029,9 +1031,8 @@ class BeamPulseSubsystem:
                 self._clear_firmware_acks()
                 self.beams_armed_status = False
                 self._notify_armed_status(False)
-                self.beam_on_status = [False, False, False]
+                self._clear_output_state()
                 self.channel_enable_status = [False, False, False]
-                self._active_channels.clear()
                 self._update_armed_button_states(False)
                 self._notify_all_channel_enables(False)
             self.update_bcon_connection_status()
@@ -1086,10 +1087,10 @@ class BeamPulseSubsystem:
 
     def _update_ui_from_registers(self, regs):
         """Mirror register data into GUI widgets (like pulser_test_gui._handle_msg 'regs')."""
-        # Update manual-tab channel cards
+        # Update channel state first; manual-tab widgets are optional for headless use.
+        channel_vars = getattr(self, "channel_vars", [])
         for ch in range(3):
-            if ch >= len(self.channel_vars):
-                continue
+            has_channel_widgets = ch < len(channel_vars)
             status_base = REG_CH_STATUS_BASE + ch * REG_CH_STATUS_STRIDE
 
             mode_code = regs[status_base + 0]
@@ -1101,9 +1102,10 @@ class BeamPulseSubsystem:
             pulse_ms = regs[base + CH_PULSE_MS_OFF]
             count_val = regs[base + CH_COUNT_OFF]
 
-            st_text = MODE_CODE_TO_LABEL.get(mode_code, "unknown")
-            self.channel_vars[ch]['status'].configure(text=f"Status: {st_text} | O:{output_level}")
-            self.channel_vars[ch]['pulses'].configure(text=f"Remaining: {remaining}")
+            if has_channel_widgets:
+                st_text = MODE_CODE_TO_LABEL.get(mode_code, "unknown")
+                channel_vars[ch]['status'].configure(text=f"Status: {st_text} | O:{output_level}")
+                channel_vars[ch]['pulses'].configure(text=f"Remaining: {remaining}")
 
             # DC mode never counts down (remaining stays 0) — treat it as
             # running whenever mode != OFF so the manual controls stay locked
@@ -1115,10 +1117,10 @@ class BeamPulseSubsystem:
             self.channel_enable_status[ch] = enabled_state
             if is_running:
                 self._active_channels.add(ch)
-                self._set_manual_channel_lock(ch, True)
             else:
                 self._active_channels.discard(ch)
-                self._set_manual_channel_lock(ch, False)
+            if has_channel_widgets:
+                self._set_manual_channel_lock(ch, is_running)
 
             # Notify dashboard so beam toggle button colour tracks hardware state
             if callable(getattr(self, '_channel_status_callback', None)):
@@ -1147,8 +1149,11 @@ class BeamPulseSubsystem:
             # above already shows the live running mode.
 
             # Auto-fill duration/count from param registers if widget is empty or '0'
-            self._safe_fill(self.channel_vars[ch]['duration'], pulse_ms)
-            self._safe_fill(self.channel_vars[ch]['count'], count_val)
+            if has_channel_widgets:
+                self._safe_fill(channel_vars[ch]['duration'], pulse_ms)
+                self._safe_fill(channel_vars[ch]['count'], count_val)
+
+        self._notify_beam_activity(bool(self._active_channels))
 
         # Interlock / watchdog / state
         interlock_ok = regs[REG_INTERLOCK_OK]
@@ -1442,6 +1447,26 @@ class BeamPulseSubsystem:
         """Register callback(armed) for software armed-state changes."""
         self._armed_status_callback = callback
 
+    def set_beam_activity_callback(self, callback):
+        """Register callback(active) for live any-channel output state."""
+        self._beam_activity_callback = callback
+        self._last_beam_activity_sent = None
+        self._notify_beam_activity(bool(getattr(self, "_active_channels", set())))
+
+    def _notify_beam_activity(self, active: bool) -> None:
+        """Notify when any Beam Pulse channel transitions between active/off."""
+        active = bool(active)
+        if active == getattr(self, "_last_beam_activity_sent", None):
+            return
+        callback = getattr(self, "_beam_activity_callback", None)
+        if not callable(callback):
+            return
+        self._last_beam_activity_sent = active
+        try:
+            callback(active)
+        except Exception:
+            pass
+
     def _notify_armed_status(self, armed):
         """Tell the host dashboard when Beam Pulse changes armed state."""
         callback = getattr(self, "_armed_status_callback", None)
@@ -1501,6 +1526,7 @@ class BeamPulseSubsystem:
             active_channels.clear()
         else:
             self._active_channels = set()
+        self._notify_beam_activity(False)
 
     def _notify_all_channel_enables(self, enabled: bool) -> None:
         """Mirror a known all-channel enable state to dashboard controls."""
@@ -1542,9 +1568,8 @@ class BeamPulseSubsystem:
         self.bcon_connection_status = False
         self.beams_armed_status = False
         self._notify_armed_status(False)
-        self.beam_on_status = [False, False, False]
+        self._clear_output_state()
         self.channel_enable_status = [False, False, False]
-        self._active_channels.clear()
         self._update_armed_button_states(False)
         self._notify_all_channel_enables(False)
         self._notify_all_channel_enables(False)

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -1154,7 +1154,8 @@ class MainControlPanel:
 
         for subsystem in [
             'VTRXSubsystem', 'CathodeA PS', 'CathodeB PS', 'CathodeC PS', 
-            'TempControllers', 'Interlocks', 'ProcessMonitors', 'KnobBox']:
+            'TempControllers', 'Interlocks', 'ProcessMonitors', 'KnobBox',
+            'Laser Monitor']:
             frame = ttk.Frame(self.com_port_menu)
             frame.pack(fill=tk.X, padx=5, pady=2)
             ttk.Label(frame, text=f"{subsystem}:").pack(side=tk.LEFT)


### PR DESCRIPTION
This PR adds a driver for the laser-monitor system. The driver talks to an arduino uno using USB serial and controls two boolean values: radiationPresent and beamsOn. Beams On simply checks beam pulse to see if there are any beams that are currently on. radiationPresent is indicated if the 20kV Bertan rises above 10kV.

The functional code is quite simple. Most of the additions are to ensure safe closing, opening, and reconnect with COM port and corrupted USB serial data. A good chunk of the code added in this PR is also unit tests made by codex to ensure that this is all working.

Because these values are updated from beam pulse, and there were many changes to the structure of beam pulse in https://github.com/uw-loci/EBEAM_dashboard/pull/144 , feature/beam-current-limit was merged into this branch to prevent huge amount of conflict changes when these get merged.