### PR TITLE
Compact EBeam Dashboard with stylistic changes to the CCS, VTRX, and PMON subpanels

### DIFF
--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -128,7 +128,7 @@ class BeamEnergySubsystem:
         self.glassman_interlock_var = tk.StringVar(value="UNARMED")
         self.arm_beams_var = tk.StringVar(value="UNARMED")
         self.ccs_power_var = tk.StringVar(value="OFF")
-        self.logic_comms_color = tk.StringVar(value="red")  # red=Disconnected, blue=Connected
+        self.logic_comms_color = tk.StringVar(value="red")  # red=Disconnected, green=Connected
         self.interlocks_color = tk.StringVar(value="red")   # red=Fault, green=All Good
         # Beam Energy owns the +20kV threshold; Dashboard provides the actual stop handler.
         self.beams_estop_current_entry_var = tk.StringVar(value="")
@@ -994,7 +994,7 @@ class BeamEnergySubsystem:
         """Update connection status indicators."""
         if index < len(self.ui_elements):
             if connected:
-                self.connection_status_colors[index].set("blue")
+                self.connection_status_colors[index].set("green")
             else:
                 self.connection_status_colors[index].set("red")
 
@@ -1061,7 +1061,7 @@ class BeamEnergySubsystem:
             self.arm_beams_var.set("ARMED" if arm_beams else "UNARMED")
             self.ccs_power_var.set("ON" if ccs_power else "OFF")
             self.glassman_interlock_var.set("ARMED" if arm_80kv else "UNARMED")
-            self.logic_comms_color.set("blue" if logic_comms else "red")
+            self.logic_comms_color.set("green" if logic_comms else "red")
             self.interlocks_color.set("red" if interlocks else "green")
 
     def start_polling_thread(self):

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -343,16 +343,18 @@ class CathodeHeatingSubsystem:
         cathode_labels = ['A', 'B', 'C']
         style = ttk.Style()
         style.configure('Flat.TButton', padding=(0, 0, 0, 0), relief='flat', borderwidth=0)
-        style.configure('Bold.TLabel', font=('Helvetica', 10, 'bold'))
-        style.configure('SubpanelTitle.TLabel', font=('Helvetica', 10, 'bold'))
-        style.configure('Subpanel.TLabelframe.Label', font=('Helvetica', 10, 'bold'))
-        style.configure('RightAlign.TLabel', font=('Helvetica', 9), anchor='e')
-        style.configure('Small.TLabel', font=('Helvetica', 8))
-        style.configure('OverTemp.TLabel', foreground='red', font=('Helvetica', 10, 'bold'))  # Overtemperature style
-        style.configure('RampOn.TButton', background='green', foreground='black', font=('Helvetica', 8, 'bold'))
-        style.configure('RampOff.TButton', background='red', foreground='black', font=('Helvetica', 8, 'bold')) # Ramp button style
-        style.configure('StopInactive.TButton', foreground='grey')
-        style.configure('StopActive.TButton',  foreground='red')
+        style.configure('Compact.TButton', font=('Segoe UI', 8), padding=(2, 0))
+        style.configure('Bold.TLabel', font=('Segoe UI', 8, 'bold'))
+        style.configure('SubpanelTitle.TLabel', font=('Segoe UI', 8, 'bold'))
+        style.configure('Subpanel.TLabelframe', padding=(3, 2))
+        style.configure('Subpanel.TLabelframe.Label', font=('Segoe UI', 8, 'bold'))
+        style.configure('RightAlign.TLabel', font=('Segoe UI', 8), anchor='e')
+        style.configure('Small.TLabel', font=('Segoe UI', 8))
+        style.configure('OverTemp.TLabel', foreground='red', font=('Segoe UI', 8, 'bold'))  # Overtemperature style
+        style.configure('RampOn.TButton', background='green', foreground='black', font=('Segoe UI', 8, 'bold'), padding=(2, 0))
+        style.configure('RampOff.TButton', background='red', foreground='black', font=('Segoe UI', 8, 'bold'), padding=(2, 0)) # Ramp button style
+        style.configure('StopInactive.TButton', foreground='grey', font=('Segoe UI', 8), padding=(2, 0))
+        style.configure('StopActive.TButton',  foreground='red', font=('Segoe UI', 8), padding=(2, 0))
 
         # Load toggle images
         self.toggle_on_image = tk.PhotoImage(file=resource_path("media/toggle_on.png"))
@@ -389,15 +391,15 @@ class CathodeHeatingSubsystem:
         self.cv_cc_labels: list[tuple[tk.Label, tk.Label]] = []   # (cv_label, cc_label) per cathode
         self.slew_rate_vars = []
         for i in range(3):
