### PR TITLE
Bugfix: CCS thread bugs

### DIFF
--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -1,7 +1,7 @@
 import threading
 import time
 import math
-from queue import Queue, Empty
+from queue import Queue, Empty, Full
 from pymodbus.client import ModbusSerialClient as ModbusClient
 from utils import LogLevel  # Ensure this module is correctly implemented
 
@@ -12,6 +12,7 @@ class E5CNModbus:
     SENSOR_ERROR = "ERROR"
     THREAD_JOIN_TIMEOUT = 2.0
     MODBUS_CLOSE_LOCK_TIMEOUT = 0.5
+    WORKER_LOG_QUEUE_MAXSIZE = 1000
 
     def __init__(self, port, baudrate=9600, timeout=1, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
         """
@@ -38,7 +39,9 @@ class E5CNModbus:
         self.port = port
         self.connected = False
         self._main_thread_ident = threading.get_ident()
-        self._log_queue = Queue()
+        self._log_queue = Queue(maxsize=self.WORKER_LOG_QUEUE_MAXSIZE)
+        self._dropped_worker_log_count = 0
+        self._dropped_worker_log_lock = threading.Lock()
         self.log(f"Initializing E5CNModbus with port: {port}", LogLevel.DEBUG)
 
         # Initialize Modbus client without 'method' parameter
@@ -248,12 +251,48 @@ class E5CNModbus:
         if threading.get_ident() == self._main_thread_ident:
             self.logger.log(message, level)
         else:
-            self._log_queue.put((message, level))
+            self._enqueue_worker_log(message, level)
+
+    def _enqueue_worker_log(self, message, level):
+        """Queue one worker log without blocking if the UI drain is stalled."""
+        try:
+            self._log_queue.put_nowait((message, level))
+            return
+        except Full:
+            pass
+
+        try:
+            self._log_queue.get_nowait()
+            self._record_dropped_worker_log()
+        except Empty:
+            pass
+
+        try:
+            self._log_queue.put_nowait((message, level))
+        except Full:
+            self._record_dropped_worker_log()
+            pass
+
+    def _record_dropped_worker_log(self):
+        with self._dropped_worker_log_lock:
+            self._dropped_worker_log_count += 1
+
+    def _pop_dropped_worker_log_count(self):
+        with self._dropped_worker_log_lock:
+            count = self._dropped_worker_log_count
+            self._dropped_worker_log_count = 0
+        return count
 
     def flush_queued_logs(self, max_messages=200):
         """Flush queued worker-thread log messages on the calling thread."""
         if not self.logger:
             return
+        dropped_count = self._pop_dropped_worker_log_count()
+        if dropped_count:
+            self.logger.log(
+                f"Dropped {dropped_count} queued E5CN worker log message(s) because the log queue was full.",
+                LogLevel.WARNING,
+            )
         processed = 0
         while processed < max_messages:
             try:

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -93,6 +93,9 @@ class E5CNModbus:
         while not self.stop_event.is_set():
             try:
                 temperature = self.read_temperature(unit)
+                if self.stop_event.is_set():
+                    self.connected = False
+                    break
                 if isinstance(temperature, (int, float)):
                     with self.temperatures_lock:
                         self.temperatures[unit - 1] = temperature
@@ -109,6 +112,9 @@ class E5CNModbus:
                     self.log(f"Unit {unit} is reading null", LogLevel.ERROR)
                 time.sleep(0.5)  # small delay between reads
             except Exception as e:
+                if self.stop_event.is_set():
+                    self.connected = False
+                    break
                 self.log(f"Error in continuous temperature reading for unit {unit}: {str(e)}", LogLevel.ERROR)
                 time.sleep(1)  # Longer delay on error
 
@@ -128,26 +134,9 @@ class E5CNModbus:
             
         self.threads.clear()
         
-        # Clean up the connection
-        acquired = self.modbus_lock.acquire(timeout=self.MODBUS_CLOSE_LOCK_TIMEOUT)
         try:
-            if not acquired:
-                self.log(
-                    "Timed out waiting for E5CN Modbus lock while closing connection; "
-                    "continuing without blocking shutdown",
-                    LogLevel.WARNING
-                )
-                return
-
-            try:
-                if self.client.is_socket_open():
-                    self.client.close()
-                    self.log("Modbus connection closed", LogLevel.DEBUG)
-            except Exception as e:
-                self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
+            return self.disconnect()
         finally:
-            if acquired:
-                self.modbus_lock.release()
             self.is_initialized.clear()
             self.flush_queued_logs()
 
@@ -177,22 +166,48 @@ class E5CNModbus:
                 return False
 
     def disconnect(self):
-        """Disconnect from the Modbus device with proper locking."""
-       # with self.modbus_lock:
+        """Disconnect from the Modbus device without blocking indefinitely on modbus_lock."""
+        if self.modbus_lock.acquire(timeout=self.MODBUS_CLOSE_LOCK_TIMEOUT):
+            try:
+                return self._close_client()
+            finally:
+                self.modbus_lock.release()
+
+        self.log("Timed out waiting for E5CN lock; force-closing client", LogLevel.WARNING)
+        return self._close_client()
+
+    def _close_client(self):
+        """Best-effort close without acquiring modbus_lock."""
+        self.connected = False
+
+        if self.client is None:
+            self.log("E5CN Modbus client is unavailable while closing connection", LogLevel.ERROR)
+            return False
+
         try:
             if self.client.is_socket_open():
                 self.client.close()
-                self.log("Disconnected from the E5CN Modbus device.", LogLevel.INFO)
+                self.log("Modbus connection closed", LogLevel.DEBUG)
             else:
-                self.log("Client already disconnected from E5CN Modbus device", LogLevel.INFO)
+                self.log("Modbus connection already closed", LogLevel.DEBUG)
+
+            if self.client.is_socket_open():
+                self.log("E5CN Modbus client still reports open after close", LogLevel.ERROR)
+                return False
+
+            return True
         except Exception as e:
-            self.log(f"Error in disconnect: {str(e)}", LogLevel.ERROR)
+            self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
+            return False
 
     def read_temperature(self, unit):
         attempts = 3
-        while attempts > 0:
+        while attempts > 0 and not self.stop_event.is_set():
             try:
                 with self.modbus_lock:
+                    if self.stop_event.is_set():
+                        return None
+
                     if not self.client.is_socket_open():
                         try:
                             if self.client.connect():

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -10,6 +10,8 @@ class E5CNModbus:
     UNIT_NUMBERS = [1, 2, 3]       # Unit numbers for each controller
     MAX_VALID_TEMPERATURE_C = 999.9
     SENSOR_ERROR = "ERROR"
+    THREAD_JOIN_TIMEOUT = 2.0
+    MODBUS_CLOSE_LOCK_TIMEOUT = 0.5
 
     def __init__(self, port, baudrate=9600, timeout=1, parity='E', stopbits=2, bytesize=8, logger=None, debug_mode=False):
         """
@@ -111,25 +113,40 @@ class E5CNModbus:
         """Stop all temperature reading threads and clean up connections."""
         self.log("Stopping temperature reading threads...", LogLevel.DEBUG)
         self.stop_event.set()
+        self.connected = False
         
         # Wait for threads to finish
         for thread in self.threads:
-            thread.join(timeout=2.0)
-            self.log(f"Thread {thread.name} stopped", LogLevel.DEBUG)
+            thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
+            if thread.is_alive():
+                self.log(f"Thread {thread.name} did not stop before timeout", LogLevel.WARNING)
+            else:
+                self.log(f"Thread {thread.name} stopped", LogLevel.DEBUG)
             
         self.threads.clear()
         
         # Clean up the connection
-        with self.modbus_lock:
+        acquired = self.modbus_lock.acquire(timeout=self.MODBUS_CLOSE_LOCK_TIMEOUT)
+        try:
+            if not acquired:
+                self.log(
+                    "Timed out waiting for E5CN Modbus lock while closing connection; "
+                    "continuing without blocking shutdown",
+                    LogLevel.WARNING
+                )
+                return
+
             try:
                 if self.client.is_socket_open():
                     self.client.close()
                     self.log("Modbus connection closed", LogLevel.DEBUG)
             except Exception as e:
                 self.log(f"Error closing connection: {str(e)}", LogLevel.ERROR)
-                
-        self.is_initialized.clear()
-        self.flush_queued_logs()
+        finally:
+            if acquired:
+                self.modbus_lock.release()
+            self.is_initialized.clear()
+            self.flush_queued_logs()
 
     def connect(self):
         """

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -819,7 +819,7 @@ class PowerSupply9104:
         command = f"SETM{setv1:04}{seti1:04}{swtime1:03}{setv2:04}{seti2:04}{swtime2:03}{setv3:04}{seti3:04}{swtime3:03}"
         return self.send_command(command)
     
-    def disable_output(self, lock_timeout=None):
+    def disable_output(self, lock_timeout=1.5):
         """Disable the power supply output unconditionally (no OVP validation)."""
         command = "SOUT0"
         response = self.send_command(command, lock_timeout=lock_timeout)

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -380,10 +380,18 @@ class PowerSupply9104:
                     self.log(f"Ramp progress: Step {step + 1}/{num_steps}, Setting {next_current:.2f}A", LogLevel.INFO)
 
                 # Longer delay between steps
-                time.sleep(step_delay)
+                if self.stop_event.wait(step_delay):
+                    self.log("Ramping thread stopped.", LogLevel.INFO)
+                    if callback:
+                        callback(False)
+                    return
 
             # Final verification after settling
-            time.sleep(1.0)  # Extra settling time
+            if self.stop_event.wait(1.0):  # Extra settling time
+                self.log("Ramping thread stopped.", LogLevel.INFO)
+                if callback:
+                    callback(False)
+                return
             _, final_current, _ = self.get_voltage_current_mode()
 
             if final_current is None:
@@ -505,10 +513,18 @@ class PowerSupply9104:
                     self.log(f"Ramp progress: Step {step + 1}/{num_steps}, Setting {next_voltage:.2f}V", LogLevel.INFO)
                     
                 # Longer delay between steps
-                time.sleep(step_delay)
+                if self.stop_event.wait(step_delay):
+                    self.log("Ramping thread stopped.", LogLevel.INFO)
+                    if callback:
+                        callback(False)
+                    return
             
             # Final verification after settling
-            time.sleep(1.0)  # Extra settling time
+            if self.stop_event.wait(1.0):  # Extra settling time
+                self.log("Ramping thread stopped.", LogLevel.INFO)
+                if callback:
+                    callback(False)
+                return
             final_voltage, _, _ = self.get_voltage_current_mode()
             
             if final_voltage is None:

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -2,7 +2,7 @@ import serial
 import threading
 import time
 import math
-from queue import Queue, Empty
+from queue import Queue, Empty, Full
 from utils import LogLevel
 
 class PowerSupply9104:
@@ -10,6 +10,7 @@ class PowerSupply9104:
     CURRENT_SETTLE_TOLERANCE = 0.10  # 9104 current resolution is 100 mA
     VOLTAGE_SETTLE_TOLERANCE = 0.20  # 9104 voltage resolution is 200 mV
     DEFAULT_SERIAL_LOCK_TIMEOUT = 0.5
+    WORKER_LOG_QUEUE_MAXSIZE = 1000
 
     def __init__(self, port, baudrate=9600, timeout=0.5, logger=None, debug_mode=False, serial_lock_timeout=DEFAULT_SERIAL_LOCK_TIMEOUT):
         self.port = port
@@ -19,7 +20,9 @@ class PowerSupply9104:
         self.debug_mode = debug_mode
         self.serial_lock_timeout = serial_lock_timeout
         self._main_thread_ident = threading.get_ident()
-        self._log_queue = Queue()
+        self._log_queue = Queue(maxsize=self.WORKER_LOG_QUEUE_MAXSIZE)
+        self._dropped_worker_log_count = 0
+        self._dropped_worker_log_lock = threading.Lock()
         self.serial_lock = threading.Lock()
         self.ser = None
         self.setup_serial()
@@ -862,12 +865,48 @@ class PowerSupply9104:
         if threading.get_ident() == self._main_thread_ident:
             self.logger.log(message, level)
         else:
-            self._log_queue.put((message, level))
+            self._enqueue_worker_log(message, level)
+
+    def _enqueue_worker_log(self, message, level):
+        """Queue one worker log without blocking if the UI drain is stalled."""
+        try:
+            self._log_queue.put_nowait((message, level))
+            return
+        except Full:
+            pass
+
+        try:
+            self._log_queue.get_nowait()
+            self._record_dropped_worker_log()
+        except Empty:
+            pass
+
+        try:
+            self._log_queue.put_nowait((message, level))
+        except Full:
+            self._record_dropped_worker_log()
+            pass
+
+    def _record_dropped_worker_log(self):
+        with self._dropped_worker_log_lock:
+            self._dropped_worker_log_count += 1
+
+    def _pop_dropped_worker_log_count(self):
+        with self._dropped_worker_log_lock:
+            count = self._dropped_worker_log_count
+            self._dropped_worker_log_count = 0
+        return count
 
     def flush_queued_logs(self, max_messages=200):
         """Flush queued worker-thread log messages on the calling thread."""
         if not self.logger:
             return
+        dropped_count = self._pop_dropped_worker_log_count()
+        if dropped_count:
+            self.logger.log(
+                f"Dropped {dropped_count} queued 9104 worker log message(s) because the log queue was full.",
+                LogLevel.WARNING,
+            )
         processed = 0
         while processed < max_messages:
             try:

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -9,24 +9,44 @@ class PowerSupply9104:
     MAX_RETRIES = 3 # 9104 display reading attempts
     CURRENT_SETTLE_TOLERANCE = 0.10  # 9104 current resolution is 100 mA
     VOLTAGE_SETTLE_TOLERANCE = 0.20  # 9104 voltage resolution is 200 mV
+    DEFAULT_SERIAL_LOCK_TIMEOUT = 0.5
 
-    def __init__(self, port, baudrate=9600, timeout=0.5, logger=None, debug_mode=False):
+    def __init__(self, port, baudrate=9600, timeout=0.5, logger=None, debug_mode=False, serial_lock_timeout=DEFAULT_SERIAL_LOCK_TIMEOUT):
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
         self.logger = logger
         self.debug_mode = debug_mode
+        self.serial_lock_timeout = serial_lock_timeout
         self._main_thread_ident = threading.get_ident()
         self._log_queue = Queue()
         self.serial_lock = threading.Lock()
+        self.ser = None
         self.setup_serial()
         self.stop_event = threading.Event()  # Stop flag for threads
         self.ramp_thread = None  # Track the ramping thread
 
+    def _acquire_serial_lock(self, action, lock_timeout=None):
+        timeout = self.serial_lock_timeout if lock_timeout is None else lock_timeout
+        if timeout is None:
+            self.serial_lock.acquire()
+            return True
+
+        acquired = self.serial_lock.acquire(timeout=timeout)
+        if not acquired:
+            self.log(f"Timed out waiting for serial lock while {action}", LogLevel.WARNING)
+        return acquired
+
     # Public serial interface methods with locking to ensure thread safety
-    def setup_serial(self):
-        with self.serial_lock:
+    def setup_serial(self, lock_timeout=None):
+        if not self._acquire_serial_lock(f"setting up serial connection on {self.port}", lock_timeout):
+            return False
+
+        try:
             self._setup_serial_unlocked()
+            return self.ser is not None
+        finally:
+            self.serial_lock.release()
     
     # The unlocked version of setup_serial, should only be called within a serial_lock context like in setup_serial or update_com_port
     def _setup_serial_unlocked(self):
@@ -40,14 +60,8 @@ class PowerSupply9104:
     def update_com_port(self, new_port, lock_timeout=None):
         self.log(f"Updating COM port from {self.port} to {new_port}", LogLevel.INFO)
 
-        if lock_timeout is None:
-            with self.serial_lock:
-                return self._update_com_port_unlocked(new_port)
-
-        # COM reconfiguration uses a bounded wait so a stuck serial transaction cannot hang the GUI.
-        acquired = self.serial_lock.acquire(timeout=lock_timeout)
+        acquired = self._acquire_serial_lock(f"updating COM port to {new_port}", lock_timeout)
         if not acquired:
-            self.log(f"Timed out waiting for serial lock while updating COM port to {new_port}", LogLevel.WARNING)
             return False
 
         try:
@@ -78,14 +92,9 @@ class PowerSupply9104:
 
     # Thread-safe method to check connection status
     def is_connected(self, lock_timeout=None):
-        if lock_timeout is None:
-            with self.serial_lock:
-                return self._is_connected_unlocked()
-
         # Returning None means "busy", distinct from a confirmed disconnected port.
-        acquired = self.serial_lock.acquire(timeout=lock_timeout)
+        acquired = self._acquire_serial_lock("checking connection", lock_timeout)
         if not acquired:
-            self.log("Timed out waiting for serial lock while checking connection", LogLevel.WARNING)
             return None
 
         try:
@@ -98,9 +107,15 @@ class PowerSupply9104:
         return self.ser is not None and self.ser.is_open
 
     # Thread-safe method to flush serial input buffer
-    def flush_serial(self):
-        with self.serial_lock:
+    def flush_serial(self, lock_timeout=None):
+        if not self._acquire_serial_lock("flushing serial input buffer", lock_timeout):
+            return False
+
+        try:
             self._flush_serial_unlocked()
+            return True
+        finally:
+            self.serial_lock.release()
 
     # Unlocked version of flush_serial, should only be called within a serial_lock context like in flush_serial or send_command
     def _flush_serial_unlocked(self):
@@ -112,16 +127,11 @@ class PowerSupply9104:
 
     def send_command(self, command, lock_timeout=None):
         """Send a command to the power supply and read the response."""
-        # Normal runtime calls preserve the original blocking lock behavior so
-        # command ordering stays simple. Shutdown paths pass lock_timeout so a
-        # dead-port poll cannot keep the dashboard waiting forever on this lock.
-        if lock_timeout is None:
-            with self.serial_lock:
-                return self._send_command_unlocked(command)
-
-        acquired = self.serial_lock.acquire(timeout=lock_timeout)
+        # All public command paths use a bounded lock wait by default so GUI
+        # callbacks fail visibly instead of waiting forever behind a stuck poll
+        # or ramp transaction.
+        acquired = self._acquire_serial_lock(f"sending '{command}'", lock_timeout)
         if not acquired:
-            self.log(f"Timed out waiting for serial lock while sending '{command}'", LogLevel.WARNING)
             return None
 
         try:
@@ -585,10 +595,6 @@ class PowerSupply9104:
         """
         for attempt in range(self.MAX_RETRIES):
             try:
-                # Bounded callers already acquire through send_command; avoid a second lock wait here.
-                if lock_timeout is None and not self.is_connected():
-                    break
-
                 reading = self.get_display_readings(lock_timeout=lock_timeout)
 
                 if not reading:
@@ -794,9 +800,6 @@ class PowerSupply9104:
     
     def disable_output(self, lock_timeout=None):
         """Disable the power supply output unconditionally (no OVP validation)."""
-        if lock_timeout is None and not self.is_connected():
-            self.log("Cannot disable output: not connected.", LogLevel.WARNING)
-            return False
         command = "SOUT0"
         response = self.send_command(command, lock_timeout=lock_timeout)
         if response and "OK" in response:
@@ -806,7 +809,7 @@ class PowerSupply9104:
             self.log(f"Failed to disable output: {response}", LogLevel.ERROR)
             return False
 
-    def close(self, ramp_join_timeout=2.0, serial_lock_timeout=1.0):
+    def close(self, ramp_join_timeout=2.0):
         """Close the serial connection and stop threads."""
         self.log("Stopping threads and closing serial connection.", LogLevel.INFO)
 
@@ -827,7 +830,7 @@ class PowerSupply9104:
         # Prefer closing while holding serial_lock, but do not let a stuck serial
         # transaction prevent shutdown. If the lock is unavailable, make a
         # best-effort close and clear self.ser so later calls fail fast.
-        acquired = self.serial_lock.acquire(timeout=serial_lock_timeout)
+        acquired = self._acquire_serial_lock("closing serial connection")
         if acquired:
             try:
                 if self.ser and self.ser.is_open:

--- a/instrumentctl/power_supply_9104/power_supply_9104.py
+++ b/instrumentctl/power_supply_9104/power_supply_9104.py
@@ -338,7 +338,8 @@ class PowerSupply9104:
                         callback(False)
                     return
 
-                if not self.is_connected():
+                connected = self.is_connected()
+                if connected is False:
                     self.log("Connection lost during ramping. Aborting ramp.", LogLevel.ERROR)
                     if callback:
                         callback(False)
@@ -475,7 +476,8 @@ class PowerSupply9104:
                         callback(False)
                     return
             
-                if not self.is_connected():
+                connected = self.is_connected()
+                if connected is False:
                     self.log("Connection lost during ramping. Aborting ramp.", LogLevel.ERROR)
                     if callback:
                         callback(False)

--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -220,7 +220,7 @@ The poller:
 
 - Runs independently of the Tkinter event loop.
 - Polls each configured 9104 roughly every 500 ms.
-- Calls `PowerSupply9104.get_voltage_current_mode(lock_timeout=...)` from the background thread.
+- Calls `PowerSupply9104.get_voltage_current_mode()` from the background thread; the driver applies its default bounded serial-lock wait.
 - Writes a small snapshot into `self.power_supply_readbacks` under `self.power_supply_readback_lock`.
 - Uses the existing `PowerSupply9104.serial_lock`, so regular commands and readback polling still serialize through the driver.
 - Marks disconnected, uninitialized, and invalid-read states in the snapshot.
@@ -304,7 +304,7 @@ It handles:
 - Serialized readback commands used by the cathode polling thread.
 - Background ramp threads.
 - Ramp stop signaling.
-- Bounded serial-lock waits for polling, reconnect, COM-port update, and shutdown paths through optional `lock_timeout` arguments on selected calls.
+- A default 0.5 s bounded serial-lock wait on public serial command paths, including GUI-triggered reads/writes, polling, reconnect, COM-port update, and shutdown output-disable calls.
 
 In short:
 

--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -304,7 +304,8 @@ It handles:
 - Serialized readback commands used by the cathode polling thread.
 - Background ramp threads.
 - Ramp stop signaling.
-- A default 0.5 s bounded serial-lock wait on public serial command paths, including GUI-triggered reads/writes, polling, reconnect, COM-port update, and shutdown output-disable calls.
+- A default 0.5 s bounded serial-lock wait on public serial command paths, including GUI-triggered reads/writes, polling, reconnect, and COM-port updates.
+- Shutdown output-disable calls use a serial-lock wait of 1.5s.
 
 In short:
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1146,9 +1146,16 @@ class CathodeHeatingSubsystem:
         # Disconnect temperature controller
         if self.temperature_controller:
             try:
-                self.temperature_controller.stop_reading()
-                self.temperature_controller.disconnect()
-                self.log("Disconnected temperature controller", LogLevel.DEBUG)
+                closed = self.temperature_controller.stop_reading()
+                self.temp_controllers_connected = False
+                if closed:
+                    self.temperature_controller = None
+                    self.log("Disconnected temperature controller", LogLevel.DEBUG)
+                else:
+                    self.log(
+                        "Temperature controller did not close cleanly; keeping old handle until cleanup succeeds",
+                        LogLevel.WARNING,
+                    )
             except Exception as e:
                 self.log(f"Error disconnecting temperature controller: {str(e)}", LogLevel.WARNING)
 
@@ -1646,9 +1653,20 @@ class CathodeHeatingSubsystem:
         # Ensure any existing controller is properly cleaned up
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
-                self.temperature_controller.stop_reading()
+                closed = self.temperature_controller.stop_reading()
+                if not closed:
+                    self.temp_controllers_connected = False
+                    self.log(
+                        "Existing temperature controller did not close; "
+                        "skipping reinitialization to avoid reopening an in-use COM port.",
+                        LogLevel.WARNING,
+                    )
+                    return False
+                self.temperature_controller = None
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)
+                self.temp_controllers_connected = False
+                return False
                 
         try:
             tc = E5CNModbus(port=port, logger=self.logger)
