### PR TITLE
Feature: CCS output disable on BCON disconnect

### DIFF
--- a/instrumentctl/BCON/bcon_driver.py
+++ b/instrumentctl/BCON/bcon_driver.py
@@ -265,7 +265,7 @@ class BCONDriver:
     # Defaults
     DEFAULT_BAUD       = 115200
     DEFAULT_UNIT       = 1
-    DEFAULT_TIMEOUT    = 1.0
+    DEFAULT_TIMEOUT    = 0.1
     DEFAULT_WATCHDOG_MS = 1500
     DEFAULT_TELEMETRY_MS = 500
     WATCHDOG_MIN_MS   = 50
@@ -867,20 +867,26 @@ class BCONDriver:
                             self._log(f"  read_block({start}, {count}) FAILED: {e}", "WARNING")
                             return False
 
-                    ok = True
                     # Read only the register addresses that the firmware actually
                     # defines. Registers 3-9, 14-19, and 24-29 are gaps in the
                     # control map, while channel status omits the +9 stride slot.
-                    ok &= read_block(0, 3)       # control: watchdog(0), telemetry(1), command(2)
-                    ok &= read_block(10, 4)      # CH1 params: mode, pulse_ms, count, enable_toggle
-                    ok &= read_block(20, 4)      # CH2 params
-                    ok &= read_block(30, 4)      # CH3 params
-                    ok &= read_block(100, 10)    # system + supervisor status (100-109)
-                    ok &= read_block(110, 9)     # CH1 status (110-118)
-                    ok &= read_block(120, 9)     # CH2 status (120-128)
-                    ok &= read_block(130, 9)     # CH3 status (130-138)
-                    ok &= read_block(140, 12)    # CH1-CH3 supervisor status (140-151)
-                    ok &= read_block(152, 2)     # last reject reason + last cmd seq
+                    poll_blocks = (
+                        (0, 3),       # control: watchdog(0), telemetry(1), command(2)
+                        (10, 4),      # CH1 params: mode, pulse_ms, count, enable_toggle
+                        (20, 4),      # CH2 params
+                        (30, 4),      # CH3 params
+                        (100, 10),    # system + supervisor status (100-109)
+                        (110, 9),     # CH1 status (110-118)
+                        (120, 9),     # CH2 status (120-128)
+                        (130, 9),     # CH3 status (130-138)
+                        (140, 12),    # CH1-CH3 supervisor status (140-151)
+                        (152, 2),     # last reject reason + last cmd seq
+                    )
+                    ok = True
+                    for start, count in poll_blocks:
+                        if not read_block(start, count):
+                            ok = False
+                            break
 
                     if not ok:
                         self._poll_errors += 1

--- a/instrumentctl/BCON/bcon_driver.py
+++ b/instrumentctl/BCON/bcon_driver.py
@@ -276,7 +276,7 @@ class BCONDriver:
     PULSE_COUNT_MIN = 1
     PULSE_COUNT_MAX = 10000
     POLL_INTERVAL      = 0.5     # seconds between register polls
-    MAX_POLL_ERRORS    = 15      # consecutive failures before auto-disconnect
+    MAX_POLL_ERRORS    = 10      # consecutive failures before auto-disconnect
     SETTLE_TIME        = 4.5     # seconds to wait after opening port (Arduino DTR reset)
     WATCHDOG_HEARTBEAT_S = 0.5   # refresh at least once per poll cycle
     COMMAND_CONFIRM_RETRIES = 4

--- a/instrumentctl/BCON/bcon_driver.py
+++ b/instrumentctl/BCON/bcon_driver.py
@@ -340,8 +340,14 @@ class BCONDriver:
 
     def _log(self, message: str, level: str = "INFO"):
         """Internal logging helper."""
-        if self.debug or level in ("ERROR", "WARNING"):
-            print(f"[BCON {level}] {message}")
+        level = str(level).upper()
+        if not (self.debug or level in ("ERROR", "WARNING")):
+            return
+
+        # Hand logs to Beam Pulse so Tk writes happen on the main thread.
+        if self._ui_queue:
+            self._ui_put("log", message, level)
+            return
 
     def _reset_cached_state(self):
         """Clear cached registers."""