-            frame = ttk.LabelFrame(self.scrollable_frame, text=f'Cathode {cathode_labels[i]}', padding= (2,5))
-            frame.grid(row=0, column=i, padx=5, pady=0.1, sticky='nsew')
+            frame = ttk.LabelFrame(self.scrollable_frame, text=f'Cathode {cathode_labels[i]}', padding=(2, 2))
+            frame.grid(row=0, column=i, padx=5, pady=0, sticky='nsew')
             self.cathode_frames.append(frame)
 
             frame.columnconfigure(1, weight=1)  # Allow notebook to expand
             frame.columnconfigure(2, weight=0)
 
             notebook = ttk.Notebook(frame)
-            notebook.grid(row=0, column=0, columnspan=2, sticky='w', pady=2)
+            notebook.grid(row=0, column=0, columnspan=2, sticky='w', pady=0)
 
             # Create the main tab
             main_tab = ttk.Frame(notebook)
@@ -413,7 +415,7 @@ class CathodeHeatingSubsystem:
 
             # ======Main Control Menu=====
             control_frame = ttk.Frame(main_tab)
-            control_frame.grid(row=0, column=0, sticky='ew', padx=2, pady=(6, 2))
+            control_frame.grid(row=0, column=0, sticky='ew', padx=2, pady=(2, 1))
             control_frame.columnconfigure(0, weight=1)
             control_frame.rowconfigure(0, weight=0)
             control_frame.rowconfigure(1, weight=0)
@@ -424,26 +426,26 @@ class CathodeHeatingSubsystem:
             heater_controls_frame.columnconfigure(1, weight=1, uniform='heater_controls')
 
             # Create current control section
-            current_control_frame = ttk.LabelFrame(heater_controls_frame, text='Heater Current Control', padding=(6, 4), style='Subpanel.TLabelframe')
+            current_control_frame = ttk.LabelFrame(heater_controls_frame, text='Heater Current Control', padding=(3, 2), style='Subpanel.TLabelframe')
             current_control_frame.grid(row=0, column=1, sticky='ew', padx=(4, 0))
 
             # Set target current entry box
             current_entry_frame = ttk.Frame(current_control_frame)
             current_entry_frame.grid(row=0, column=0, sticky='w')
 