@@ -3277,8 +3295,9 @@ class CathodeHeatingSubsystem:
 
         if hasattr(self, 'temperature_controller') and self.temperature_controller:
             try:
-                self.temperature_controller.stop_reading()
+                closed = self.temperature_controller.stop_reading()
+                if not closed:
+                    self.log("Temperature controller did not close cleanly during shutdown", LogLevel.WARNING)
                 self.temp_controllers_connected = False
-                self.temperature_controller.disconnect()
             except Exception as e:
                 self.log(f"Error cleaning up existing controller: {str(e)}", LogLevel.ERROR)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1134,7 +1134,7 @@ class CathodeHeatingSubsystem:
             if ps is not None:
                 try:
                     if hasattr(ps, 'close'):
-                        ps.close(ramp_join_timeout=2.0, serial_lock_timeout=1.0)
+                        ps.close(ramp_join_timeout=2.0)
                     elif hasattr(ps, 'disconnect'):
                         ps.disconnect()
                     self.log(f"Disconnected power supply {idx + 1}", LogLevel.DEBUG)
@@ -1327,7 +1327,7 @@ class CathodeHeatingSubsystem:
                 except Exception as e:
                     if ps is not None and hasattr(ps, 'close'):
                         try:
-                            ps.close(ramp_join_timeout=2.0, serial_lock_timeout=1.0)
+                            ps.close(ramp_join_timeout=2.0)
                         except Exception:
                             pass
                     self.log(f"Failed to initialize {cathode} on port {port}: {str(e)}", LogLevel.ERROR)