--- a/subsystem/beam_pulse/README.md
+++ b/subsystem/beam_pulse/README.md
@@ -23,6 +23,8 @@ flowchart TD
     BeamPulse -->|"channel status, channel enable,<br/>armed state, action feedback"| MainControl
     MainControl -->|"emission limit provider"| BeamPulse
     Cathode -->|"predicted emission currents"| MainControl
+    BeamPulse -->|"manual disconnect check,<br/>disconnect notification"| MainControl
+    MainControl -->|"BCON-connected provider,<br/>guard setting, turn_off_all_beams()"| Cathode
 
     BeamEnergy -->|"+20kV current E-stop callback"| MainControl
     MainControl -->|"turn_off_all_beams()"| Cathode
@@ -82,10 +84,19 @@ as `("regs", regs)` messages. The subsystem consumes the queue on the Tk main
 thread every 200 ms, updates widgets, and forwards live state to Main Control
 callbacks.
 
+Driver warning/error logs are also routed through the same UI queue, so BCON
+worker-thread diagnostics are displayed through the dashboard logging path
+instead of being printed directly from the worker.
+
 On connect, the subsystem applies its preferred defaults:
 
 - Watchdog: `BCONDriver.DEFAULT_WATCHDOG_MS` currently 1500 ms.
 - Telemetry: `BCONDriver.DEFAULT_TELEMETRY_MS` currently 500 ms.
+
+The driver uses a short serial read timeout and disconnects itself after a
+bounded number of consecutive polling failures. When that happens, Beam Pulse
+clears its local armed/output/channel-enable mirrors, updates its UI, and emits
+the registered disconnect callback.
 
 ## Channel Modes
 
@@ -104,7 +115,7 @@ for pulse duration and count.
 
 ## Safety And Guard Rails
 
-There are three layers of safety/status behavior to keep distinct:
+There are four layers of safety/status behavior to keep distinct:
 
 - Beam Pulse software arming: `arm_beams()` allows output-producing actions;
   `disarm_beams()` stops CSV playback, clears local output state, commands BCON
@@ -114,13 +125,15 @@ There are three layers of safety/status behavior to keep distinct:
 - Emission-current limit: Beam Pulse blocks non-OFF Beam ON, Sync Start, and CSV
   step commands when the projected predicted emission current is at or above the
   Main Control limit.
+- BCON/CCS disconnect guard: Beam Pulse reports BCON disconnects to Main Control. Main Control then
+  decides whether Cathode Heating should disable or block CCS output.
 
 ### Main Control Arm Beams Button
 
 The Main Control `ARM BEAMS` / `BEAMS ARMED` control is the software
-permission switch for Beam Pulse actions.Arming does
-NOT start output, enable a channel, turn on cathode heating, or send a hardware
-arm command to BCON. It only allows armed-gated Dashboard controls to be used.
+permission switch for Beam Pulse actions. Arming does NOT start output, enable
+a channel, turn on cathode heating, or send a hardware arm command to BCON. It
+only allows armed-gated Dashboard controls to be used.
 
 When BCON is connected and beams are armed, the operator can:
 
@@ -135,6 +148,22 @@ stops any running CSV sequence, commands all BCON beam channels off when a BCON
 driver is available, disables armed-gated controls, and resets Dashboard beam
 buttons to OFF. It does not turn off cathode heater power-supply outputs; use
 `BEAMS E-STOP` when cathode heater outputs must also be shut off.
+
+### BCON Disconnect Integration
+
+Beam Pulse exposes two disconnect-related hooks for Main Control:
+
+- A manual-disconnect callback, called before an operator-requested BCON
+  disconnect proceeds.
+- A disconnect callback, called after Beam Pulse observes that BCON is no longer
+  connected.
+
+This keeps the BCON hardware lifecycle inside Beam Pulse while leaving the
+cross-subsystem safety decision in Main Control. In the current dashboard
+wiring, Main Control uses those hooks to warn the operator before a manual BCON
+disconnect would shut down active CCS outputs, and to call Cathode Heating's
+`turn_off_all_beams()` path when BCON is lost unexpectedly and the guard is
+enabled.
 
 ## Main Control API
 
