### PR TITLE
Return none when ERR

### DIFF
--- a/citestfiles/CathodeHeating/read_temperature_test.py
+++ b/citestfiles/CathodeHeating/read_temperature_test.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from subsystem.cathode_heating.cathode_heating import CathodeHeatingSubsystem
+
+
+class FakeStringVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def set(self, value):
+        self.value = value
+
+
+class TestReadTemperature(unittest.TestCase):
+    def setUp(self):
+        self.subsys = object.__new__(CathodeHeatingSubsystem)
+        self.subsys.temperature_controller = MagicMock()
+        self.subsys.temperature_controller.connected = True
+        self.subsys.clamp_temperature_vars = [FakeStringVar("--") for _ in range(3)]
+        self.subsys.set_plot_color = MagicMock()
+        self.subsys.log = MagicMock()
+
+    def test_cached_string_error_displays_err_without_fallthrough(self):
+        self.subsys.temperature_controller.temperatures = ["ERROR", None, None]
+
+        temperature = self.subsys.read_temperature(0)
+
+        self.assertIsNone(temperature)
+        self.assertEqual(self.subsys.clamp_temperature_vars[0].value, "ERR")
+        self.subsys.set_plot_color.assert_called_once_with(0, 'ERROR')
+
+    def test_missing_temperature_data_displays_blank_reading(self):
+        self.subsys.temperature_controller.temperatures = [None, None, None]
+
+        temperature = self.subsys.read_temperature(0)
+
+        self.assertIsNone(temperature)
+        self.assertEqual(self.subsys.clamp_temperature_vars[0].value, "-- C")
+        self.subsys.set_plot_color.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -1703,6 +1703,7 @@ class CathodeHeatingSubsystem:
                     self.set_plot_color(index, 'ERROR')
                     self.log(f"Reading temperature for cathode {index+1} returned an error: {temperature}",
                               LogLevel.ERROR)
+                    return None
                 else:
                     self.log(f"No temperature data for cathode {index+1}", LogLevel.WARNING)
             except Exception as e:


### PR DESCRIPTION
This PR fixes a cathode temperature display fallthrough in `read_temperature()`. When the E5CN temperature controller reports a cached string error such as `"ERROR"`, the GUI now leaves the clamp temperature label at `ERR` and keeps the plot in the error state instead of falling through to the default missing-reading display of `-- C`. The invalid reading still returns `None`, so logging, plotting data, and overtemperature comparisons continue to exclude it from numeric temperature handling.

It also adds focused regression coverage for the two relevant UI states: cached sensor errors display `ERR`, while genuinely missing cached data still displays `-- C`. This preserves the intended distinction between a known sensor/controller error and no available temperature reading, making the dashboard status clearer without changing the broader temperature-control behavior.