### PR TITLE
Compacted VTRX subpanel

### DIFF
--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -390,14 +390,13 @@ class VTRXSubsystem:
 
         # Plot frame
         plot_frame = tk.Frame(layout_frame)
-        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=1) 
+        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(4, 6), pady=(3, 5)) 
         self.fig, self.ax = plt.subplots()
-        self.fig.subplots_adjust(left=0.15, right=0.99, top=0.97, bottom=0.05)
+        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.94, bottom=0.18)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
         self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
         self.fig.autofmt_xdate()  
         self.ax.set_title('')
-        self.ax.set_xlabel('Time', fontsize=8)
         self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
@@ -408,7 +407,7 @@ class VTRXSubsystem:
         self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
         self.canvas.draw()
         self.canvas_widget = self.canvas.get_tk_widget()
-        self.canvas_widget.pack(fill=tk.BOTH, expand=True)
+        self.canvas_widget.pack(fill=tk.BOTH, expand=True, padx=4, pady=3)
      
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         """

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -296,13 +296,17 @@ class VTRXSubsystem:
         """
         layout_frame = tk.Frame(self.parent)
         layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        layout_frame.grid_columnconfigure(0, weight=0)
+        layout_frame.grid_columnconfigure(1, weight=1)
+        layout_frame.grid_rowconfigure(0, weight=1)
+        layout_frame.grid_rowconfigure(1, weight=0)
 
         # Formatting status indicators
         switches_frame = tk.Frame(layout_frame)
-        switches_frame.pack(side=tk.LEFT, fill=tk.Y, expand=True, padx=5)
+        switches_frame.grid(row=0, column=0, sticky='nsew', padx=5)
 
         # Distribute vertical space
-        switches_frame.grid_rowconfigure(tuple(range(10)), weight=1)
+        switches_frame.grid_rowconfigure(tuple(range(8)), weight=1)
         switches_frame.grid_columnconfigure(0, weight=3) # Label colunm
         switches_frame.grid_columnconfigure(1, weight=1) # indicator column 
 
@@ -327,29 +331,9 @@ class VTRXSubsystem:
             canvas.grid(row=idx, column=1, sticky='nsew', pady=2, padx=(0, 1))
             self.circle_indicators.append((canvas, oval_id))
 
-        # Pressure label setup
-        pressure_frame = tk.Frame(switches_frame)
-        pressure_frame.grid(row=len(switch_labels), column=0, columnspan=2, sticky='nsew', pady=1)
-        # Configure columns to center the label
-        pressure_frame.grid_columnconfigure(0, weight=1) 
-        pressure_frame.grid_columnconfigure(2, weight=1) 
-        pressure_frame.grid_columnconfigure(1, weight=0) 
-
-        self.label_pressure = tk.Label(
-            pressure_frame,
-            text="No data...", 
-            anchor='center',
-            font=('Helvetica', 11, 'bold'), 
-            relief='ridge', 
-            bg='white',
-            fg='black', 
-            padx=3, pady=2
-        )
-        self.label_pressure.grid(row=0, column=1, ipady=2, pady=(0,2))
-
         # Buttons frame
-        button_frame = tk.Frame(switches_frame)
-        button_frame.grid(row=len(switch_labels)+1, column=0, columnspan=2, sticky='nsew', pady=1)
+        button_frame = tk.Frame(layout_frame)
+        button_frame.grid(row=1, column=0, sticky='ew', padx=5, pady=(2, 1))
         button_frame.bind("<Configure>", self._on_button_frame_resize)
 
         self.button_frame = button_frame
@@ -390,7 +374,7 @@ class VTRXSubsystem:
 
         # Plot frame
         plot_frame = tk.Frame(layout_frame)
-        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(4, 6), pady=(3, 5)) 
+        plot_frame.grid(row=0, column=1, sticky='nsew', padx=(4, 6), pady=(3, 1)) 
         self.fig, self.ax = plt.subplots()
         self.fig.subplots_adjust(left=0.17, right=0.96, top=0.94, bottom=0.18)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
@@ -408,6 +392,23 @@ class VTRXSubsystem:
         self.canvas.draw()
         self.canvas_widget = self.canvas.get_tk_widget()
         self.canvas_widget.pack(fill=tk.BOTH, expand=True, padx=4, pady=3)
+
+        # Pressure label setup
+        pressure_frame = tk.Frame(layout_frame)
+        pressure_frame.grid(row=1, column=1, sticky='ew', padx=(4, 6), pady=(2, 1))
+        pressure_frame.grid_columnconfigure(0, weight=1)
+
+        self.label_pressure = tk.Label(
+            pressure_frame,
+            text="No data...", 
+            anchor='center',
+            font=('Helvetica', 11, 'bold'), 
+            relief='ridge', 
+            bg='white',
+            fg='black', 
+            padx=3, pady=2
+        )
+        self.label_pressure.grid(row=0, column=0, ipady=2)
      
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         """


### PR DESCRIPTION
<img width="521" height="335" alt="image" src="https://github.com/user-attachments/assets/17598eb4-605e-44e1-b93f-e182eb2ad2c0" />

Compacted the VTRX subpanel to improve readability with new dashboard layout.
- Reduced the VTRX graph’s overall vertical footprint.
- Added more padding around the graph so it is not pressed against the subpanel edge.
- Removed the x-axis Time label.
- Adjusted plot margins so tick labels and axes have more breathing room.
- Moved the pressure readout from the left status column to underneath the graph.
- Kept the time range selector and Save Plot button grouped under the left indicator column.
- Aligned the graph height visually with the indicator list, ending near Argon Gate CLOSED.