@@ -158,6 +187,8 @@ Main Control registers these callbacks/providers on Beam Pulse:
 | `set_armed_status_callback(callback)` | `callback(armed)` | mirror software armed state |
 | `set_action_feedback_callback(callback)` | `callback(event_type, message, outcome, configs)` | action line and firmware acknowledgement display |
 | `set_emission_limit_providers(limit, currents)` | callables | emission-limit guard data |
+| `set_manual_disconnect_callback(callback)` | `callback() -> bool` | ask Main Control whether a user-requested BCON disconnect may continue |
+| `set_disconnect_callback(callback)` | `callback()` | notify Main Control after BCON disconnects |
 
 ## Manual And Sync Operation
 

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -114,6 +114,8 @@ class BeamPulseSubsystem:
         self._action_feedback_callback = None
         self._armed_status_callback = None
         self._beam_activity_callback = None
+        self._manual_disconnect_callback = None
+        self._disconnect_callback = None
         self._last_beam_activity_sent = None
         self._pending_firmware_acks = deque()
         self._last_send_failure_message = ""
@@ -1043,6 +1045,12 @@ class BeamPulseSubsystem:
                 self.channel_enable_status = [False, False, False]
                 self._update_armed_button_states(False)
                 self._notify_all_channel_enables(False)
+                callback = getattr(self, "_disconnect_callback", None)
+                if callable(callback):
+                    try:
+                        callback()
+                    except Exception:
+                        pass
             self.update_bcon_connection_status()
         elif typ == "regs":
             regs = msg[1]
@@ -1342,6 +1350,13 @@ class BeamPulseSubsystem:
             return
         if self.bcon_driver.is_connected():
             # User clicked "Disconnect" — only tear down, do NOT reconnect.
+            callback = getattr(self, "_manual_disconnect_callback", None)
+            if callable(callback):
+                try:
+                    if not callback():
+                        return
+                except Exception:
+                    return
             self.disconnect()
             if hasattr(self, 'connect_btn'):
                 self.connect_btn.configure(text="Reconnect", state="normal")
@@ -1449,6 +1464,12 @@ class BeamPulseSubsystem:
         self._beam_activity_callback = callback
         self._last_beam_activity_sent = None
         self._notify_beam_activity(bool(getattr(self, "_active_channels", set())))
+
+    def set_manual_disconnect_callback(self, callback):
+        self._manual_disconnect_callback = callback if callable(callback) else None
+
+    def set_disconnect_callback(self, callback):
+        self._disconnect_callback = callback if callable(callback) else None
 
     def _notify_beam_activity(self, active: bool) -> None:
         """Notify when any Beam Pulse channel transitions between active/off."""

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -92,7 +92,7 @@ class BeamPulseSubsystem:
                 port=port,
                 baudrate=baudrate,
                 unit=unit,
-                timeout=1.0,
+                timeout=BCONDriver.DEFAULT_TIMEOUT,
                 debug=debug,
             )
         else:

--- a/subsystem/beam_pulse/beam_pulse.py
+++ b/subsystem/beam_pulse/beam_pulse.py
@@ -1055,6 +1055,12 @@ class BeamPulseSubsystem:
         elif typ == "regs":
             regs = msg[1]
             self._update_ui_from_registers(regs)
+        elif typ == "log":
+            # BCON driver queued this from a worker thread; _log handles main-thread UI logging.
+            text = str(msg[1])
+            level_name = str(msg[2]).upper() if len(msg) > 2 else "INFO"
+            level = getattr(LogLevel, level_name, LogLevel.INFO)
+            self._log(f"BCON: {text}", level)
         elif typ == "wrote":
             reg, val = msg[1], msg[2]
             if reg == REG_COMMAND and val != 0:

--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -13,6 +13,8 @@ The subsystem sits between the Tkinter GUI and the hardware drivers. It is respo
 - Coordinating immediate sets vs. ramped sets.
 - Keeping live voltage, current, mode, and temperature displays updated.
 - Polling 9104 power-supply readbacks on a background thread.
+- Cooperating with Main Control's BCON-disconnect guard so CCS outputs are not
+  enabled when BCON is unavailable, unless that guard is intentionally disabled.
 
 ## Hardware Relationships
 
@@ -32,6 +34,10 @@ At runtime the subsystem has three main jobs:
 3. Refresh GUI values on a 500 ms Tkinter loop by consuming 9104 readbacks from a background poller.
 
 Temperature-controller readings are still owned by the `E5CNModbus` temperature-controller object. `cathode_heating.py` reads the latest cached temperature value from `temperature_controller.temperatures[index]`.
+
+Main Control may also provide a BCON connection checker and a runtime guard
+setting. When that guard is enabled, Cathode Heating treats a disconnected BCON
+as a reason to block new CCS output enables.
 
 ## UI Structure Per Cathode
 
@@ -155,12 +161,30 @@ Before sending a new setpoint, the subsystem validates it against current driver
 
 When the output toggle is switched on, `toggle_output()` also verifies:
 
+- BCON is connected, when Main Control's BCON-disconnect guard is enabled.
 - A stored target voltage exists.
 - A stored target current exists.
 - The stored target voltage is within OVP.
 - The stored target current is within OCP.
 
 If any of those checks fail, output is not enabled.
+
+## BCON Disconnect Guard
+
+Main Control gives Cathode Heating:
+
+- `disable_ccs_output_on_bcon_disconnect`: the runtime guard setting, defaulted
+  on by Main Control.
+- `bcon_is_connected`: a callable that reports the current Beam Pulse/BCON
+  connection state.
+
+With the guard enabled, `toggle_output()` refuses to enable a cathode output
+when BCON is disconnected and logs a warning naming the affected cathode. This
+prevents CCS output from being turned on after BCON communication has been lost.
+
+For an actual BCON disconnect event, Main Control calls Cathode Heating's
+existing `turn_off_all_beams()` helper when any cathode output is active. That
+path turns off all active 9104 outputs and updates the cathode output button state.
 
 ## Ramping Behavior
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -147,6 +147,8 @@ class CathodeHeatingSubsystem:
         self.power_supply_poll_thread = None
         self.power_supply_poll_stop_event = threading.Event()
         self.power_supply_poll_stop = self.power_supply_poll_stop_event
+        self.disable_ccs_output_on_bcon_disconnect = True
+        self.bcon_is_connected = None
         # Tells the long-lived poller to pause while COM-port updates swap driver objects.
         self.power_supply_reconfiguring = threading.Event()
         self.power_supply_readback_lock = threading.Lock()
@@ -2152,6 +2154,22 @@ class CathodeHeatingSubsystem:
         new_state = not self.toggle_states[index]
 
         if new_state:  # If turning output ON
+            if self.disable_ccs_output_on_bcon_disconnect:
+                bcon_is_connected = getattr(self, "bcon_is_connected", None)
+                try:
+                    bcon_connected = (
+                        bool(bcon_is_connected()) if callable(bcon_is_connected) else False
+                    )
+                except Exception:
+                    bcon_connected = False
+                if not bcon_connected:
+                    cathode = ['A', 'B', 'C'][index]
+                    self.log(
+                        f"CCS output enable blocked for Cathode {cathode}: BCON device not connected.",
+                        LogLevel.WARNING,
+                    )
+                    return
+
             # Retrieve target voltage and current
             target_voltage = self.user_set_voltages[index]
             if target_voltage is None:

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -45,6 +45,7 @@ Main Control is a two-tab subpanel.
 - Launch Log Post-processor button.
 - UI log-level and file log-level dropdowns.
 - Total Max Emission Current control.
+- Disable CCS Output on BCON Disconnect toggle.
 - F1 keyboard shortcut hint.
 
 ## Code Structure