-            ttk.Label(current_entry_frame, text='Sent', style='RightAlign.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 4))
-            ttk.Label(current_entry_frame, text='Goal', style='RightAlign.TLabel').grid(row=1, column=0, sticky='w', padx=(0, 4), pady=(2, 0))
-            ttk.Label(current_entry_frame, text='Entry', style='RightAlign.TLabel').grid(row=2, column=0, sticky='w', padx=(0, 4), pady=(2, 0))
+            ttk.Label(current_entry_frame, text='Sent', style='RightAlign.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 3))
+            ttk.Label(current_entry_frame, text='Goal', style='RightAlign.TLabel').grid(row=1, column=0, sticky='w', padx=(0, 3), pady=(1, 0))
+            ttk.Label(current_entry_frame, text='Entry', style='RightAlign.TLabel').grid(row=2, column=0, sticky='w', padx=(0, 3), pady=(1, 0))
 
             target_current = tk.DoubleVar(value=0.0)
             current_entry_field = ttk.Entry(current_entry_frame, textvariable=target_current, width=5)
-            current_entry_field.grid(row=2, column=1, sticky='w', padx=(0, 2), pady=(2, 0))
+            current_entry_field.grid(row=2, column=1, sticky='w', padx=(0, 2), pady=(1, 0))
             self.entry_fields.append(current_entry_field)
 
-            set_current_button = ttk.Button(current_entry_frame, text="Set", width=4, command=lambda i=i, entry_field=current_entry_field: self.handle_current_entry_set(i, entry_field))
-            set_current_button.grid(row=2, column=2, sticky='w', padx=(2, 0), pady=(2, 0))
+            set_current_button = ttk.Button(current_entry_frame, text="Set", width=4, style='Compact.TButton', command=lambda i=i, entry_field=current_entry_field: self.handle_current_entry_set(i, entry_field))
+            set_current_button.grid(row=2, column=2, sticky='w', padx=(2, 0), pady=(1, 0))
 
-            current_display_frame = tk.Frame(current_entry_frame, bd=2, relief='groove', padx=2, pady=1)
+            current_display_frame = tk.Frame(current_entry_frame, bd=1, relief='groove', padx=1, pady=0)
             current_display_frame.configure(bg='#d9d9d9')
             current_display_frame.grid(row=0, column=1, sticky='w')
             current_label = ttk.Label(current_display_frame, textvariable=self.sent_heater_current_vars[i], style='Bold.TLabel')
@@ -451,41 +453,41 @@ class CathodeHeatingSubsystem:
             unit_label = ttk.Label(current_display_frame, text=" A", style="Bold.TLabel")
             unit_label.pack(side='left')
 
-            current_display_frame_secondary = tk.Frame(current_entry_frame, bd=2, relief='groove', padx=2, pady=1)
+            current_display_frame_secondary = tk.Frame(current_entry_frame, bd=1, relief='groove', padx=1, pady=0)
             current_display_frame_secondary.configure(bg='#d9d9d9')
-            current_display_frame_secondary.grid(row=1, column=1, sticky='w', pady=(2, 0))
+            current_display_frame_secondary.grid(row=1, column=1, sticky='w', pady=(1, 0))
             current_label_secondary = ttk.Label(current_display_frame_secondary, textvariable=self.heater_current_vars[i], style='Bold.TLabel')
             current_label_secondary.pack(side='left')
             unit_label_secondary = ttk.Label(current_display_frame_secondary, text=" A", style="Bold.TLabel")
             unit_label_secondary.pack(side='left')
 
-            inc_current_button = ttk.Button(current_entry_frame, text="+0.01", width=5, command=lambda i=i: self.adjust_current(i, 0.01))
-            inc_current_button.grid(row=3, column=1, sticky='w', pady=(3, 0))
-            dec_current_button = ttk.Button(current_entry_frame, text="-0.01", width=5, command=lambda i=i: self.adjust_current(i, -0.01))
-            dec_current_button.grid(row=3, column=2, sticky='w', padx=(2, 0), pady=(3, 0))
+            inc_current_button = ttk.Button(current_entry_frame, text="+0.01", width=5, style='Compact.TButton', command=lambda i=i: self.adjust_current(i, 0.01))
+            inc_current_button.grid(row=3, column=1, sticky='w', pady=(1, 0))
+            dec_current_button = ttk.Button(current_entry_frame, text="-0.01", width=5, style='Compact.TButton', command=lambda i=i: self.adjust_current(i, -0.01))
+            dec_current_button.grid(row=3, column=2, sticky='w', padx=(2, 0), pady=(1, 0))
 
             # Create voltage control section
-            voltage_control_frame = ttk.LabelFrame(heater_controls_frame, text='Heater Voltage Control', padding=(6, 4), style='Subpanel.TLabelframe')
+            voltage_control_frame = ttk.LabelFrame(heater_controls_frame, text='Heater Voltage Control', padding=(3, 2), style='Subpanel.TLabelframe')
             voltage_control_frame.grid(row=0, column=0, sticky='ew')
 
             voltage_entry_frame = ttk.Frame(voltage_control_frame)
             voltage_entry_frame.grid(row=0, column=0, sticky='w')
 
-            ttk.Label(voltage_entry_frame, text='Sent', style='RightAlign.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 4))
-            ttk.Label(voltage_entry_frame, text='Goal', style='RightAlign.TLabel').grid(row=1, column=0, sticky='w', padx=(0, 4), pady=(2, 0))
-            ttk.Label(voltage_entry_frame, text='Entry', style='RightAlign.TLabel').grid(row=2, column=0, sticky='w', padx=(0, 4), pady=(2, 0))
+            ttk.Label(voltage_entry_frame, text='Sent', style='RightAlign.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 3))
+            ttk.Label(voltage_entry_frame, text='Goal', style='RightAlign.TLabel').grid(row=1, column=0, sticky='w', padx=(0, 3), pady=(1, 0))
+            ttk.Label(voltage_entry_frame, text='Entry', style='RightAlign.TLabel').grid(row=2, column=0, sticky='w', padx=(0, 3), pady=(1, 0))
 
             target_voltage = tk.DoubleVar(value=0.0)
             voltage_entry_field = ttk.Entry(voltage_entry_frame, textvariable=target_voltage, width=5)
-            voltage_entry_field.grid(row=2, column=1, sticky='w', padx=(0, 2), pady=(2, 0))
+            voltage_entry_field.grid(row=2, column=1, sticky='w', padx=(0, 2), pady=(1, 0))
             self.entry_fields.append(voltage_entry_field)
 
-            set_voltage_button = ttk.Button(voltage_entry_frame, text="Set", width=4, command=lambda i=i, entry_field=voltage_entry_field: self.handle_voltage_entry_set(i, entry_field))
-            set_voltage_button.grid(row=2, column=2, sticky='w', padx=(2, 0), pady=(2, 0))
+            set_voltage_button = ttk.Button(voltage_entry_frame, text="Set", width=4, style='Compact.TButton', command=lambda i=i, entry_field=voltage_entry_field: self.handle_voltage_entry_set(i, entry_field))
+            set_voltage_button.grid(row=2, column=2, sticky='w', padx=(2, 0), pady=(1, 0))
 
             self.set_button_states.append([set_voltage_button, set_current_button])
 
-            voltage_display_frame = tk.Frame(voltage_entry_frame, bd=2, relief='groove', padx=2, pady=1)
+            voltage_display_frame = tk.Frame(voltage_entry_frame, bd=1, relief='groove', padx=1, pady=0)
             voltage_display_frame.configure(bg='#d9d9d9')
             voltage_display_frame.grid(row=0, column=1, sticky='w')
             voltage_label = ttk.Label(voltage_display_frame, textvariable=self.sent_heater_voltage_vars[i], style='Bold.TLabel')
@@ -493,26 +495,26 @@ class CathodeHeatingSubsystem:
             unit_label = ttk.Label(voltage_display_frame, text=" V", style="Bold.TLabel")
             unit_label.pack(side='left')
 
-            voltage_display_frame_secondary = tk.Frame(voltage_entry_frame, bd=2, relief='groove', padx=2, pady=1)
+            voltage_display_frame_secondary = tk.Frame(voltage_entry_frame, bd=1, relief='groove', padx=1, pady=0)
             voltage_display_frame_secondary.configure(bg='#d9d9d9')
-            voltage_display_frame_secondary.grid(row=1, column=1, sticky='w', pady=(2, 0))
+            voltage_display_frame_secondary.grid(row=1, column=1, sticky='w', pady=(1, 0))
             voltage_label_secondary = ttk.Label(voltage_display_frame_secondary, textvariable=self.heater_voltage_vars[i], style='Bold.TLabel')
             voltage_label_secondary.pack(side='left')
             unit_label_secondary = ttk.Label(voltage_display_frame_secondary, text=" V", style="Bold.TLabel")
             unit_label_secondary.pack(side='left')
 
-            inc_voltage_button = ttk.Button(voltage_entry_frame, text="+0.02", width=5, command=lambda i=i: self.adjust_voltage(i, 0.02))
-            inc_voltage_button.grid(row=3, column=1, sticky='w', pady=(3, 0))
-            dec_voltage_button = ttk.Button(voltage_entry_frame, text="-0.02", width=5, command=lambda i=i: self.adjust_voltage(i, -0.02))
-            dec_voltage_button.grid(row=3, column=2, sticky='w', padx=(2, 0), pady=(3, 0))
+            inc_voltage_button = ttk.Button(voltage_entry_frame, text="+0.02", width=5, style='Compact.TButton', command=lambda i=i: self.adjust_voltage(i, 0.02))
+            inc_voltage_button.grid(row=3, column=1, sticky='w', pady=(1, 0))
+            dec_voltage_button = ttk.Button(voltage_entry_frame, text="-0.02", width=5, style='Compact.TButton', command=lambda i=i: self.adjust_voltage(i, -0.02))
+            dec_voltage_button.grid(row=3, column=2, sticky='w', padx=(2, 0), pady=(1, 0))
 
             # Store adjustment buttons for enabling/disabling during ramps
             self.curr_adjustment_buttons.append([inc_current_button, dec_current_button])
             self.vlt_adjustment_buttons.append([inc_voltage_button, dec_voltage_button])
 
             # Create entries and display labels
-            output_control_frame = ttk.LabelFrame(control_frame, text=f'Output {cathode_labels[i]}', padding=(6, 4), style='Subpanel.TLabelframe')
-            output_control_frame.grid(row=1, column=0, sticky='ew', pady=(4, 0))
+            output_control_frame = ttk.LabelFrame(control_frame, text=f'Output {cathode_labels[i]}', padding=(3, 2), style='Subpanel.TLabelframe')
+            output_control_frame.grid(row=1, column=0, sticky='ew', pady=(2, 0))
             output_control_frame.columnconfigure(0, weight=0)
             output_control_frame.columnconfigure(1, weight=0)
 
@@ -520,7 +522,7 @@ class CathodeHeatingSubsystem:
             ramp_frame = ttk.Frame(output_control_frame)
             ramp_frame.grid(row=0, column=1, sticky='w', padx=(10, 0), pady=(0, 0))
 
-            ttk.Label(ramp_frame, text='Output Mode', style='Small.TLabel').grid(row=0, column=0, sticky='w', pady=(0, 0))
+            ttk.Label(ramp_frame, text='Output Mode', style='Small.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 4), pady=(0, 0))
 
             ramp_var = tk.StringVar(value=self.OUTPUT_MODE_VALUE_TO_LABEL["immediate"])
             self.set_ramp_mode(i, "immediate") # Default to immediate set
@@ -538,7 +540,7 @@ class CathodeHeatingSubsystem:
                     self.OUTPUT_MODE_LABEL_TO_VALUE.get(v.get(), 'immediate')
                 )
             )
-            ramp_dropdown.grid(row=1, column=0, sticky='w', pady=(0, 0))
+            ramp_dropdown.grid(row=0, column=1, sticky='w', pady=(0, 0))
 
             self.ramp_mode_vars.append(ramp_var)
             self.ramp_mode_dropdowns.append(ramp_dropdown)
@@ -558,7 +560,7 @@ class CathodeHeatingSubsystem:
             stop_ramp_btn = ttk.Button(
                 output_button_frame,
                 text='STOP RAMP',
-                width=12,
+                width=10,
                 state='disabled',                   # greyed‑out by default
                 style='StopInactive.TButton',
                 command=lambda i=i: self.stop_ramp(i)
@@ -567,8 +569,8 @@ class CathodeHeatingSubsystem:
             self.stop_ramp_buttons.append(stop_ramp_btn)
 
             # Predicted Values
-            predictions_frame = ttk.LabelFrame(main_tab, text='Predicted Output', padding=(6, 4), style='Subpanel.TLabelframe')
-            predictions_frame.grid(row=1, column=0, sticky='ew', pady=(4, 0), padx=2)
+            predictions_frame = ttk.LabelFrame(main_tab, text='Predicted Output', padding=(3, 2), style='Subpanel.TLabelframe')
+            predictions_frame.grid(row=1, column=0, sticky='ew', pady=(2, 0), padx=2)
             predictions_frame.columnconfigure(0, weight=0)
             predictions_frame.columnconfigure(1, weight=1)
             predictions_frame.columnconfigure(2, weight=0)
@@ -576,7 +578,7 @@ class CathodeHeatingSubsystem:
 
             # LUT selector moved to Main tab so dataset toggling stays near predicted values.
             lut_selector_frame = ttk.Frame(predictions_frame)
-            lut_selector_frame.grid(row=0, column=0, columnspan=4, sticky='ew', pady=(0, 4))
+            lut_selector_frame.grid(row=0, column=0, columnspan=4, sticky='ew', pady=(0, 2))
             lut_selector_frame.columnconfigure(1, weight=1)
 
             lookup_table_label = ttk.Label(lut_selector_frame, text='Lookup Table Dataset:', style='RightAlign.TLabel')
@@ -592,7 +594,7 @@ class CathodeHeatingSubsystem:
                 width=30,
                 postcommand=lambda box=None: self._style_lut_dropdown_items(lookup_table_box, lookup_table_options, retries=4)
             )
-            lookup_table_box.grid(row=0, column=1, sticky='w', padx=(8, 0))
+            lookup_table_box.grid(row=0, column=1, sticky='w', padx=(6, 0))
             self._style_lut_dropdown_items(lookup_table_box, lookup_table_options, retries=4)
             lookup_table_box.bind(
                 '<Button-1>',
@@ -672,34 +674,32 @@ class CathodeHeatingSubsystem:
             ttk.Label(predictions_frame, textvariable=self.predicted_heater_current_vars[i], style='Bold.TLabel').grid(row=2, column=3, sticky='w', padx=(2, 0))
 
             # Measured/Actual values
-            measured_frame = ttk.LabelFrame(main_tab, text='Measured Output', padding=(6, 4), style='Subpanel.TLabelframe')
-            measured_frame.grid(row=2, column=0, sticky='ew', pady=(4, 0), padx=2)
+            measured_frame = ttk.LabelFrame(main_tab, text='Measured Output', padding=(3, 2), style='Subpanel.TLabelframe')
+            measured_frame.grid(row=2, column=0, sticky='ew', pady=(2, 0), padx=2)
             
             # Voltage
-            ttk.Label(measured_frame, text='Voltage', style='RightAlign.TLabel').grid(row=0, column=0, sticky='w', padx=(0, 2))
-            actual_voltage_frame = tk.Frame(measured_frame, bd=2, relief='groove', padx=2, pady=1)
+            actual_voltage_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
             actual_voltage_frame.configure(bg='#d9d9d9')
-            actual_voltage_frame.grid(row=0, column=1, sticky='w', padx=(0, 8))
+            actual_voltage_frame.grid(row=0, column=0, sticky='w', padx=(0, 6))
             actual_voltage_label = ttk.Label(actual_voltage_frame, textvariable=self.actual_heater_voltage_vars[i], style='Bold.TLabel') 
             actual_voltage_label.pack(side='left')
             unit_label = ttk.Label(actual_voltage_frame, text=" V", style="Bold.TLabel")
             unit_label.pack(side='left')
 
             # Current
-            ttk.Label(measured_frame, text='Current', style='RightAlign.TLabel').grid(row=0, column=2, sticky='w', padx=(0, 2))
-            actual_current_frame = tk.Frame(measured_frame, bd=2, relief='groove', padx=2, pady=1)
+            actual_current_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
             actual_current_frame.configure(bg='#d9d9d9')
-            actual_current_frame.grid(row=0, column=3, sticky='w', padx=(0, 8))
+            actual_current_frame.grid(row=0, column=1, sticky='w', padx=(0, 8))
             actual_current_label = ttk.Label(actual_current_frame, textvariable=self.actual_heater_current_vars[i], style='Bold.TLabel') 
             actual_current_label.pack(side='left')
             unit_label = ttk.Label(actual_current_frame, text=" A", style="Bold.TLabel")
             unit_label.pack(side='left')
             
             # Temp
-            ttk.Label(measured_frame, text='Temp', style='RightAlign.TLabel').grid(row=0, column=4, sticky='w', padx=(0, 2))
-            actual_temp_frame = tk.Frame(measured_frame, bd=2, relief='groove', padx=2, pady=1)
+            ttk.Label(measured_frame, text='Temp', style='RightAlign.TLabel').grid(row=0, column=2, sticky='w', padx=(0, 2))
+            actual_temp_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
             actual_temp_frame.configure(bg='#d9d9d9')
-            actual_temp_frame.grid(row=0, column=5, sticky='w')
+            actual_temp_frame.grid(row=0, column=3, sticky='w')
             actual_temp_label = ttk.Label(actual_temp_frame, textvariable=self.clamp_temperature_vars[i], style='Bold.TLabel') 
             actual_temp_label.pack(side='left')
 
@@ -707,7 +707,7 @@ class CathodeHeatingSubsystem:
 
             # CV / CC mode indicator
             indicator_frame = ttk.Frame(measured_frame)
-            indicator_frame.grid(row=0, column=6, padx=(16, 0), sticky='e')
+            indicator_frame.grid(row=0, column=4, padx=(10, 0), sticky='e')
 
             cv_label = tk.Label(indicator_frame, text='CV', width=3,
                             fg='white', bg='grey', relief='ridge')

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -8,7 +8,7 @@ class TemperatureBar(tk.Canvas):
 
     DISCONNECTED = -1
     SENSOR_ERROR = -2
-    TOP_PADDING = 2
+    TOP_PADDING = 1
     SCALE_LABELS = {
         'Solenoids': [10 , 120], 
         'Chambers' : [10, 100], 
@@ -20,12 +20,12 @@ class TemperatureBar(tk.Canvas):
         SENSOR_ERROR: '#FFA500',  # Keep orange for actual sensor errors
     }
 
-    def __init__(self, parent, name: str, height: int = 58, width: int = 580):
+    def __init__(self, parent, name: str, height: int = 36, width: int = 580):
         super().__init__(parent, height=height, width=width, highlightthickness=0)
         self.name = name
         self.height = height
         self.width = width
-        self.bar_height = 14
+        self.bar_height = 11
         self.value = None
 
         self.bind('<Configure>', self._handle_resize)
@@ -46,21 +46,21 @@ class TemperatureBar(tk.Canvas):
         self._draw_bar()
 
     def create_title(self):
-        title_x = 8
+        title_x = 6
         title_y = self.TOP_PADDING + (self.bar_height // 2)
         self.create_text(
             title_x,
             title_y,
             text=self.name, 
-            font=('Arial', 8, 'bold'), 
+            font=('Segoe UI', 8, 'bold'), 
             anchor='w',
             tags='static'
         )
         
     def create_scale(self):
         # Scale line
-        self.scale_left = 90
-        self.scale_right = max(self.scale_left + 40, self.width - 55)
+        self.scale_left = 82
+        self.scale_right = max(self.scale_left + 40, self.width - 44)
         self.bar_top = self.TOP_PADDING
         self.bar_bottom = self.bar_top + self.bar_height
         scale_width = self.scale_right - self.scale_left
@@ -70,7 +70,8 @@ class TemperatureBar(tk.Canvas):
             self.bar_top,
             self.scale_right,
             self.bar_bottom,
-            outline='#444444',
+            outline='#5a5a5a',
+            fill='#eeeeee',
             tags='static'
         )
 
@@ -95,15 +96,16 @@ class TemperatureBar(tk.Canvas):
                 x,
                 self.bar_bottom,
                 x,
-                self.bar_bottom + 4,
+                self.bar_bottom + 3,
+                fill='#333333',
                 tags='scale_labels'
             )
             self.create_text(
                 x,
-                self.bar_bottom + 6,
+                self.bar_bottom + 4,
                 text=str(i), 
                 anchor='n',
-                font=('Arial', 7),
+                font=('Segoe UI', 6),
                 tags='scale_labels'
             )
         
@@ -162,10 +164,10 @@ class TemperatureBar(tk.Canvas):
 
         # Update value label
         self.create_text(
-            self.width - 8,
+            self.width - 6,
             self.TOP_PADDING + (self.bar_height // 2),
             text=value_text,
-            font=('Arial', 9, 'bold'),
+            font=('Segoe UI', 8, 'bold'),
             fill='#808080' if self.value == self.DISCONNECTED else 'black',
             anchor='e',
             tags='value'
@@ -246,18 +248,18 @@ class ProcessMonitorSubsystem:
 
     def setup_gui(self):
         self.frame = tk.Frame(self.parent)
-        self.frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self.frame.pack(side=tk.TOP, fill=tk.X, expand=False)
         
         # Configure grid weights for responsive layout
         self.frame.grid_columnconfigure(0, weight=1)
         for i in range(len(self.thermometers)):
-            self.frame.grid_rowconfigure(i, weight=1)
+            self.frame.grid_rowconfigure(i, weight=0)
         
         # Create temperature bars
         self.temp_bars: Dict[str, TemperatureBar] = {}
         for i, name in enumerate(self.thermometers):
             bar = TemperatureBar(self.frame, name)
-            bar.grid(row=i, column=0, padx=5, pady=2, sticky='nsew')
+            bar.grid(row=i, column=0, padx=4, pady=(1, 0), sticky='ew')
             self.temp_bars[name] = bar
 
     def update_temperatures(self):

--- a/subsystem/process_monitor/process_monitor.py
+++ b/subsystem/process_monitor/process_monitor.py
@@ -248,18 +248,18 @@ class ProcessMonitorSubsystem:
 
     def setup_gui(self):
         self.frame = tk.Frame(self.parent)
-        self.frame.pack(side=tk.TOP, fill=tk.X, expand=False)
+        self.frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
         
         # Configure grid weights for responsive layout
         self.frame.grid_columnconfigure(0, weight=1)
         for i in range(len(self.thermometers)):
-            self.frame.grid_rowconfigure(i, weight=0)
+            self.frame.grid_rowconfigure(i, weight=1)
         
         # Create temperature bars
         self.temp_bars: Dict[str, TemperatureBar] = {}
         for i, name in enumerate(self.thermometers):
             bar = TemperatureBar(self.frame, name)
-            bar.grid(row=i, column=0, padx=4, pady=(1, 0), sticky='ew')
+            bar.grid(row=i, column=0, padx=4, pady=(1, 0), sticky='nsew')
             self.temp_bars[name] = bar
 
     def update_temperatures(self):

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -25,6 +25,9 @@ def resource_path(relative_path):
     return os.path.join(base_path, relative_path)
 
 class VTRXSubsystem: 
+    PLOT_X_TICK_LABEL_SIZE = 6
+    PLOT_Y_TICK_LABEL_SIZE = 8
+
     ERROR_CODES = {
         0: "VALVE CONTENTION",
         1: "COLD CATHODE FAILURE",
@@ -384,8 +387,7 @@ class VTRXSubsystem:
         self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
-        self.ax.tick_params(axis='x', labelsize=6, pad=1)
-        self.ax.tick_params(axis='y', labelsize=8, pad=1)
+        self._apply_plot_label_sizes()
         self.ax.grid(True)
 
         self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
@@ -495,8 +497,15 @@ class VTRXSubsystem:
             start_time = current_time - datetime.timedelta(seconds=self.display_window)
             self.ax.set_xlim(start_time, current_time)
 
+        self._apply_plot_label_sizes()
         self.canvas.draw_idle()
         self.canvas.flush_events()
+
+    def _apply_plot_label_sizes(self):
+        """Keep static and dynamically generated graph labels the same size."""
+        self.ax.tick_params(axis='x', which='both', labelsize=self.PLOT_X_TICK_LABEL_SIZE, pad=1)
+        self.ax.tick_params(axis='y', which='both', labelsize=self.PLOT_Y_TICK_LABEL_SIZE, pad=1)
+        self.ax.yaxis.get_offset_text().set_fontsize(self.PLOT_Y_TICK_LABEL_SIZE)
 
     def start_serial_thread(self):
         self.stop_event.clear()

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -390,14 +390,13 @@ class VTRXSubsystem:
 
         # Plot frame
         plot_frame = tk.Frame(layout_frame)
-        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=1) 
+        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(4, 6), pady=(3, 5)) 
         self.fig, self.ax = plt.subplots()
-        self.fig.subplots_adjust(left=0.15, right=0.99, top=0.97, bottom=0.05)
+        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.94, bottom=0.18)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
         self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
         self.fig.autofmt_xdate()  
         self.ax.set_title('')
-        self.ax.set_xlabel('Time', fontsize=8)
         self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
@@ -408,7 +407,7 @@ class VTRXSubsystem:
         self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
         self.canvas.draw()
         self.canvas_widget = self.canvas.get_tk_widget()
-        self.canvas_widget.pack(fill=tk.BOTH, expand=True)
+        self.canvas_widget.pack(fill=tk.BOTH, expand=True, padx=4, pady=3)
      
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         """

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -27,7 +27,7 @@ def resource_path(relative_path):
 class VTRXSubsystem: 
     PLOT_X_TICK_LABEL_SIZE = 6
     PLOT_Y_TICK_LABEL_SIZE = 8
-
+    PLOT_TITLE_PAD = 2 # makes the title not get clipped
     ERROR_CODES = {
         0: "VALVE CONTENTION",
         1: "COLD CATHODE FAILURE",
@@ -214,7 +214,7 @@ class VTRXSubsystem:
         """
         self.label_pressure.config(text="No data...", fg="red")
         self.line.set_color('red')
-        self.ax.set_title('(Error)', fontsize=10, color='red')
+        self.ax.set_title('(Error)', fontsize=10, color='red', pad=self.PLOT_TITLE_PAD)
         for canvas, oval_id in self.circle_indicators:
             canvas.itemconfig(oval_id, fill='red')
         self.canvas.draw_idle()
@@ -379,11 +379,11 @@ class VTRXSubsystem:
         plot_frame = tk.Frame(layout_frame)
         plot_frame.grid(row=0, column=1, sticky='nsew', padx=(4, 6), pady=(3, 1)) 
         self.fig, self.ax = plt.subplots()
-        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.94, bottom=0.18)
+        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.92, bottom=0.18)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
         self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
         self.fig.autofmt_xdate()  
-        self.ax.set_title('')
+        self.ax.set_title('', pad=self.PLOT_TITLE_PAD)
         self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
@@ -460,8 +460,9 @@ class VTRXSubsystem:
             self.line.set_color('green' if not self.error_state else 'red')
             self.ax.set_title(
                 'VTRX Pressure Readout',
-                fontsize=10,
-                color='black' if not self.error_state else 'red'
+                fontsize=8,
+                color='black' if not self.error_state else 'red',
+                pad=self.PLOT_TITLE_PAD
             )
             self.update_plot()
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -296,13 +296,17 @@ class VTRXSubsystem:
         """
         layout_frame = tk.Frame(self.parent)
         layout_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        layout_frame.grid_columnconfigure(0, weight=0)
+        layout_frame.grid_columnconfigure(1, weight=1)
+        layout_frame.grid_rowconfigure(0, weight=1)
+        layout_frame.grid_rowconfigure(1, weight=0)
 
         # Formatting status indicators
         switches_frame = tk.Frame(layout_frame)
-        switches_frame.pack(side=tk.LEFT, fill=tk.Y, expand=True, padx=5)
+        switches_frame.grid(row=0, column=0, sticky='nsew', padx=5)
 
         # Distribute vertical space
-        switches_frame.grid_rowconfigure(tuple(range(10)), weight=1)
+        switches_frame.grid_rowconfigure(tuple(range(8)), weight=1)
         switches_frame.grid_columnconfigure(0, weight=3) # Label colunm
         switches_frame.grid_columnconfigure(1, weight=1) # indicator column 
 
@@ -327,29 +331,9 @@ class VTRXSubsystem:
             canvas.grid(row=idx, column=1, sticky='nsew', pady=2, padx=(0, 1))
             self.circle_indicators.append((canvas, oval_id))
 
-        # Pressure label setup
-        pressure_frame = tk.Frame(switches_frame)
-        pressure_frame.grid(row=len(switch_labels), column=0, columnspan=2, sticky='nsew', pady=1)
-        # Configure columns to center the label
-        pressure_frame.grid_columnconfigure(0, weight=1) 
-        pressure_frame.grid_columnconfigure(2, weight=1) 
-        pressure_frame.grid_columnconfigure(1, weight=0) 
-
-        self.label_pressure = tk.Label(
-            pressure_frame,
-            text="No data...", 
-            anchor='center',
-            font=('Helvetica', 11, 'bold'), 
-            relief='ridge', 
-            bg='white',
-            fg='black', 
-            padx=3, pady=2
-        )
-        self.label_pressure.grid(row=0, column=1, ipady=2, pady=(0,2))
-
         # Buttons frame
-        button_frame = tk.Frame(switches_frame)
-        button_frame.grid(row=len(switch_labels)+1, column=0, columnspan=2, sticky='nsew', pady=1)
+        button_frame = tk.Frame(layout_frame)
+        button_frame.grid(row=1, column=0, sticky='ew', padx=5, pady=(2, 1))
         button_frame.bind("<Configure>", self._on_button_frame_resize)
 
         self.button_frame = button_frame
@@ -390,7 +374,7 @@ class VTRXSubsystem:
 
         # Plot frame
         plot_frame = tk.Frame(layout_frame)
-        plot_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=(4, 6), pady=(3, 5)) 
+        plot_frame.grid(row=0, column=1, sticky='nsew', padx=(4, 6), pady=(3, 1)) 
         self.fig, self.ax = plt.subplots()
         self.fig.subplots_adjust(left=0.17, right=0.96, top=0.94, bottom=0.18)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
@@ -408,6 +392,23 @@ class VTRXSubsystem:
         self.canvas.draw()
         self.canvas_widget = self.canvas.get_tk_widget()
         self.canvas_widget.pack(fill=tk.BOTH, expand=True, padx=4, pady=3)
+
+        # Pressure label setup
+        pressure_frame = tk.Frame(layout_frame)
+        pressure_frame.grid(row=1, column=1, sticky='ew', padx=(4, 6), pady=(2, 1))
+        pressure_frame.grid_columnconfigure(0, weight=1)
+
+        self.label_pressure = tk.Label(
+            pressure_frame,
+            text="No data...", 
+            anchor='center',
+            font=('Helvetica', 11, 'bold'), 
+            relief='ridge', 
+            bg='white',
+            fg='black', 
+            padx=3, pady=2
+        )
+        self.label_pressure.grid(row=0, column=0, ipady=2)
      
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         """


### PR DESCRIPTION
<img width="1922" height="1040" alt="image" src="https://github.com/user-attachments/assets/1cb69329-6be5-413a-bb32-acf854b23d20" />
Targeted stylistic changes towards the CCS, VTRX, and PMON subpanels created a more compact version of the dashboard allowing all subpanels to fit on the lab laptop. All changes are frontend UI focused and do not impact hardware functionality or communication. 