@@ -1847,7 +1847,7 @@ class CathodeHeatingSubsystem:
             return
 
         try:
-            ps.update_com_port(port, lock_timeout=1.0)
+            ps.update_com_port(port)
         except Exception:
             # PowerSupply9104 logs serial failures itself; keep this worker quiet.
             pass
@@ -1875,7 +1875,7 @@ class CathodeHeatingSubsystem:
                     continue
 
                 try:
-                    connected = ps.is_connected(lock_timeout=0.25)
+                    connected = ps.is_connected()
                     if connected is None:
                         # Another command owns the serial lock; keep the GUI responsive and retry later.
                         self._set_power_supply_readback(index, error="busy")
@@ -1887,7 +1887,7 @@ class CathodeHeatingSubsystem:
                             self._attempt_power_supply_reopen(index, ps)
                         continue
 
-                    voltage, current, mode = ps.get_voltage_current_mode(lock_timeout=0.25)
+                    voltage, current, mode = ps.get_voltage_current_mode()
                     if voltage is None or current is None:
                         self._set_power_supply_readback(index, error="invalid_read")
                     else:
@@ -3247,12 +3247,12 @@ class CathodeHeatingSubsystem:
                     if hasattr(ps, 'disable_output'):
                         # Try to turn output off, but continue closing if a dead serial transaction owns the lock.
                         self.log(f"Disabling output on cathode {chr(65 + i)} power supply", LogLevel.INFO)