@@ -55,12 +56,15 @@ Main Control is a two-tab subpanel.
 - `create_beam_output_status_panel()` builds the Beam A/B/C output lines and
   latest-action line.
 - `wire_beam_pulse()` registers Main Control as the callback target for Beam
-  Pulse status updates and gives Beam Pulse the emission-limit providers.
+  Pulse status updates, gives Beam Pulse the emission-limit providers, and wires
+  BCON disconnect notifications into Cathode Heating.
 - `wire_beam_energy()` registers the Beam Energy +20 kV current E-stop callback.
 - `create_com_port_frame()`, `apply_com_port_changes()`, and related helpers
   manage COM-port selection through the parent Dashboard.
 - `set_total_max_emission_current_limit()` validates and persists the emission
   limit through `usr/main_control_config.py`.
+- `toggle_disable_ccs_output_on_bcon_disconnect()` updates the runtime
+  BCON/CCS guard setting and propagates it to Cathode Heating.
 
 ## Major Action Handlers
 
@@ -75,6 +79,7 @@ Main Control is a two-tab subpanel.
 | `_on_channel_status_update()` | Mirrors live BCON channel output state into Beam A/B/C buttons and status lines. |
 | `_on_channel_enable_status_update()` | Mirrors live BCON channel enable state into CH A/B/C buttons and beam-button availability. |
 | `_handle_action_feedback()` | Converts Beam Pulse action callbacks into the latest-action status line. |
+| `_handle_bcon_disconnected()` | Disables CCS output through Cathode Heating when BCON disconnects and the guard is enabled. |
 
 ## Subsystem Relationships
 
@@ -100,16 +105,22 @@ Beam Pulse calls back into Main Control with:
 - Live channel enable status.
 - Software armed status.
 - Action feedback and firmware acknowledgement text.
+- Manual-disconnect confirmation requests.
+- BCON disconnect notifications.
 
 ### Cathode Heating
 
-Main Control uses Cathode Heating in two ways:
+Main Control uses Cathode Heating in three ways:
 
 - It exposes `get_predicted_emission_currents_ma()` to Beam Pulse so Beam Pulse
   can block output commands that would exceed the configured total predicted
   emission-current limit.
 - During BEAMS E-STOP, Main Control calls `turn_off_all_beams()` to turn off the
   cathode heating power-supply outputs.
+- When the BCON-disconnect guard is enabled, Main Control also calls
+  `turn_off_all_beams()` if BCON disconnects while any cathode output is active.
+  The same setting is passed to Cathode Heating so it can block new CCS output
+  enables while BCON is disconnected.
 
 ### Beam Energy
 
@@ -137,4 +148,8 @@ Dashboard callbacks.
   performs output checks before sending the synchronized start to BCON.
 - BEAMS E-STOP is the Main Control path that combines BCON stop, Cathode Heating
   output shutdown, Beam Pulse disarm, and Main Control UI reset.
-  
+- Disable CCS Output on BCON Disconnect is a runtime Main Control setting. When
+  enabled, an unexpected BCON disconnect turns off active CCS outputs, and a
+  manual BCON disconnect asks for confirmation before it shuts those outputs
+  down. When disabled, BCON disconnects no longer drive CCS output shutdown or
+  block cathode output enable requests.

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -717,6 +717,17 @@ class MainControlPanel:
             cathode.disable_ccs_output_on_bcon_disconnect = (
                 self.disable_ccs_output_on_bcon_disconnect
             )
+        # When turning this setting on, immediately check BCON connection and update 
+        # CCS output to off if needed so the UI state is consistent with the setting.
+        if self.disable_ccs_output_on_bcon_disconnect:
+            beam_pulse = getattr(self, "subsystems", {}).get("Beam Pulse")
+            is_connected = getattr(beam_pulse, "is_connected", None)
+            try:
+                bcon_connected = bool(is_connected()) if callable(is_connected) else False
+            except Exception:
+                bcon_connected = False
+            if not bcon_connected:
+                self._handle_bcon_disconnected()
         state = "enabled" if self.disable_ccs_output_on_bcon_disconnect else "disabled"
         self.logger.info(f"Disable CCS Output on BCON Disconnect {state}")
 

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -71,6 +71,7 @@ class MainControlPanel:
         self.toggle_off_image = toggle_off_image
         self.subsystems = {}
         self.com_ports = self._get_com_ports()
