### PR TITLE
Refactor changing all webmonitor log references to data log

### DIFF
--- a/citestfiles/startup_logging_test.py
+++ b/citestfiles/startup_logging_test.py
@@ -56,7 +56,7 @@ class TestStartupLogger(unittest.TestCase):
             contents = file.read()
 
         self.assertIn("Log file created at", contents)
-        self.assertIn("WebMonitor log file created at", contents)
+        self.assertIn("Datalog file created at", contents)
         self.assertIn("Process launch", contents)
 
     def test_attach_text_widget_replays_buffer_without_creating_second_file(self):

--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -227,9 +227,11 @@ class TestSupabaseRateLimiting(unittest.TestCase):
         self.mock_sb_class.return_value = self.mock_sb_instance
 
         self.logger = Logger(text_widget=None, log_to_file=True)
-        # Inject a mock webMonitor_log_file so the file-write branch doesn't crash
-        self.logger.webMonitor_log_file = MagicMock()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now()
+        if self.logger.datalog_file:
+            self.logger.datalog_file.close()
+        # Inject a mock datalog_file so the file-write branch doesn't crash
+        self.logger.datalog_file = MagicMock()
+        self.logger.datalog_start_time = datetime.datetime.now()
 
     def tearDown(self):
         try:
@@ -369,11 +371,11 @@ class TestSupabaseRateLimiting(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 4: WebMonitor log format
+# Class 4: Datalog format
 # ---------------------------------------------------------------------------
 
-class TestWebMonitorLogFormat(unittest.TestCase):
-    """Tests for the JSON structure written to webMonitor_log_file."""
+class TestDatalogFormat(unittest.TestCase):
+    """Tests for the JSON structure written to datalog_file."""
 
     def setUp(self):
         self.sb_patcher = patch("utils._create_supabase_client")
@@ -383,8 +385,8 @@ class TestWebMonitorLogFormat(unittest.TestCase):
         self.logger = Logger(text_widget=None, log_to_file=False)
         # Inject StringIO so log_dict_update writes to it
         self.buf = io.StringIO()
-        self.logger.webMonitor_log_file = self.buf
-        self.logger.webMonitor_log_start_time = datetime.datetime.now()
+        self.logger.datalog_file = self.buf
+        self.logger.datalog_start_time = datetime.datetime.now()
         self.logger.log_to_file = True
 
     def tearDown(self):
@@ -398,26 +400,26 @@ class TestWebMonitorLogFormat(unittest.TestCase):
         line = self.buf.readline().strip()
         return json.loads(line)
 
-    def test_webmonitor_log_entry_is_valid_json(self):
+    def test_datalog_entry_is_valid_json(self):
         self.logger.log_dict_update({"pressure": 1.2e-5})
         self.buf.seek(0)
         line = self.buf.readline().strip()
         # Should not raise
         json.loads(line)
 
-    def test_webmonitor_log_entry_has_timestamp_and_status_keys(self):
+    def test_datalog_entry_has_timestamp_and_status_keys(self):
         self.logger.log_dict_update({"pressure": 1.0})
         entry = self._get_entry()
         self.assertIn("timestamp", entry)
         self.assertIn("status", entry)
 
-    def test_webmonitor_log_timestamp_format(self):
+    def test_datalog_timestamp_format(self):
         self.logger.log_dict_update({"pressure": 1.0})
         entry = self._get_entry()
         # Should not raise if format matches
         datetime.datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S.%f")
 
-    def test_webmonitor_log_status_contains_dict_logger_snapshot(self):
+    def test_datalog_status_contains_dict_logger_snapshot(self):
         self.logger.dict_logger["pressure"] = 9.9e-6
         self.logger.log_dict_update(self.logger.dict_logger)
         entry = self._get_entry()
@@ -428,25 +430,25 @@ class TestWebMonitorLogFormat(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 5: WebMonitor rotation
+# Class 5: Datalog rotation
 # ---------------------------------------------------------------------------
 
-class TestWebMonitorRotation(unittest.TestCase):
-    """Tests for 1-hour web monitor rollover with timestamped filenames."""
+class TestDatalogRotation(unittest.TestCase):
+    """Tests for 1-hour datalog rollover with timestamped filenames."""
 
     def setUp(self):
         self.sb_patcher = patch("utils._create_supabase_client")
         mock_sb_class = self.sb_patcher.start()
         mock_sb_class.return_value = MagicMock()
 
-        self.test_root = os.path.join(TEST_TMP_ROOT, f"wm_rotation_{uuid.uuid4().hex}")
+        self.test_root = os.path.join(TEST_TMP_ROOT, f"datalog_rotation_{uuid.uuid4().hex}")
         os.makedirs(self.test_root, exist_ok=True)
         self.base_path_patcher = patch.object(Logger, "_get_dashboard_base_path", return_value=self.test_root)
         self.base_path_patcher.start()
 
         self.logger = Logger(text_widget=None, log_to_file=False)
         self.logger.supabase_client = None
-        self.logger.setup_wm_logfile()
+        self.logger.setup_datalog_file()
         self.logger.log_to_file = True
 
     def tearDown(self):
@@ -457,66 +459,66 @@ class TestWebMonitorRotation(unittest.TestCase):
             self.sb_patcher.stop()
             shutil.rmtree(self.test_root, ignore_errors=True)
 
-    def _read_wm_lines(self, filepath=None):
-        target = filepath or self.logger.webMonitor_log_filepath
+    def _read_datalog_lines(self, filepath=None):
+        target = filepath or self.logger.datalog_filepath
         with open(target, "r", encoding="utf-8") as fh:
             return [line.rstrip("\n") for line in fh]
 
-    def _list_wm_files(self):
-        wm_dir = os.path.dirname(self.logger.webMonitor_log_filepath)
+    def _list_datalog_files(self):
+        datalog_dir = os.path.dirname(self.logger.datalog_filepath)
         return sorted(
-            entry for entry in os.listdir(wm_dir)
-            if entry.startswith("webMonitor_log_") and entry.endswith(".txt")
+            entry for entry in os.listdir(datalog_dir)
+            if entry.startswith("datalog_") and entry.endswith(".txt")
         )
 
-    def test_setup_wm_logfile_uses_timestamped_filename(self):
-        filename = os.path.basename(self.logger.webMonitor_log_filepath)
-        self.assertRegex(filename, r"^webMonitor_log_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.txt$")
+    def test_setup_datalog_file_uses_timestamped_filename(self):
+        filename = os.path.basename(self.logger.datalog_filepath)
+        self.assertRegex(filename, r"^datalog_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.txt$")
 
-    def test_webmonitor_log_rotates_after_one_hour_into_new_file(self):
+    def test_datalog_rotates_after_one_hour_into_new_file(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        first_path = self.logger.webMonitor_log_filepath
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now() - datetime.timedelta(hours=1, seconds=1)
+        first_path = self.logger.datalog_filepath
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
+        self.logger.datalog_start_time = datetime.datetime.now() - datetime.timedelta(hours=1, seconds=1)
         time.sleep(1.1)
 
         self.logger.log_dict_update({"pressure": 1.0})
 
-        second_path = self.logger.webMonitor_log_filepath
+        second_path = self.logger.datalog_filepath
         self.assertNotEqual(second_path, first_path)
-        self.assertEqual(len(self._list_wm_files()), 2)
-        self.assertEqual(self._read_wm_lines(first_path), [seed_entry])
-        lines = self._read_wm_lines(second_path)
+        self.assertEqual(len(self._list_datalog_files()), 2)
+        self.assertEqual(self._read_datalog_lines(first_path), [seed_entry])
+        lines = self._read_datalog_lines(second_path)
         self.assertEqual(len(lines), 1)
         entry = json.loads(lines[0])
         self.assertEqual(entry["status"]["pressure"], 1.0)
         datetime.datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S.%f")
 
-    def test_webmonitor_log_does_not_rotate_before_one_hour(self):
+    def test_datalog_does_not_rotate_before_one_hour(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
         original_start_time = datetime.datetime.now() - datetime.timedelta(minutes=59, seconds=59)
-        self.logger.webMonitor_log_start_time = original_start_time
-        original_path = self.logger.webMonitor_log_filepath
+        self.logger.datalog_start_time = original_start_time
+        original_path = self.logger.datalog_filepath
 
         self.logger.log_dict_update({"pressure": 2.0})
 
-        self.assertEqual(self.logger.webMonitor_log_filepath, original_path)
-        lines = self._read_wm_lines()
+        self.assertEqual(self.logger.datalog_filepath, original_path)
+        lines = self._read_datalog_lines()
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], seed_entry)
-        self.assertEqual(self.logger.webMonitor_log_start_time, original_start_time)
+        self.assertEqual(self.logger.datalog_start_time, original_start_time)
         entry = json.loads(lines[1])
         self.assertEqual(entry["status"]["pressure"], 2.0)
 
-    def test_webmonitor_retry_reopens_in_append_mode_within_window(self):
+    def test_datalog_retry_reopens_in_append_mode_within_window(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now() - datetime.timedelta(minutes=30)
-        original_path = self.logger.webMonitor_log_filepath
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
+        self.logger.datalog_start_time = datetime.datetime.now() - datetime.timedelta(minutes=30)
+        original_path = self.logger.datalog_filepath
 
         class FailingWriter:
             def write(self, _message):
@@ -528,12 +530,13 @@ class TestWebMonitorRotation(unittest.TestCase):
             def close(self):
                 pass
 
-        self.logger.webMonitor_log_file = FailingWriter()
+        self.logger.datalog_file.close()
+        self.logger.datalog_file = FailingWriter()
 
         self.logger.log_dict_update({"pressure": 3.0})
 
-        self.assertEqual(self.logger.webMonitor_log_filepath, original_path)
-        lines = self._read_wm_lines()
+        self.assertEqual(self.logger.datalog_filepath, original_path)
+        lines = self._read_datalog_lines()
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], seed_entry)
         entry = json.loads(lines[1])

--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -252,7 +252,7 @@ class G9Driver:
             self.logger.update_field("safetyOutputStatusFlags", binary_data["sotsf"])
             self.logger.update_field("safetyInputStatusFlags", binary_data["sitsf"])
 
-        # Store data flags to be logged in interlock.py for web monitor
+        # Store data flags to be logged in interlock.py for the datalog.
         debug_data = {
             'sotdf': binary_data['sotdf'],
             'sitdf': binary_data['sitdf']

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -645,7 +645,7 @@ class BeamEnergySubsystem:
                 self.update_connection_status(index, comms)
                 self.update_forced_off_status(index, reset_counter_3kv > 0)
             
-            # Build a web monitor log payload
+            # Build a datalog payload.
             if self.logger and hasattr(self.logger, "update_field"):
 
                 # Build keyed per-supply payload entries.

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -283,7 +283,7 @@ class InterlocksSubsystem:
                 
                 sitsf_bits, sitdf_bits, g9_output, unit_status, input_terms, output_terms, debug_data = status
 
-                # Log debug data for web monitor
+                # Log debug data for the datalog.
                 self.log(f"Safety Output Terminal Data Flags: {debug_data['sotdf']}", LogLevel.DEBUG)
                 self.log(f"Safety Input Terminal Data Flags: {debug_data['sitdf']}", LogLevel.DEBUG)
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -216,7 +216,7 @@ class VTRXSubsystem:
             canvas.itemconfig(oval_id, fill='red')
         self.canvas.draw_idle()
 
-        #Clear the webmonitor fields if error state
+        # Clear the datalog fields if error state.
         if self.logger and hasattr(self.logger, "clear_value"):
             self.logger.clear_value("vacuumBits")
             self.logger.clear_value("pressure")

--- a/utils.py
+++ b/utils.py
@@ -55,10 +55,10 @@ class Logger:
         self.log_to_file = log_to_file
         self.log_file = None
         self.log_start_time = None
-        self.webMonitor_log_start_time = None
+        self.datalog_start_time = None
         self.log_filepath = None
-        self.webMonitor_log_file = None
-        self.webMonitor_log_filepath = None
+        self.datalog_file = None
+        self.datalog_filepath = None
         self._pending_widget_messages = deque(maxlen=self.STARTUP_BUFFER_MAX)
         self.supabase_client = None
         self.last_supabase_write = None
@@ -91,7 +91,7 @@ class Logger:
             }
         if log_to_file:
             self.setup_log_file()
-            self.setup_wm_logfile()
+            self.setup_datalog_file()
 
     def _get_dashboard_base_path(self):
         return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
@@ -127,32 +127,32 @@ class Logger:
         except Exception as e:
             print(f"Error creating log file: {str(e)}")
 
-    def setup_wm_logfile(self):
-        """Setup a new web monitor log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
+    def setup_datalog_file(self):
+        """Setup a new sensor snapshot datalog file."""
         try:
-            wm_log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-WMLogs")
-            os.makedirs(wm_log_dir, exist_ok=True)
+            datalog_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Datalogs")
+            os.makedirs(datalog_dir, exist_ok=True)
 
-            # Create the web monitor log file with the same timestamped pattern used by the main log.
-            webMonitor_log_file_name = f"webMonitor_log_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
-            if self.webMonitor_log_file != None:
-                self.webMonitor_log_file.close()
-            self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
-            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
-            self.webMonitor_log_start_time = datetime.datetime.now()
-            self.info(f"WebMonitor log file created at {self.webMonitor_log_filepath}")
+            # Create the datalog file with the same timestamped pattern used by the main log.
+            datalog_file_name = f"datalog_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
+            if self.datalog_file != None:
+                self.datalog_file.close()
+            self.datalog_filepath = os.path.join(datalog_dir, datalog_file_name)
+            self.datalog_file = open(self.datalog_filepath, 'w')
+            self.datalog_start_time = datetime.datetime.now()
+            self.info(f"Datalog file created at {self.datalog_filepath}")
         except Exception as e:
-            print(f"Error creating web monitor log file: {str(e)}")
+            print(f"Error creating datalog file: {str(e)}")
 
-    def _reopen_wm_logfile_append(self):
-        """Reopen the current web monitor log file without resetting its rotation window."""
+    def _reopen_datalog_append(self):
+        """Reopen the current datalog file without resetting its rotation window."""
         try:
-            if self.webMonitor_log_filepath is None:
-                self.setup_wm_logfile()
+            if self.datalog_filepath is None:
+                self.setup_datalog_file()
                 return
-            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'a')
+            self.datalog_file = open(self.datalog_filepath, 'a')
         except Exception as e:
-            print(f"Error opening web monitor log file: {str(e)}")
+            print(f"Error opening datalog file: {str(e)}")
 
     def log(self, msg, level=LogLevel.INFO):
         """ Log a message to the text widget and optionally to local file """
@@ -218,38 +218,38 @@ class Logger:
         self._enqueue_supabase_update(update_dict, now)
 
         if self.log_to_file:
-            if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
-                if self.webMonitor_log_file:
-                    self.webMonitor_log_file.close()
-                self.setup_wm_logfile()
-            elif self.webMonitor_log_file is None:
-                self._reopen_wm_logfile_append()
-            if self.webMonitor_log_file:
+            if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
+                if self.datalog_file:
+                    self.datalog_file.close()
+                self.setup_datalog_file()
+            elif self.datalog_file is None:
+                self._reopen_datalog_append()
+            if self.datalog_file:
                 entry = {
                     "timestamp": timestamp,
                     "status": update_dict
                 }
                 try:
-                    self.webMonitor_log_file.write(json.dumps(entry) + "\n")
-                    self.webMonitor_log_file.flush()
+                    self.datalog_file.write(json.dumps(entry) + "\n")
+                    self.datalog_file.flush()
                 except Exception as e:
                     try:
-                        self.webMonitor_log_file.close()
+                        self.datalog_file.close()
                     except Exception:
                         pass
-                    self.webMonitor_log_file = None
+                    self.datalog_file = None
                     try:
-                        if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
-                            self.setup_wm_logfile()
+                        if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
+                            self.setup_datalog_file()
                         else:
-                            self._reopen_wm_logfile_append()
-                        if self.webMonitor_log_file:
-                            self.webMonitor_log_file.write(json.dumps(entry) + "\n")
-                            self.webMonitor_log_file.flush()
+                            self._reopen_datalog_append()
+                        if self.datalog_file:
+                            self.datalog_file.write(json.dumps(entry) + "\n")
+                            self.datalog_file.flush()
                         else:
-                            print(f"Error writing web monitor updates: {e}")
+                            print(f"Error writing datalog updates: {e}")
                     except Exception as retry_error:
-                        print(f"Error writing web monitor updates: {retry_error}")
+                        print(f"Error writing datalog updates: {retry_error}")
 
     def _enqueue_supabase_update(self, update_dict, now):
         if self._closed or not self.supabase_client or not self.log_to_file:
@@ -377,12 +377,12 @@ class Logger:
                 self.log_file = None
             except Exception as e:
                 print(f"Error closing log file {str(e)}")
-        if self.webMonitor_log_file:
+        if self.datalog_file:
             try:
-                self.webMonitor_log_file.close()
-                self.webMonitor_log_file = None
+                self.datalog_file.close()
+                self.datalog_file = None
             except Exception as e:
-                print(f"Error closing web monitor log file: {str(e)}")
+                print(f"Error closing datalog file: {str(e)}")
 
 import tkinter as tk
 import sys
@@ -465,12 +465,12 @@ class MessagesFrame:
                 except Exception as e:
                     print(f"Error closing log file: {e}")
                 self.logger.log_file = None
-            if self.logger.webMonitor_log_file:
+            if self.logger.datalog_file:
                 try:
-                    self.logger.webMonitor_log_file.close()
+                    self.logger.datalog_file.close()
                 except Exception as e:
-                    print(f"Error closing web monitor log file: {e}")
-                self.logger.webMonitor_log_file = None
+                    print(f"Error closing datalog file: {e}")
+                self.logger.datalog_file = None
             self.toggle_file_logging_button.config(text="Record Log: OFF")
             self.logging_indicator_canvas.itemconfig(self.logging_indicator_circle, fill="gray")
         else:
@@ -480,8 +480,8 @@ class MessagesFrame:
             
             if not self.logger.log_file:  # if no file is open, set up a new one
                 self.logger.setup_log_file()
-            if not self.logger.webMonitor_log_file:
-                self.logger.setup_wm_logfile()
+            if not self.logger.datalog_file:
+                self.logger.setup_datalog_file()
             self.toggle_file_logging_button.config(text="Record Log: ON")
             self.logging_indicator_canvas.itemconfig(
                 self.logging_indicator_circle, 


### PR DESCRIPTION
Changes all webmonitor log creation and references to be datalog more accurately describing its purpose for future development. 
- New references: datalog_file, datalog_filepath, datalog_start_time
- New functions: setup_datalog_file() and _reopen_datalog_append()
- files now go under EBEAM-Dashboard-Datalogs
- filenames now use datalog_YYYY-MM-DD_HH-MM-SS.txt
- UI/logger messages now say “Datalog”
- Updated the matching tests and stale subsystem comments that described payloads as web monitor data.

Kepco Dashboard will be updated to match the rename. Should wait to be merged until cbmark logger is stable and updated as well.

Addresses issue #104 