-                        ps.disable_output(lock_timeout=1.0)
+                        ps.disable_output()
                 except Exception as e:
                     self.log(f"Error disabling output on cathode {chr(65 + i)}: {e}", LogLevel.ERROR)
                 if hasattr(ps, 'close'):
                     try:
-                        ps.close(ramp_join_timeout=2.0, serial_lock_timeout=1.0)
+                        ps.close(ramp_join_timeout=2.0)
                     except TypeError:
                         ps.close()
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -3222,10 +3222,12 @@ class CathodeHeatingSubsystem:
         UI callback - user pressed STOP RAMP.
         """
         ps = self.power_supplies[index]
+        was_ramping = self.is_ramping(index)
         if ps:
             ps.stop_ramp()
         self.log(f'STOP RAMP pressed for Cathode {["A","B","C"][index]}', LogLevel.WARNING)
-        self.on_ramp_complete(index)
+        if not was_ramping:
+            self.on_ramp_complete(index)
 
     def set_curr_adjustment_buttons_state(self, index: int, state: str):
         """Enable or disable the current +/- adjustment buttons for one cathode."""

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -191,6 +191,8 @@ class CathodeHeatingSubsystem:
         self.initialize_temperature_controllers()   # Connect to temperature controllers
         self.initialize_power_supplies()            # Connect to power supplies
         self.start_power_supply_polling()           # Poll 9104 readbacks off the Tk thread
+        self.after_id = None
+        self._updates_cancelled = False
         self.update_data()                          # Start the data update loop
 
     def _style_lut_dropdown_items(self, combobox, options, retries=4):
@@ -1929,6 +1931,22 @@ class CathodeHeatingSubsystem:
 
     
     def update_data(self):
+        if getattr(self, "_updates_cancelled", False):
+            return
+
+        try:
+            self._update_data_once()
+        except Exception as e:
+            message = f"Cathode heating update_data failed: {type(e).__name__}: {e}"
+            try:
+                self.log(message, LogLevel.ERROR)
+            except Exception:
+                print(f"{LogLevel.ERROR.name}: {message}")
+        finally:
+            if not getattr(self, "_updates_cancelled", False):
+                self.after_id = self.parent.after(500, self.update_data)
+
+    def _update_data_once(self):
         current_time = datetime.datetime.now()
         plot_this_cycle = (current_time - self.last_plot_time) >= self.plot_interval
 
@@ -2031,20 +2049,19 @@ class CathodeHeatingSubsystem:
             if plot_this_cycle:  # Ensure plots are updated only when new data is plotted
                 self.update_plot(i)
 
-        # Schedule next update
-        self.after_id = self.parent.after(500, self.update_data)
-
     def cancel_updates(self):
         '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''
+        self._updates_cancelled = True
         if hasattr(self, 'after_id') and self.after_id:
             try:
                 self.parent.after_cancel(self.after_id)
-                self.after_id = None
                 if self.logger:
                     self.log('Canceled scheduled cathode heating display update.', LogLevel.DEBUG)
             except Exception as e:
                 if self.logger:
                     self.log('Failed to cancel scheduled cathode heating display update.', LogLevel.DEBUG)
+            finally:
+                self.after_id = None
 
     def update_plot(self, index):
         if len(self.time_data[index]) == 0:


### PR DESCRIPTION
This PR addresses the bugs from the codex analysis of CCS issues. These bugs have not been observed, but have been confirmed to be real, yet unlikely, situations. These are all related to CCS, and are also all quite small, they'll be combined into this single PR. 

See the following issues: 

- 9014 Poller Blocking GUI Serial I/O #154 
- Cathode Heating update_data() permanently die after exception #155
- Bug: E5CN Shutdown Lock Hang #156
- Bug: Unbounded Worker Log Queues #157 
- Bug: Stop Ramp UI Completes Too Early #158
 

NOTE: This PR should only be reviewed and merged once all PRs 153 and under are merged into develop as it is based off a branch with all those merged together. This PR is currently being compared to test/PRs-153-and-below-merged to more easily see diffs in files changed, and for codex reviews. Once develop gets PRs 153 and under merged, this PR should change back to being compared to develop.