+        self.disable_ccs_output_on_bcon_disconnect = True
 
         self.total_max_emission_current_ma = load_total_max_emission_current(logger=self.logger)
         self.total_max_emission_current_entry_var = tk.StringVar(value="")
@@ -124,6 +125,17 @@ class MainControlPanel:
                 lambda: self.total_max_emission_current_ma,
                 self._get_predicted_emission_currents_for_beam_pulse,
             )
+        if hasattr(beam_pulse, "set_manual_disconnect_callback"):
+            beam_pulse.set_manual_disconnect_callback(self._confirm_manual_bcon_disconnect)
+        if hasattr(beam_pulse, "set_disconnect_callback"):
+            beam_pulse.set_disconnect_callback(self._handle_bcon_disconnected)
+        cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
+        if cathode is not None:
+            cathode.disable_ccs_output_on_bcon_disconnect = (
+                self.disable_ccs_output_on_bcon_disconnect
+            )
+            if callable(getattr(beam_pulse, "is_connected", None)):
+                cathode.bcon_is_connected = beam_pulse.is_connected
 
     def _get_predicted_emission_currents_for_beam_pulse(self):
         cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
@@ -266,11 +278,22 @@ class MainControlPanel:
         config_frame = ttk.Frame(config_tab, padding="10")
         config_frame.pack(fill=tk.BOTH, expand=True)
 
-        # 1. COM Port Configuration
-        self.create_com_port_frame(config_frame)
+        section_frame = ttk.Frame(config_frame)
+        section_frame.pack(side=tk.TOP, anchor='nw', fill=tk.X)
 
-        # 2. Save Layout button
-        save_layout_frame = ttk.Frame(config_frame)
+        general_frame = ttk.LabelFrame(section_frame, text="General", padding=(8, 6))
+        general_frame.pack(side=tk.LEFT, anchor='nw', padx=(0, 12), pady=5)
+
+        beam_cathode_frame = ttk.LabelFrame(
+            section_frame,
+            text="Beam and Cathode Enable Settings",
+            padding=(8, 6),
+        )
+        beam_cathode_frame.pack(side=tk.LEFT, anchor='nw', pady=5)
+
+        self.create_com_port_frame(general_frame)
+
+        save_layout_frame = ttk.Frame(general_frame)
         save_layout_frame.pack(side=tk.TOP, anchor='nw', padx=5, pady=5)
         ttk.Button(
             save_layout_frame,
@@ -278,15 +301,13 @@ class MainControlPanel:
             command=self.save_current_pane_state
         ).pack(side=tk.LEFT, padx=5)
 
-        # 3. Post Processor button
-        self.create_post_processor_button(config_frame)
+        self.create_post_processor_button(general_frame)
 
-        # 4. Log Level dropdown
-        self.create_log_level_dropdown(config_frame)
-        self.file_create_log_level_dropdown(config_frame)
+        self.create_log_level_dropdown(general_frame)
+        self.file_create_log_level_dropdown(general_frame)
 
-        # Expose the limit used by beam-output start paths.
-        self.create_total_max_emission_current_controls(config_frame)
+        self.create_total_max_emission_current_controls(beam_cathode_frame)
+        self.create_disable_ccs_output_on_bcon_disconnect_toggle(beam_cathode_frame)
 
         # Add F1 help hint
         help_label = ttk.Label(
@@ -659,6 +680,64 @@ class MainControlPanel:
             foreground="gray",
         ).pack(anchor=tk.W, padx=(2, 0), pady=(0, 4))
 
+    def create_disable_ccs_output_on_bcon_disconnect_toggle(self, parent_frame):
+        section = ttk.Frame(parent_frame)
+        section.pack(side=tk.TOP, anchor='nw', padx=5, pady=(6, 2))
+        ttk.Label(
+            section,
+            text="Disable CCS Output on BCON Disconnect",
+            font=("Segoe UI", 8, "bold"),
+        ).pack(anchor=tk.W, pady=(0, 2))
+
+        if self.toggle_on_image and self.toggle_off_image:
+            self.disable_ccs_bcon_disconnect_button = tk.Button(
+                section,
+                image=self.toggle_on_image,
+                command=self.toggle_disable_ccs_output_on_bcon_disconnect,
+                relief=tk.FLAT,
+                bd=0,
+                bg="white",
+            )
+        else:
+            self.disable_ccs_bcon_disconnect_button = tk.Button(
+                section,
+                command=self.toggle_disable_ccs_output_on_bcon_disconnect,
+                width=8,
+            )
+        self.disable_ccs_bcon_disconnect_button.pack(anchor=tk.W)
+        self._update_disable_ccs_bcon_disconnect_toggle()
+
+    def toggle_disable_ccs_output_on_bcon_disconnect(self):
+        self.disable_ccs_output_on_bcon_disconnect = (
+            not self.disable_ccs_output_on_bcon_disconnect
+        )
+        self._update_disable_ccs_bcon_disconnect_toggle()
+        cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
+        if cathode is not None:
+            cathode.disable_ccs_output_on_bcon_disconnect = (
+                self.disable_ccs_output_on_bcon_disconnect
+            )
+        state = "enabled" if self.disable_ccs_output_on_bcon_disconnect else "disabled"
+        self.logger.info(f"Disable CCS Output on BCON Disconnect {state}")
+
+    def _update_disable_ccs_bcon_disconnect_toggle(self):
+        btn = getattr(self, "disable_ccs_bcon_disconnect_button", None)
+        if btn is None:
+            return
+        enabled = bool(self.disable_ccs_output_on_bcon_disconnect)
+        if self.toggle_on_image and self.toggle_off_image:
+            _safe_widget_config(
+                btn,
+                image=self.toggle_on_image if enabled else self.toggle_off_image,
+            )
+        else:
+            _safe_widget_config(
+                btn,
+                text="ON" if enabled else "OFF",
+                bg="#2e7d32" if enabled else "#888888",
+                fg="white",
+            )
+
     def set_total_max_emission_current_limit(self):
         """UI callback for committing the Main Control total emission limit."""
         raw_text = str(self.total_max_emission_current_entry_var.get()).strip()
@@ -802,6 +881,65 @@ class MainControlPanel:
             "failure",
         )
         return None
+
+    def _ask_bcon_disconnect_confirmation(self):
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Disconnect BCON")
+        dialog.transient(self.root)
+        dialog.grab_set()
+        result = {"confirmed": False}
+
+        ttk.Label(
+            dialog,
+            text=(
+                "CCS Output will be disabled if BCON is disconnected. "
+                "Are you sure you want to disconnect?"
+            ),
+            wraplength=360,
+            justify=tk.LEFT,
+            padding=(12, 12),
+        ).pack(fill=tk.X)
+
+        buttons = ttk.Frame(dialog, padding=(12, 0, 12, 12))
+        buttons.pack(fill=tk.X)
+
+        def confirm():
+            result["confirmed"] = True
+            dialog.destroy()
+
+        ttk.Button(buttons, text="Yes, disconnect", command=confirm).pack(
+            side=tk.LEFT, padx=(0, 8)
+        )
+        ttk.Button(buttons, text="Cancel", command=dialog.destroy).pack(side=tk.LEFT)
+        dialog.protocol("WM_DELETE_WINDOW", dialog.destroy)
+        dialog.wait_window()
+        return result["confirmed"]
+
+    def _confirm_manual_bcon_disconnect(self):
+        cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
+        ccs_output_active = bool(cathode and any(getattr(cathode, "toggle_states", [])))
+        if self.disable_ccs_output_on_bcon_disconnect and ccs_output_active:
+            if not self._ask_bcon_disconnect_confirmation():
+                self.logger.info("BCON disconnect canceled; CCS output remains enabled")
+                return False
+            turn_off = getattr(cathode, "turn_off_all_beams", None)
+            if callable(turn_off):
+                self.logger.warning(
+                    "BCON manual disconnect requested; disabling CCS output"
+                )
+                turn_off()
+        return True
+
+    def _handle_bcon_disconnected(self):
+        if not self.disable_ccs_output_on_bcon_disconnect:
+            return
+        cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
+        if not cathode or not any(getattr(cathode, "toggle_states", [])):
+            return
+        turn_off = getattr(cathode, "turn_off_all_beams", None)
+        if callable(turn_off):
+            self.logger.warning("BCON disconnected; disabling CCS output")
+            turn_off()
 
     def _set_armed_ui(self, armed, reset=False):
         if hasattr(self, "beams_ready_button"):

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -883,37 +883,14 @@ class MainControlPanel:
         return None
 
     def _ask_bcon_disconnect_confirmation(self):
-        dialog = tk.Toplevel(self.root)
-        dialog.title("Disconnect BCON")
-        dialog.transient(self.root)
-        dialog.grab_set()
-        result = {"confirmed": False}
-
-        ttk.Label(
-            dialog,
-            text=(
+        return messagebox.askokcancel(
+            "Disconnect BCON",
+            (
                 "CCS Output will be disabled if BCON is disconnected. "
-                "Are you sure you want to disconnect?"
+                "Click 'OK' if you still want to disconnect."
             ),
-            wraplength=360,
-            justify=tk.LEFT,
-            padding=(12, 12),
-        ).pack(fill=tk.X)
-
-        buttons = ttk.Frame(dialog, padding=(12, 0, 12, 12))
-        buttons.pack(fill=tk.X)
-
-        def confirm():
-            result["confirmed"] = True
-            dialog.destroy()
-
-        ttk.Button(buttons, text="Yes, disconnect", command=confirm).pack(
-            side=tk.LEFT, padx=(0, 8)
+            parent=self.root,
         )
-        ttk.Button(buttons, text="Cancel", command=dialog.destroy).pack(side=tk.LEFT)
-        dialog.protocol("WM_DELETE_WINDOW", dialog.destroy)
-        dialog.wait_window()
-        return result["confirmed"]
 
     def _confirm_manual_bcon_disconnect(self):
         cathode = getattr(self, "subsystems", {}).get("Cathode Heating")

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -906,8 +906,8 @@ class MainControlPanel:
     def _confirm_manual_bcon_disconnect(self):
         cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
         ccs_output_active = bool(cathode and any(getattr(cathode, "toggle_states", [])))
-        if self.disable_ccs_output_on_bcon_disconnect and ccs_output_active:
-            if not self._ask_bcon_disconnect_confirmation():
+        if self.disable_ccs_output_on_bcon_disconnect and cathode:
+            if ccs_output_active and not self._ask_bcon_disconnect_confirmation():
                 self.logger.info("BCON disconnect canceled; CCS output remains enabled")
                 return False
             turn_off = getattr(cathode, "turn_off_all_beams", None)
@@ -922,7 +922,7 @@ class MainControlPanel:
         if not self.disable_ccs_output_on_bcon_disconnect:
             return
         cathode = getattr(self, "subsystems", {}).get("Cathode Heating")
-        if not cathode or not any(getattr(cathode, "toggle_states", [])):
+        if not cathode:
             return
         turn_off = getattr(cathode, "turn_off_all_beams", None)
         if callable(turn_off):


### PR DESCRIPTION
This PR implements a lock on CCS output enable switches so that they are not allowed to turn on if BCON is disconnected, an doesn't allow CCS from turning on if BCON is disconnected. This PR also adds a button in the Main Control Config menu that lets the user toggle this functionality, mostly for testing purposes. 

This PR branches off of PR #160. That branch should be reviewed and merged before this branch is able to be. 

NOTE: This PR should only be reviewed and merged once all PRs 153 and under are merged into develop as it is based off a branch with all those merged together. This PR is currently being compared to test/PRs-153-and-below-merged to more easily see diffs in files changed, and for codex reviews. Once develop gets PRs 153 and under merged, this PR should change back to being compared to develop.