### PR TITLE
Feature: CCS Warning Highlights

### DIFF
--- a/citestfiles/CathodeHeating/beams_off_test.py
+++ b/citestfiles/CathodeHeating/beams_off_test.py
@@ -18,6 +18,37 @@ class TestBeamsOff(unittest.TestCase):
             ps.disable_output.return_value = disable_result
         return ps
 
+    def make_warning_widgets(self):
+        return [[MagicMock(), MagicMock()] for _ in range(3)]
+
+    def install_measured_output_warning_state(self):
+        self.subsys.measured_output_warning_since = {
+            "voltage": [object(), object(), object()],
+            "current": [object(), object(), object()],
+        }
+        self.subsys.measured_output_warning_active = {
+            "voltage": [True, True, True],
+            "current": [True, True, True],
+        }
+        self.subsys.measured_output_warning_logged = {
+            "voltage": [True, True, True],
+            "current": [True, True, True],
+        }
+        self.subsys.actual_heater_voltage_box_widgets = self.make_warning_widgets()
+        self.subsys.actual_heater_current_box_widgets = self.make_warning_widgets()
+
+    def assert_measured_output_warning_cleared(self, index):
+        for measurement_type in ("voltage", "current"):
+            self.assertIsNone(
+                self.subsys.measured_output_warning_since[measurement_type][index]
+            )
+            self.assertFalse(
+                self.subsys.measured_output_warning_active[measurement_type][index]
+            )
+            self.assertFalse(
+                self.subsys.measured_output_warning_logged[measurement_type][index]
+            )
+
     def setUp(self):
         # Bypass __init__ to avoid Tk and image loading
         self.subsys = object.__new__(CathodeHeatingSubsystem)
@@ -31,6 +62,7 @@ class TestBeamsOff(unittest.TestCase):
         # Simple logger hook
         self.subsys.logger = MagicMock()
         self.subsys.log = lambda msg, lvl=LogLevel.INFO: None
+        self.install_measured_output_warning_state()
 
         # Alias method under test (name in your file)
         self.turn_off_all_beams = self.subsys.turn_off_all_beams
@@ -46,6 +78,8 @@ class TestBeamsOff(unittest.TestCase):
         self.assertFalse(self.subsys.toggle_states[2])
         self.subsys.toggle_buttons[0].config.assert_called_once()
         self.subsys.toggle_buttons[2].config.assert_called_once()
+        self.assert_measured_output_warning_cleared(0)
+        self.assert_measured_output_warning_cleared(2)
         # Uninitialized index 1 untouched
         self.subsys.toggle_buttons[1].config.assert_not_called()
 

--- a/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
+++ b/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
@@ -249,7 +249,7 @@ class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
 
         self.assertEqual(main_control._vtrx_ccs_disable_timer_started_at, 100.0)
         self.assertTrue(
-            any("CCS output will be disabled after 30 seconds" in message for message in main_control.logger.messages("CRITICAL"))
+            any("CCS output will be disabled in 30 seconds" in message for message in main_control.logger.messages("CRITICAL"))
         )
 
         main_control._test_time["value"] = 109.0
@@ -325,7 +325,7 @@ class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
         self.assertEqual(cathode.turn_off_calls, 0)
         self.assertTrue(
             any(
-                "pressure reading is stale; CCS output will be disabled after 30 seconds" in message
+                "pressure reading is stale; CCS output will be disabled in 30 seconds" in message
                 for message in main_control.logger.messages("CRITICAL")
             )
         )

--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -102,6 +102,7 @@ The `Config` tab includes:
 - Overcurrent protection (OCP).
 - Current slew rate.
 - Voltage slew rate.
+- Measured voltage/current difference warning thresholds.
 - `Log Power Settings` button and status readback.
 
 ## Output Modes
@@ -244,6 +245,47 @@ The UI tracks three different kinds of values:
 
 This separation is useful during ramps because the sent value can change step-by-step before the measured value settles.
 
+## Warning and Highlight Behavior
+
+The cathode UI has two warning/highlight paths:
+
+- Measured-output sent-vs-measured warnings for heater voltage and current.
+- Overtemperature warning state for clamp temperature.
+
+### Sent-vs-Measured Voltage and Current Warnings
+
+Each cathode has two configurable thresholds on the `Config` tab:
+
+- `Voltage Diff Warning (%)`
+- `Current Diff Warning (%)`
+
+The warning calculation is:
+
+```text
+abs(measured - sent) > abs(sent) * threshold_percent / 100
+```
+
+If that condition remains true for more `1.5`s the measured voltage or current box turns orange and a warning is logged once for that continuous breach. 
+
+Important nuances:
+
+- Voltage warnings are active only while output is enabled and the live 9104 mode is `CV Mode`.
+- Current warnings are active only while output is enabled and the live 9104 mode is `CC Mode`.
+- Warnings are cleared when output is off, readback is unavailable, the sent value is missing or invalid, the sent value is zero, the threshold changes, or the corresponding goal is cleared.
+- A `0%` threshold is allowed. With a nonzero sent value, any nonzero measured difference can warn after the delay.
+- A sent value of zero disables the percent-difference warning for that channel.
+- During a ramp, every successful sent update clears the warning timer for that channel.
+- COM-port reinitialization and reconnect paths reset live readbacks and command readiness, but the displayed sent values can represent the last successful command from before the reconnect until a new command updates them.
+
+### Overtemperature Warning
+
+When the measured temperature is above the configured limit:
+
+- The measured clamp-temperature box turns orange.
+- A critical log entry is emitted: `Cathode X OVERTEMP!`.
+
+When temperature returns below the limit, the measured temperature box returns to the normal measured-output background and status returns to `Normal`. If temperature is unavailable, status becomes `N/A` and the box is also returned to normal.
+
 ## Data Refresh Loop
 
 `update_data()` is the main GUI refresh loop. It runs every 500 ms and, for each cathode:
@@ -252,8 +294,9 @@ This separation is useful during ramps because the sent value can change step-by
 - Reads the latest 9104 voltage, current, and CV/CC mode snapshot.
 - Marks power-supply readbacks unavailable when the snapshot says the supply is disconnected or the read is invalid.
 - Publishes valid heater current and voltage readbacks to the logger.
+- Updates measured voltage/current warning highlights from sent-vs-measured comparisons.
 - Reads the latest clamp temperature data from the temperature-controller interface.
-- Updates overtemperature state and plot color.
+- Updates overtemperature status, temperature-box highlight, and plot color.
 - Appends plot data on the plot interval.
 - Schedules the next update with `self.parent.after(500, self.update_data)`.
 
@@ -520,16 +563,20 @@ flowchart TB
     CacheOK -- No --> ClearPS["Clear heater readback displays
     and publish None values"]
 
-    UpdatePS --> ReadTemp["Read cached E5CN temperature"]
-    ClearPS --> ReadTemp
+    UpdatePS --> WarnCheck["Update sent-vs-measured
+    voltage/current warnings"]
+    ClearPS --> WarnCheck
+    WarnCheck --> ReadTemp["Read cached E5CN temperature"]
     ReadTemp --> TempValid{"Temperature is a float?"}
     TempValid -- No --> TempUnavailable["Show -- C
     and update plot error state"]
     TempValid -- Yes --> CheckOT{"Temperature >
     overtemp limit?"}
     CheckOT -- Yes --> OTActions["Set OVERTEMP status
+    orange temp box
     and red plot state"]
     CheckOT -- No --> NormalTemp["Set Normal status
+    normal temp box
     and normal plot state"]
 
     OTActions --> PlotCheck{"5-second plot interval elapsed?"}

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -238,6 +238,10 @@ class CathodeHeatingSubsystem:
             "voltage": [False, False, False],
             "current": [False, False, False],
         }
+        self.measured_output_warning_logged = {
+            "voltage": [False, False, False],
+            "current": [False, False, False],
+        }
         self.log_power_settings_buttons = []
         self.lookup_table_comboboxes = []
         self.curr_adjustment_buttons = []  # Track current +/- buttons 
@@ -2744,31 +2748,55 @@ class CathodeHeatingSubsystem:
             widget.configure(fg=self.MEASURED_OUTPUT_NORMAL_FG)
         self.measured_output_warning_active[measurement_type][index] = bool(warning_active)
 
-    def _clear_measured_output_warning(self, index, measurement_type):
+    def _measured_output_unit(self, measurement_type):
+        return "V" if measurement_type == "voltage" else "A"
+
+    def _log_measured_output_warning_breach(self, index, measurement_type, sent, measured, threshold_percent, difference):
+        if self.measured_output_warning_logged[measurement_type][index]:
+            return
+        self.measured_output_warning_logged[measurement_type][index] = True
+        cathode = ['A', 'B', 'C'][index]
+        unit = self._measured_output_unit(measurement_type)
+        self.log(
+            f"Cathode {cathode} measured-output {measurement_type} warning: "
+            f"measured {measured:.2f}{unit}, sent {sent:.2f}{unit}, "
+            f"difference {difference:.2f}{unit} exceeds {threshold_percent:g}% threshold.",
+            LogLevel.WARNING,
+        )
+
+    def _clear_measured_output_warning(self, index, measurement_type, *, log_clear=False):
+        was_logged = self.measured_output_warning_logged[measurement_type][index]
         self.measured_output_warning_since[measurement_type][index] = None
         self._set_measured_output_warning_box(index, measurement_type, False)
+        self.measured_output_warning_logged[measurement_type][index] = False
+        if log_clear and was_logged:
+            cathode = ['A', 'B', 'C'][index]
+            self.log(
+                f"Cathode {cathode} measured-output {measurement_type} warning cleared.",
+                LogLevel.INFO,
+            )
 
     def _update_single_measured_output_warning(self, index, measurement_type, sent_value, measured_value, active, now):
         if not active:
-            self._clear_measured_output_warning(index, measurement_type)
+            self._clear_measured_output_warning(index, measurement_type, log_clear=True)
             return
 
         try:
             sent = float(sent_value)
             measured = float(measured_value)
         except (TypeError, ValueError):
-            self._clear_measured_output_warning(index, measurement_type)
+            self._clear_measured_output_warning(index, measurement_type, log_clear=True)
             return
 
         if not np.isfinite(sent) or not np.isfinite(measured) or sent == 0.0:
-            self._clear_measured_output_warning(index, measurement_type)
+            self._clear_measured_output_warning(index, measurement_type, log_clear=True)
             return
 
         threshold_percent = self.measured_output_warning_thresholds[measurement_type][index]
         allowed_difference = abs(sent) * (threshold_percent / 100.0)
         difference = abs(measured - sent)
         if difference <= allowed_difference:
-            self._clear_measured_output_warning(index, measurement_type)
+            self._clear_measured_output_warning(index, measurement_type, log_clear=True)
             return
 
         violation_started = self.measured_output_warning_since[measurement_type][index]
@@ -2777,11 +2805,17 @@ class CathodeHeatingSubsystem:
             self._set_measured_output_warning_box(index, measurement_type, False)
             return
 
-        self._set_measured_output_warning_box(
-            index,
-            measurement_type,
-            (now - violation_started) > self.MEASURED_OUTPUT_WARNING_SECONDS,
-        )
+        warning_active = (now - violation_started) > self.MEASURED_OUTPUT_WARNING_SECONDS
+        self._set_measured_output_warning_box(index, measurement_type, warning_active)
+        if warning_active:
+            self._log_measured_output_warning_breach(
+                index,
+                measurement_type,
+                sent,
+                measured,
+                threshold_percent,
+                difference,
+            )
 
     def _update_measured_output_warning_indicators(self, index, voltage, current, mode):
         if not (0 <= index < 3):

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -65,15 +65,24 @@ class CathodeHeatingSubsystem:
     RICHARDSON_WORK_FUNCTION_EV = 2.69
     BOLTZMANN_CONSTANT_EV_PER_K = 8.617333262145e-5
     
-    # Empirical correction for using the ES440 heater V-I characterization as an
-    # outside-LUT fallback with CCS experimental LUT data.
-    #
-    # The Cbmark_Beam_A_07_2025 LUT boundary gives 6.03 A -> 0.81 V, while the
-    # uncorrected ES440 V-I model gives about 0.5174 V at 6.03 A. The offset
-    # below keeps the extrapolated ES440 V-I curve continuous with that
-    # experimental boundary without changing in-domain LUT interpolation.
-    HEATER_IV_CORRECTION_ENABLED = True
-    HEATER_IV_VOLTAGE_OFFSET_V = 0.2926
+    # Outside-LUT calibration is dataset-specific. Add future LUT calibrations
+    # here rather than changing the ES440 reference data or prediction logic.
+    # Unlisted datasets retain the raw ES440/Richardson fallback (zero offsets).
+    PREDICTION_MODEL_DEFAULT_CALIBRATION = {
+        "heater_iv_voltage_offset_v": 0.0,
+        "voltage_mode_model_offset_v": 0.0,
+        "current_mode_temperature_offset_k": 0.0,
+    }
+    PREDICTION_MODEL_DATASET_CALIBRATIONS = {
+        "Cbmark_Beam_A_07_2025.csv": {
+            # Physical I-V alignment: 6.03 A -> 0.81 V at the LUT boundary.
+            "heater_iv_voltage_offset_v": 0.2926,
+            # Internal beam-model calibration used only when voltage binds.
+            "voltage_mode_model_offset_v": 0.0914943979,
+            # Internal beam-model calibration used only when current binds.
+            "current_mode_temperature_offset_k": 511.0,
+        },
+    }
 
     OUTPUT_MODE_LABEL_TO_VALUE = {
         'Ramp Current': 'ramp_current',
@@ -2955,8 +2964,24 @@ class CathodeHeatingSubsystem:
         radius_cm = (cls.RICHARDSON_CATHODE_DIAMETER_MM / 10.0) / 2.0
         return float(np.pi * radius_cm * radius_cm)
 
-    def _estimate_heater_voltage_from_current_model(self, current):
-        """Estimate heater voltage from the corrected ES440 heater V-I model."""
+    def _prediction_model_calibration(self, index):
+        """Return the outside-LUT calibration for the selected dataset."""
+        calibration = dict(self.PREDICTION_MODEL_DEFAULT_CALIBRATION)
+        selected_files = getattr(self, "selected_lut_files", None)
+        selected_filename = None
+        if selected_files is not None and 0 <= index < len(selected_files):
+            selected_filename = selected_files[index]
+
+        if selected_filename:
+            selected_key = str(selected_filename).lower()
+            for filename, overrides in self.PREDICTION_MODEL_DATASET_CALIBRATIONS.items():
+                if filename.lower() == selected_key:
+                    calibration.update(overrides)
+                    break
+        return calibration
+
+    def _estimate_heater_voltage_from_current_model(self, index, current):
+        """Estimate physical heater voltage from the dataset-corrected I-V model."""
         voltage = self._linear_model_value(
             ES440_cathode.heater_voltage_current_data,
             current,
@@ -2965,18 +2990,17 @@ class CathodeHeatingSubsystem:
         )
         if voltage is None:
             return None
-        if self.HEATER_IV_CORRECTION_ENABLED:
-            voltage += self.HEATER_IV_VOLTAGE_OFFSET_V
-        return voltage
+        calibration = self._prediction_model_calibration(index)
+        return voltage + calibration["heater_iv_voltage_offset_v"]
 
-    def _estimate_heater_current_from_voltage_model(self, voltage):
-        """Estimate heater current from the corrected ES440 heater V-I model."""
+    def _estimate_heater_current_from_voltage_model(self, index, voltage):
+        """Estimate physical heater current from the dataset-corrected I-V model."""
         try:
             model_voltage = float(voltage)
         except (TypeError, ValueError):
             return None
-        if self.HEATER_IV_CORRECTION_ENABLED:
-            model_voltage -= self.HEATER_IV_VOLTAGE_OFFSET_V
+        calibration = self._prediction_model_calibration(index)
+        model_voltage -= calibration["heater_iv_voltage_offset_v"]
         return self._linear_model_value(
             ES440_cathode.heater_voltage_current_data,
             model_voltage,
@@ -2992,6 +3016,64 @@ class CathodeHeatingSubsystem:
             x_index=0,
             y_index=1,
         )
+
+    def _estimate_mode_aware_temperature(
+        self,
+        index,
+        heater_voltage,
+        heater_current,
+        controlling_mode,
+    ):
+        """Return the effective temperature for the binding outside-LUT constraint.
+
+        The physical heater I-V correction and the emission-model corrections are
+        intentionally separate. Voltage control uses its voltage only as an
+        internal coordinate in the raw ES440 model. Current control uses physical
+        heater current and applies the dataset's temperature calibration.
+        """
+        calibration = self._prediction_model_calibration(index)
+        if controlling_mode == "voltage":
+            try:
+                model_voltage = (
+                    float(heater_voltage)
+                    + calibration["voltage_mode_model_offset_v"]
+                )
+            except (TypeError, ValueError):
+                return None
+            model_heater_current = self._linear_model_value(
+                ES440_cathode.heater_voltage_current_data,
+                model_voltage,
+                x_index=1,
+                y_index=0,
+            )
+            if model_heater_current is None:
+                return None
+            temperature_k = self._estimate_true_temperature_from_current_model(
+                model_heater_current
+            )
+            correction = "voltage-model offset"
+        elif controlling_mode == "current":
+            try:
+                model_heater_current = float(heater_current)
+            except (TypeError, ValueError):
+                return None
+            temperature_k = self._estimate_true_temperature_from_current_model(
+                model_heater_current
+            )
+            if temperature_k is not None:
+                temperature_k += calibration["current_mode_temperature_offset_k"]
+            correction = "current-temperature offset"
+        else:
+            return None
+
+        if temperature_k is None:
+            return None
+        return {
+            "temperature_k": float(temperature_k),
+            "model_heater_current": float(model_heater_current),
+            "control_mode": controlling_mode,
+            "correction": correction,
+        }
 
     def _richardson_emission_current_a(self, temperature_k):
         """
@@ -3018,7 +3100,13 @@ class CathodeHeatingSubsystem:
             return None
         return float(emission_a)
 
-    def _richardson_fallback_beam_current_ma(self, index, heater_voltage, target_heater_current=None):
+    def _richardson_fallback_beam_current_ma(
+        self,
+        index,
+        heater_voltage,
+        target_heater_current=None,
+        controlling_mode=None,
+    ):
         """
         Predict beam current above the LUT domain using Richardson-Dushman.
 
@@ -3028,12 +3116,11 @@ class CathodeHeatingSubsystem:
         requested heater voltage/current is above the LUT range.
 
         The physics path is:
-        1. Resolve heater current. If the caller already has a requested/current-
-           limited heater current, use it. Otherwise estimate current from heater
-           voltage using the ES440 heater V-I characterization.
-        2. Estimate true emitting-surface temperature from heater current using the
-           ES440 heater-current/temperature characterization. This is not clamp
-           temperature; it is a model estimate of cathode surface temperature.
+        1. Resolve the physical heater current from the requested limits and the
+           dataset-corrected I-V relationship.
+        2. Use the correction for the binding constraint to estimate effective
+           emitting-surface temperature. This is a model temperature, not clamp
+           temperature.
         3. Apply Richardson-Dushman to predict total emission current in amps.
         4. Convert total emission current to beam current in mA using the configured
            beam/emission fraction, matching the existing dashboard convention:
@@ -3054,13 +3141,30 @@ class CathodeHeatingSubsystem:
         if heater_current is None:
             if not above_voltage_lut:
                 return None
-            heater_current = self._estimate_heater_current_from_voltage_model(heater_voltage)
+            heater_current = self._estimate_heater_current_from_voltage_model(
+                index,
+                heater_voltage,
+            )
         else:
             above_current_lut = self._is_above_lut_domain(index, heater_current, "heater_current", "voltage")
             if not above_voltage_lut and not above_current_lut:
                 return None
 
-        temperature_k = self._estimate_true_temperature_from_current_model(heater_current)
+        if controlling_mode not in ("current", "voltage"):
+            # Compatibility fallback for callers that have not resolved a binding
+            # constraint: supplied current implies current control; otherwise use
+            # voltage control.
+            controlling_mode = "current" if target_heater_current is not None else "voltage"
+
+        temperature_prediction = self._estimate_mode_aware_temperature(
+            index,
+            heater_voltage,
+            heater_current,
+            controlling_mode,
+        )
+        if temperature_prediction is None:
+            return None
+        temperature_k = temperature_prediction["temperature_k"]
         emission_current_a = self._richardson_emission_current_a(temperature_k)
         if emission_current_a is None:
             return None
@@ -3068,9 +3172,12 @@ class CathodeHeatingSubsystem:
         beam_current_ma = emission_current_a * 1000.0 * self.BEAM_CURRENT_FRACTION_OF_EMISSION
         return {
             "heater_current": float(heater_current),
+            "model_heater_current": temperature_prediction["model_heater_current"],
             "temperature_k": float(temperature_k),
             "emission_current_a": float(emission_current_a),
             "beam_current_ma": float(beam_current_ma),
+            "control_mode": controlling_mode,
+            "correction": temperature_prediction["correction"],
         }
 
     def _log_richardson_fallback_prediction(self, index, heater_voltage, fallback, reason):
@@ -3096,9 +3203,11 @@ class CathodeHeatingSubsystem:
         self.log(
             (
                 f"Cathode {cathode_label} Richardson fallback details: "
+                f"control_mode={fallback['control_mode']}, "
                 f"heater_voltage={float(heater_voltage):.3f}V, "
                 f"heater_current={fallback['heater_current']:.3f}A, "
-                f"true_temperature={fallback['temperature_k']:.1f}K, "
+                f"model_heater_current={fallback['model_heater_current']:.3f}A, "
+                f"effective_temperature={fallback['temperature_k']:.1f}K, "
                 f"emission={fallback['emission_current_a'] * 1000.0:.6f}mA, "
                 f"beam={fallback['beam_current_ma']:.6f}mA, "
                 f"diameter={self.RICHARDSON_CATHODE_DIAMETER_MM:.3f}mm, "
@@ -3367,14 +3476,17 @@ class CathodeHeatingSubsystem:
                     # Current is limited by voltage and will not reach full set value
                     pred_heater_current = limited_current
                     pred_heater_voltage = self.user_set_voltages[index]
+                    controlling_mode = "voltage"
                 else:
                     # Voltage is potentially limited by current
                     pred_heater_current = current
                     pred_heater_voltage = min(self.user_set_voltages[index], limited_voltage)
+                    controlling_mode = "current"
             else:
                 # If no heater voltage is set we will predict the voltage produced by the new current and set it on the power supply
                 pred_heater_voltage = self._voltage_for_current(index, current)
                 pred_heater_current = current
+                controlling_mode = "current"
 
             if pred_heater_voltage is None:
                 self.clear_prediction_variables(index)
@@ -3388,7 +3500,8 @@ class CathodeHeatingSubsystem:
             _,_, pred_beam_current = self.emission_cur_vlt_converter(
                 index,
                 pred_heater_voltage,
-                target_heater_current=pred_heater_current
+                target_heater_current=pred_heater_current,
+                controlling_mode=controlling_mode,
             )
 
             # Check that LUT returned values, if not then reset predicted values
@@ -3411,7 +3524,17 @@ class CathodeHeatingSubsystem:
                 self._is_above_lut_domain(index, pred_heater_current, "heater_current", "voltage")
                 or self._is_above_lut_domain(index, pred_heater_voltage, "voltage", "beam_current")
             ):
-                temp_k = self._estimate_true_temperature_from_current_model(pred_heater_current)
+                temperature_prediction = self._estimate_mode_aware_temperature(
+                    index,
+                    pred_heater_voltage,
+                    pred_heater_current,
+                    controlling_mode,
+                )
+                temp_k = (
+                    temperature_prediction["temperature_k"]
+                    if temperature_prediction is not None
+                    else None
+                )
                 self.predicted_temperature_vars[index].set(f'{temp_k - 273.15:.0f} C' if temp_k is not None else '--')
             else:
                 self.predicted_temperature_vars[index].set('--')
@@ -3452,14 +3575,17 @@ class CathodeHeatingSubsystem:
                     # Voltage is limited by current and will not reach full set value
                     pred_heater_voltage = limited_voltage
                     pred_heater_current = self.user_set_currents[index]
+                    controlling_mode = "current"
                 else:
                     # Current is potentially limited by voltage
                     pred_heater_voltage = voltage
                     pred_heater_current = min(self.user_set_currents[index], limited_current)
+                    controlling_mode = "voltage"
             else:
                 # If no heater current is set we will predict the current produced by the new voltage and set it on the power supply
                 pred_heater_current = self._current_for_voltage(index, voltage)
                 pred_heater_voltage = voltage
+                controlling_mode = "voltage"
 
             if pred_heater_current is None or pred_heater_voltage is None:
                 self.clear_prediction_variables(index)
@@ -3473,7 +3599,8 @@ class CathodeHeatingSubsystem:
             _,_, pred_beam_current = self.emission_cur_vlt_converter(
                 index,
                 pred_heater_voltage,
-                target_heater_current=pred_heater_current
+                target_heater_current=pred_heater_current,
+                controlling_mode=controlling_mode,
             )
 
             # Check that LUT returned values, if not then reset predicted values
@@ -3496,7 +3623,17 @@ class CathodeHeatingSubsystem:
                 self._is_above_lut_domain(index, pred_heater_voltage, "voltage", "beam_current")
                 or self._is_above_lut_domain(index, pred_heater_current, "heater_current", "voltage")
             ):
-                temp_k = self._estimate_true_temperature_from_current_model(pred_heater_current)
+                temperature_prediction = self._estimate_mode_aware_temperature(
+                    index,
+                    pred_heater_voltage,
+                    pred_heater_current,
+                    controlling_mode,
+                )
+                temp_k = (
+                    temperature_prediction["temperature_k"]
+                    if temperature_prediction is not None
+                    else None
+                )
                 self.predicted_temperature_vars[index].set(f'{temp_k - 273.15:.0f} C' if temp_k is not None else '--')
             else:
                 self.predicted_temperature_vars[index].set('--')
@@ -3514,7 +3651,7 @@ class CathodeHeatingSubsystem:
         if heater_current is not None:
             return heater_current
         if self._is_above_lut_domain(index, voltage, "voltage", "heater_current"):
-            return self._estimate_heater_current_from_voltage_model(voltage)
+            return self._estimate_heater_current_from_voltage_model(index, voltage)
         return None
 
     def _voltage_for_current(self, index: int, current: float):
@@ -3523,10 +3660,16 @@ class CathodeHeatingSubsystem:
         if heater_voltage is not None:
             return heater_voltage
         if self._is_above_lut_domain(index, current, "heater_current", "voltage"):
-            return self._estimate_heater_voltage_from_current_model(current)
+            return self._estimate_heater_voltage_from_current_model(index, current)
         return None
 
-    def emission_cur_vlt_converter(self, index, val, target_heater_current=None):
+    def emission_cur_vlt_converter(
+        self,
+        index,
+        val,
+        target_heater_current=None,
+        controlling_mode=None,
+    ):
         """
         Convert between voltage and current using the DataFrame lookup.
 
@@ -3541,6 +3684,9 @@ class CathodeHeatingSubsystem:
             target_heater_current (float | None): Resolved heater current from
                 the active setpoint path. Used by the above-LUT Richardson
                 fallback because temperature is estimated from heater current.
+            controlling_mode (str | None): Binding physical constraint, either
+                ``current`` or ``voltage``. Selects the dataset correction used
+                by the outside-LUT temperature model.
 
         Returns:
             tuple: (heater_voltage, heater_current, beam_current)
@@ -3562,6 +3708,7 @@ class CathodeHeatingSubsystem:
                     index,
                     val,
                     target_heater_current=target_heater_current,
+                    controlling_mode=controlling_mode,
                 )
                 if fallback is not None:
                     self._log_richardson_fallback_prediction(index, val, fallback, reason)
@@ -3578,6 +3725,7 @@ class CathodeHeatingSubsystem:
                     index,
                     val,
                     target_heater_current=target_heater_current,
+                    controlling_mode=controlling_mode,
                 )
                 if fallback is not None:
                     self._log_richardson_fallback_prediction(index, val, fallback, reason)

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -64,6 +64,16 @@ class CathodeHeatingSubsystem:
     RICHARDSON_CONSTANT_A_PER_CM2_K2 = 80.0
     RICHARDSON_WORK_FUNCTION_EV = 2.69
     BOLTZMANN_CONSTANT_EV_PER_K = 8.617333262145e-5
+    
+    # Empirical correction for using the ES440 heater V-I characterization as an
+    # outside-LUT fallback with CCS experimental LUT data.
+    #
+    # The Cbmark_Beam_A_07_2025 LUT boundary gives 6.03 A -> 0.81 V, while the
+    # uncorrected ES440 V-I model gives about 0.5174 V at 6.03 A. The offset
+    # below keeps the extrapolated ES440 V-I curve continuous with that
+    # experimental boundary without changing in-domain LUT interpolation.
+    HEATER_IV_CORRECTION_ENABLED = True
+    HEATER_IV_VOLTAGE_OFFSET_V = 0.2926
 
     OUTPUT_MODE_LABEL_TO_VALUE = {
         'Ramp Current': 'ramp_current',
@@ -2946,19 +2956,30 @@ class CathodeHeatingSubsystem:
         return float(np.pi * radius_cm * radius_cm)
 
     def _estimate_heater_voltage_from_current_model(self, current):
-        """Estimate heater voltage from ES440 heater-current/voltage data."""
-        return self._linear_model_value(
+        """Estimate heater voltage from the corrected ES440 heater V-I model."""
+        voltage = self._linear_model_value(
             ES440_cathode.heater_voltage_current_data,
             current,
             x_index=0,
             y_index=1,
         )
+        if voltage is None:
+            return None
+        if self.HEATER_IV_CORRECTION_ENABLED:
+            voltage += self.HEATER_IV_VOLTAGE_OFFSET_V
+        return voltage
 
     def _estimate_heater_current_from_voltage_model(self, voltage):
-        """Estimate heater current from ES440 heater-current/voltage data."""
+        """Estimate heater current from the corrected ES440 heater V-I model."""
+        try:
+            model_voltage = float(voltage)
+        except (TypeError, ValueError):
+            return None
+        if self.HEATER_IV_CORRECTION_ENABLED:
+            model_voltage -= self.HEATER_IV_VOLTAGE_OFFSET_V
         return self._linear_model_value(
             ES440_cathode.heater_voltage_current_data,
-            voltage,
+            model_voltage,
             x_index=1,
             y_index=0,
         )

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -53,6 +53,12 @@ class CathodeHeatingSubsystem:
     OVERTEMP_THRESHOLD = 200.0 # Overtemperature threshold in C
     POLL_ERROR_LOG_INTERVAL_SECONDS = 10.0
     WORKER_LOG_QUEUE_MAXSIZE = 1000
+    DEFAULT_VOLTAGE_DIFF_WARNING_PERCENT = 10.0
+    DEFAULT_CURRENT_DIFF_WARNING_PERCENT = 10.0
+    MEASURED_OUTPUT_WARNING_SECONDS = 1.5
+    MEASURED_OUTPUT_NORMAL_BG = 'white'
+    MEASURED_OUTPUT_NORMAL_FG = 'black'
+    MEASURED_OUTPUT_WARNING_BG = '#FF8000'
     # Failed deferred 9104 setup is retried by the poller, but not on every poll cycle.
     POWER_SUPPLY_CONFIG_RETRY_COOLDOWN_SECONDS = 10.0
 
@@ -214,15 +220,33 @@ class CathodeHeatingSubsystem:
         self.entry_fields = []
         self.user_set_voltages = [None, None, None]
         self.user_set_currents = [None, None, None]
+        self.sent_heater_voltage_values = [None, None, None]
+        self.sent_heater_current_values = [None, None, None]
         self.vlt_slew_rate = [0.02, 0.02, 0.02] # Default slew rates in V/s, 0.02 is mimimum ps resolution
         self.curr_slew_rate = [0.01, 0.01, 0.01] # Default slew rates in A/s, 0.01 is mimimum ps resolution
         self.ramp_status = [False, False, False]
         self.ramp_control_mode = ["current", "current", "current"] # "current" | "voltage"
+        self.measured_output_warning_thresholds = {
+            "voltage": [self.DEFAULT_VOLTAGE_DIFF_WARNING_PERCENT for _ in range(3)],
+            "current": [self.DEFAULT_CURRENT_DIFF_WARNING_PERCENT for _ in range(3)],
+        }
+        self.measured_output_warning_since = {
+            "voltage": [None, None, None],
+            "current": [None, None, None],
+        }
+        self.measured_output_warning_active = {
+            "voltage": [False, False, False],
+            "current": [False, False, False],
+        }
         self.log_power_settings_buttons = []
         self.lookup_table_comboboxes = []
         self.curr_adjustment_buttons = []  # Track current +/- buttons 
         self.vlt_adjustment_buttons = []  # Track voltage +/- buttons 
         self.set_button_states = [] # Track both voltage and current set button states to disable during ramp
+        self.actual_heater_voltage_frames = []
+        self.actual_heater_current_frames = []
+        self.actual_heater_voltage_box_widgets = []
+        self.actual_heater_current_box_widgets = []
         self.power_supply_comms_indicators = []
         self.temperature_comms_indicators = []
 
@@ -381,6 +405,16 @@ class CathodeHeatingSubsystem:
         self.overcurrent_limit_vars = [tk.DoubleVar(value=9.0) for _ in range(3)]  # Default 9.0A limit (1.0V -> 9.0A per ES440 cathode, not 8.5A)
         self.ovl_readback_vars = [tk.StringVar(value='N/A') for _ in range(3)]
         self.ocl_readback_vars = [tk.StringVar(value='N/A') for _ in range(3)]
+        self.voltage_diff_warning_entry_vars = [tk.StringVar(value='') for _ in range(3)]
+        self.current_diff_warning_entry_vars = [tk.StringVar(value='') for _ in range(3)]
+        self.voltage_diff_warning_value_vars = [
+            tk.StringVar(value=self._format_measured_output_warning_threshold(i, "voltage"))
+            for i in range(3)
+        ]
+        self.current_diff_warning_value_vars = [
+            tk.StringVar(value=self._format_measured_output_warning_threshold(i, "current"))
+            for i in range(3)
+        ]
 
     def setup_gui(self):
         self._init_ocl_live_values()
@@ -780,21 +814,57 @@ class CathodeHeatingSubsystem:
             
             # Voltage
             actual_voltage_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
-            actual_voltage_frame.configure(bg='#d9d9d9')
+            actual_voltage_frame.configure(bg=self.MEASURED_OUTPUT_NORMAL_BG)
             actual_voltage_frame.grid(row=0, column=0, sticky='w', padx=(0, 6))
-            actual_voltage_label = ttk.Label(actual_voltage_frame, textvariable=self.actual_heater_voltage_vars[i], style='Bold.TLabel') 
+            actual_voltage_label = tk.Label(
+                actual_voltage_frame,
+                textvariable=self.actual_heater_voltage_vars[i],
+                bg=self.MEASURED_OUTPUT_NORMAL_BG,
+                fg=self.MEASURED_OUTPUT_NORMAL_FG,
+                font=('Segoe UI', 8, 'bold'),
+            )
             actual_voltage_label.pack(side='left')
-            unit_label = ttk.Label(actual_voltage_frame, text=" V", style="Bold.TLabel")
-            unit_label.pack(side='left')
+            actual_voltage_unit_label = tk.Label(
+                actual_voltage_frame,
+                text=" V",
+                bg=self.MEASURED_OUTPUT_NORMAL_BG,
+                fg=self.MEASURED_OUTPUT_NORMAL_FG,
+                font=('Segoe UI', 8, 'bold'),
+            )
+            actual_voltage_unit_label.pack(side='left')
+            self.actual_heater_voltage_frames.append(actual_voltage_frame)
+            self.actual_heater_voltage_box_widgets.append([
+                actual_voltage_frame,
+                actual_voltage_label,
+                actual_voltage_unit_label,
+            ])
 
             # Current
             actual_current_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
-            actual_current_frame.configure(bg='#d9d9d9')
+            actual_current_frame.configure(bg=self.MEASURED_OUTPUT_NORMAL_BG)
             actual_current_frame.grid(row=0, column=1, sticky='w', padx=(0, 8))
-            actual_current_label = ttk.Label(actual_current_frame, textvariable=self.actual_heater_current_vars[i], style='Bold.TLabel') 
+            actual_current_label = tk.Label(
+                actual_current_frame,
+                textvariable=self.actual_heater_current_vars[i],
+                bg=self.MEASURED_OUTPUT_NORMAL_BG,
+                fg=self.MEASURED_OUTPUT_NORMAL_FG,
+                font=('Segoe UI', 8, 'bold'),
+            )
             actual_current_label.pack(side='left')
-            unit_label = ttk.Label(actual_current_frame, text=" A", style="Bold.TLabel")
-            unit_label.pack(side='left')
+            actual_current_unit_label = tk.Label(
+                actual_current_frame,
+                text=" A",
+                bg=self.MEASURED_OUTPUT_NORMAL_BG,
+                fg=self.MEASURED_OUTPUT_NORMAL_FG,
+                font=('Segoe UI', 8, 'bold'),
+            )
+            actual_current_unit_label.pack(side='left')
+            self.actual_heater_current_frames.append(actual_current_frame)
+            self.actual_heater_current_box_widgets.append([
+                actual_current_frame,
+                actual_current_label,
+                actual_current_unit_label,
+            ])
             
             # Temp
             ttk.Label(measured_frame, text='Temp', style='RightAlign.TLabel').grid(row=0, column=2, sticky='w', padx=(0, 2))
@@ -1140,6 +1210,75 @@ class CathodeHeatingSubsystem:
             if not hasattr(self, '_sync_vsr_funcs'):
                 self._sync_vsr_funcs = []
             self._sync_vsr_funcs.append(sync_vsr)
+
+            voltage_warning_frame = ttk.Frame(config_tab)
+            voltage_warning_frame.grid(row=7, column=0, columnspan=3, sticky='w', pady=(2, 2))
+            voltage_warning_label_frame = ttk.Frame(voltage_warning_frame)
+            voltage_warning_label_frame.grid(row=0, column=0, sticky='w')
+            voltage_warning_label = ttk.Label(
+                voltage_warning_label_frame,
+                text='Voltage Diff Warning (%):',
+                style='RightAlign.TLabel',
+            )
+            voltage_warning_label.pack(side='left')
+            voltage_warning_display_frame = tk.Frame(voltage_warning_label_frame, bd=2, relief='groove', padx=2, pady=1)
+            voltage_warning_display_frame.configure(bg=self.MEASURED_OUTPUT_NORMAL_BG)
+            voltage_warning_display_frame.pack(side='left', padx=(6, 0))
+            ttk.Label(
+                voltage_warning_display_frame,
+                textvariable=self.voltage_diff_warning_value_vars[i],
+                style='Bold.TLabel',
+                width=5,
+                anchor='e',
+            ).pack(side='left')
+            voltage_warning_entry = ttk.Entry(
+                voltage_warning_frame,
+                textvariable=self.voltage_diff_warning_entry_vars[i],
+                width=7,
+            )
+            voltage_warning_entry.grid(row=0, column=1, sticky='w', padx=(5, 2))
+            ttk.Button(
+                voltage_warning_frame,
+                text="Set",
+                width=4,
+                command=lambda i=i: self.set_measured_output_warning_threshold(i, "voltage"),
+            ).grid(row=0, column=2, sticky='w', padx=(2, 2))
+            ToolTip(voltage_warning_label, "Measured voltage warning threshold as a percentage of sent voltage")
+
+            current_warning_frame = ttk.Frame(config_tab)
+            current_warning_frame.grid(row=8, column=0, columnspan=3, sticky='w', pady=(2, 2))
+            current_warning_label_frame = ttk.Frame(current_warning_frame)
+            current_warning_label_frame.grid(row=0, column=0, sticky='w')
+            current_warning_label = ttk.Label(
+                current_warning_label_frame,
+                text='Current Diff Warning (%):',
+                style='RightAlign.TLabel',
+            )
+            current_warning_label.pack(side='left')
+            current_warning_display_frame = tk.Frame(current_warning_label_frame, bd=2, relief='groove', padx=2, pady=1)
+            current_warning_display_frame.configure(bg=self.MEASURED_OUTPUT_NORMAL_BG)
+            current_warning_display_frame.pack(side='left', padx=(7, 0))
+            ttk.Label(
+                current_warning_display_frame,
+                textvariable=self.current_diff_warning_value_vars[i],
+                style='Bold.TLabel',
+                width=5,
+                anchor='e',
+            ).pack(side='left')
+            current_warning_entry = ttk.Entry(
+                current_warning_frame,
+                textvariable=self.current_diff_warning_entry_vars[i],
+                width=7,
+            )
+            current_warning_entry.grid(row=0, column=1, sticky='w', padx=(5, 2))
+            ttk.Button(
+                current_warning_frame,
+                text="Set",
+                width=4,
+                command=lambda i=i: self.set_measured_output_warning_threshold(i, "current"),
+            ).grid(row=0, column=2, sticky='w', padx=(2, 2))
+            ToolTip(current_warning_label, "Measured current warning threshold as a percentage of sent current")
+
             # Add label for Temperature Controller
             ttk.Label(config_tab, text="\nTemperature Controller", style='Bold.TLabel').grid(row=9, column=0, columnspan=3, sticky="ew")
 
@@ -2328,6 +2467,8 @@ class CathodeHeatingSubsystem:
         self.actual_heater_current_vars[index].set("--")
         self.actual_heater_voltage_vars[index].set("--")
         self.operation_mode_var[index].set("Mode: --")
+        self._clear_measured_output_warning(index, "voltage")
+        self._clear_measured_output_warning(index, "current")
 
         if index < len(self.cv_cc_labels):
             cv_lbl, cc_lbl = self.cv_cc_labels[index]
@@ -2439,6 +2580,8 @@ class CathodeHeatingSubsystem:
                 self._log_power_supply_readback_state(i, "not_initialized")
                 self._mark_power_supply_unavailable(i)
 
+            self._update_measured_output_warning_indicators(i, voltage, current, mode)
+
             temperature = self.read_temperature(i)
             if self.logger and hasattr(self.logger, "update_cathode_field"):
                 cathode_label = ['A', 'B', 'C'][i]
@@ -2537,6 +2680,134 @@ class CathodeHeatingSubsystem:
         ax.relim()
         ax.autoscale_view(scaley=False)  # Only autoscale x-axis
         ax.figure.canvas.draw()
+
+    def _format_measured_output_warning_threshold(self, index, measurement_type):
+        value = self.measured_output_warning_thresholds[measurement_type][index]
+        return f"{value:g} %"
+
+    def set_measured_output_warning_threshold(self, index, measurement_type):
+        if measurement_type == "voltage":
+            entry_var = self.voltage_diff_warning_entry_vars[index]
+            value_var = self.voltage_diff_warning_value_vars[index]
+            label = "voltage"
+        else:
+            entry_var = self.current_diff_warning_entry_vars[index]
+            value_var = self.current_diff_warning_value_vars[index]
+            label = "current"
+
+        raw_value = entry_var.get().strip()
+        if raw_value == "":
+            self.log(f"Missing CCS measured-output {label} warning threshold for Cathode {['A', 'B', 'C'][index]}", LogLevel.WARNING)
+            msgbox.showerror("Error", f"Please enter a {label} warning threshold percentage.")
+            return
+
+        try:
+            new_value = float(raw_value)
+        except ValueError:
+            self.log(f"Invalid CCS measured-output {label} warning threshold for Cathode {['A', 'B', 'C'][index]}: {raw_value}", LogLevel.WARNING)
+            msgbox.showerror("Error", f"Please enter a valid {label} warning threshold percentage.")
+            return
+
+        if not np.isfinite(new_value) or new_value < 0:
+            self.log(
+                f"Invalid CCS measured-output {label} warning threshold for Cathode {['A', 'B', 'C'][index]}: {new_value}",
+                LogLevel.WARNING,
+            )
+            msgbox.showerror("Error", "Warning threshold percentage must be zero or greater.")
+            return
+
+        self.measured_output_warning_thresholds[measurement_type][index] = new_value
+        value_var.set(self._format_measured_output_warning_threshold(index, measurement_type))
+        entry_var.set("")
+        self._clear_measured_output_warning(index, measurement_type)
+        self.log(
+            f"Set Cathode {['A', 'B', 'C'][index]} measured-output {label} warning threshold to {new_value:g}%",
+            LogLevel.INFO,
+        )
+
+    def _set_measured_output_warning_box(self, index, measurement_type, warning_active):
+        box_widgets = (
+            self.actual_heater_voltage_box_widgets
+            if measurement_type == "voltage"
+            else self.actual_heater_current_box_widgets
+        )
+        if index >= len(box_widgets):
+            return
+        background_color = (
+            self.MEASURED_OUTPUT_WARNING_BG
+            if warning_active
+            else self.MEASURED_OUTPUT_NORMAL_BG
+        )
+        for widget in box_widgets[index]:
+            widget.configure(bg=background_color)
+        for widget in box_widgets[index][1:]:
+            widget.configure(fg=self.MEASURED_OUTPUT_NORMAL_FG)
+        self.measured_output_warning_active[measurement_type][index] = bool(warning_active)
+
+    def _clear_measured_output_warning(self, index, measurement_type):
+        self.measured_output_warning_since[measurement_type][index] = None
+        self._set_measured_output_warning_box(index, measurement_type, False)
+
+    def _update_single_measured_output_warning(self, index, measurement_type, sent_value, measured_value, active, now):
+        if not active:
+            self._clear_measured_output_warning(index, measurement_type)
+            return
+
+        try:
+            sent = float(sent_value)
+            measured = float(measured_value)
+        except (TypeError, ValueError):
+            self._clear_measured_output_warning(index, measurement_type)
+            return
+
+        if not np.isfinite(sent) or not np.isfinite(measured) or sent == 0.0:
+            self._clear_measured_output_warning(index, measurement_type)
+            return
+
+        threshold_percent = self.measured_output_warning_thresholds[measurement_type][index]
+        allowed_difference = abs(sent) * (threshold_percent / 100.0)
+        difference = abs(measured - sent)
+        if difference <= allowed_difference:
+            self._clear_measured_output_warning(index, measurement_type)
+            return
+
+        violation_started = self.measured_output_warning_since[measurement_type][index]
+        if violation_started is None:
+            self.measured_output_warning_since[measurement_type][index] = now
+            self._set_measured_output_warning_box(index, measurement_type, False)
+            return
+
+        self._set_measured_output_warning_box(
+            index,
+            measurement_type,
+            (now - violation_started) > self.MEASURED_OUTPUT_WARNING_SECONDS,
+        )
+
+    def _update_measured_output_warning_indicators(self, index, voltage, current, mode):
+        if not (0 <= index < 3):
+            return
+
+        output_enabled = bool(self.toggle_states[index])
+        active_voltage = output_enabled and mode == "CV Mode"
+        active_current = output_enabled and mode == "CC Mode"
+        now = time.monotonic()
+
+        self._update_single_measured_output_warning(
+            index,
+            "voltage",
+            self.sent_heater_voltage_values[index],
+            voltage,
+            active_voltage,
+            now,
+        )
+        self._update_single_measured_output_warning(
+            index,
+            "current",
+            self.sent_heater_current_values[index],
+            current,
+            active_current,
+            now,
+        )
 
     def toggle_ramp(self, index):
         """
@@ -2755,6 +3026,8 @@ class CathodeHeatingSubsystem:
             else:
                 self.log(f"Failed to disable output for Cathode {['A', 'B', 'C'][index]}", LogLevel.ERROR)
             self.on_ramp_complete(index)
+            self._clear_measured_output_warning(index, "voltage")
+            self._clear_measured_output_warning(index, "current")
 
         # Update the toggle state and button image
         self.toggle_states[index] = new_state
@@ -2796,6 +3069,8 @@ class CathodeHeatingSubsystem:
                     # Update toggle state and button image
                     self.toggle_states[i] = False
                     self.toggle_buttons[i].config(image=self.toggle_off_image)
+                    self._clear_measured_output_warning(i, "voltage")
+                    self._clear_measured_output_warning(i, "current")
                 else:
                     self.log(f"Failed to turn off heater for Cathode {cathode_label}", LogLevel.ERROR)
             except Exception as e:
@@ -3135,8 +3410,10 @@ class CathodeHeatingSubsystem:
                 self.user_set_currents[index] = None
                 self.current_set[index] = False
                 self.heater_current_vars[index].set('--')
+                self.sent_heater_current_values[index] = None
                 self.sent_heater_current_vars[index].set('--')
                 self.predicted_heater_current_vars[index].set('--')
+                self._clear_measured_output_warning(index, "current")
                 self.log(f"Cleared current goal for Cathode {['A', 'B', 'C'][index]}", LogLevel.INFO)
                 self.refresh_predictions(index)
                 return
@@ -3187,8 +3464,10 @@ class CathodeHeatingSubsystem:
                 self.user_set_voltages[index] = None
                 self.voltage_set[index] = False
                 self.heater_voltage_vars[index].set('--')
+                self.sent_heater_voltage_values[index] = None
                 self.sent_heater_voltage_vars[index].set('--')
                 self.predicted_heater_voltage_vars[index].set('--')
+                self._clear_measured_output_warning(index, "voltage")
                 self.log(f"Cleared voltage goal for Cathode {['A', 'B', 'C'][index]}", LogLevel.INFO)
                 self.refresh_predictions(index)
                 return
@@ -3914,11 +4193,23 @@ class CathodeHeatingSubsystem:
 
     def _update_sent_current_display(self, index: int, sent_current: float):
         if index < len(self.sent_heater_current_vars):
-            self.sent_heater_current_vars[index].set(f"{sent_current:.2f}")
+            try:
+                self.sent_heater_current_values[index] = float(sent_current)
+                self.sent_heater_current_vars[index].set(f"{float(sent_current):.2f}")
+            except (TypeError, ValueError):
+                self.sent_heater_current_values[index] = None
+                self.sent_heater_current_vars[index].set('--')
+            self._clear_measured_output_warning(index, "current")
 
     def _update_sent_voltage_display(self, index: int, sent_voltage: float):
         if index < len(self.sent_heater_voltage_vars):
-            self.sent_heater_voltage_vars[index].set(f"{sent_voltage:.2f}")
+            try:
+                self.sent_heater_voltage_values[index] = float(sent_voltage)
+                self.sent_heater_voltage_vars[index].set(f"{float(sent_voltage):.2f}")
+            except (TypeError, ValueError):
+                self.sent_heater_voltage_values[index] = None
+                self.sent_heater_voltage_vars[index].set('--')
+            self._clear_measured_output_warning(index, "voltage")
 
     def is_ramping(self, index:int) -> bool:
         ps = self.power_supplies[index] if index < len(self.power_supplies) else None

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -251,6 +251,7 @@ class CathodeHeatingSubsystem:
         self.actual_heater_current_frames = []
         self.actual_heater_voltage_box_widgets = []
         self.actual_heater_current_box_widgets = []
+        self.actual_heater_temperature_box_widgets = []
         self.power_supply_comms_indicators = []
         self.temperature_comms_indicators = []
 
@@ -433,7 +434,6 @@ class CathodeHeatingSubsystem:
         style.configure('Subpanel.TLabelframe.Label', font=('Segoe UI', 8, 'bold'))
         style.configure('RightAlign.TLabel', font=('Segoe UI', 8), anchor='e')
         style.configure('Small.TLabel', font=('Segoe UI', 8))
-        style.configure('OverTemp.TLabel', foreground='red', font=('Segoe UI', 8, 'bold'))  # Overtemperature style
         style.configure('RampOn.TButton', background='green', foreground='black', font=('Segoe UI', 8, 'bold'), padding=(2, 0))
         style.configure('RampOff.TButton', background='red', foreground='black', font=('Segoe UI', 8, 'bold'), padding=(2, 0)) # Ramp button style
         style.configure('StopInactive.TButton', foreground='grey', font=('Segoe UI', 8), padding=(2, 0))
@@ -873,12 +873,22 @@ class CathodeHeatingSubsystem:
             # Temp
             ttk.Label(measured_frame, text='Temp', style='RightAlign.TLabel').grid(row=0, column=2, sticky='w', padx=(0, 2))
             actual_temp_frame = tk.Frame(measured_frame, bd=1, relief='groove', padx=1, pady=0)
-            actual_temp_frame.configure(bg='#d9d9d9')
+            actual_temp_frame.configure(bg=self.MEASURED_OUTPUT_NORMAL_BG)
             actual_temp_frame.grid(row=0, column=3, sticky='w')
-            actual_temp_label = ttk.Label(actual_temp_frame, textvariable=self.clamp_temperature_vars[i], style='Bold.TLabel') 
+            actual_temp_label = tk.Label(
+                actual_temp_frame,
+                textvariable=self.clamp_temperature_vars[i],
+                bg=self.MEASURED_OUTPUT_NORMAL_BG,
+                fg=self.MEASURED_OUTPUT_NORMAL_FG,
+                font=('Segoe UI', 8, 'bold'),
+            )
             actual_temp_label.pack(side='left')
 
             self.clamp_temp_labels.append(actual_temp_label)
+            self.actual_heater_temperature_box_widgets.append([
+                actual_temp_frame,
+                actual_temp_label,
+            ])
 
             # CV / CC mode indicator
             indicator_frame = ttk.Frame(measured_frame)
@@ -2613,18 +2623,18 @@ class CathodeHeatingSubsystem:
             else:
                 self.operation_mode_var[i].set('Mode: --')
 
-            # Overtemperature check and update label style
+            # Overtemperature check and update warning highlight
             if temperature is not None:
                 if temperature > self.overtemp_limit_vars[i].get():
                     self.overtemp_status_vars[i].set("OVERTEMP!")
                     self.log(f"Cathode {['A', 'B', 'C'][i]} OVERTEMP!", LogLevel.CRITICAL)
-                    self.clamp_temp_labels[i].config(style='OverTemp.TLabel')  # Change to red style
+                    self._set_measured_temperature_warning_box(i, True)
                 else:
                     self.overtemp_status_vars[i].set('Normal')
-                    self.clamp_temp_labels[i].config(style='Bold.TLabel')  # Revert to normal style
+                    self._set_measured_temperature_warning_box(i, False)
             else:
                 self.overtemp_status_vars[i].set('N/A')
-                self.clamp_temp_labels[i].config(style='Bold.TLabel')
+                self._set_measured_temperature_warning_box(i, False)
 
             # Update the plot for current cathode
             if plot_this_cycle:  # Ensure plots are updated only when new data is plotted
@@ -2747,6 +2757,19 @@ class CathodeHeatingSubsystem:
         for widget in box_widgets[index][1:]:
             widget.configure(fg=self.MEASURED_OUTPUT_NORMAL_FG)
         self.measured_output_warning_active[measurement_type][index] = bool(warning_active)
+
+    def _set_measured_temperature_warning_box(self, index, warning_active):
+        if index >= len(self.actual_heater_temperature_box_widgets):
+            return
+        background_color = (
+            self.MEASURED_OUTPUT_WARNING_BG
+            if warning_active
+            else self.MEASURED_OUTPUT_NORMAL_BG
+        )
+        for widget in self.actual_heater_temperature_box_widgets[index]:
+            widget.configure(bg=background_color)
+        for widget in self.actual_heater_temperature_box_widgets[index][1:]:
+            widget.configure(fg=self.MEASURED_OUTPUT_NORMAL_FG)
 
     def _measured_output_unit(self, measurement_type):
         return "V" if measurement_type == "voltage" else "A"


### PR DESCRIPTION
This PR adds warning highlights around the text of CCS measured voltage, current, and temperature values. This PR also adds settings in the config menu for setting the threshold % that will trigger a warning.

Changes in this PR:
- The Config tab now has per-cathode fields for:
     - Voltage Diff Warning (%)
     - Current Diff Warning (%)
 - On every data update, the code compares live 9104 readback against the last sent value. If the threshold breach remains true for more than 1.5s, the corresponding measured-output box turns orange and a warning is logged. The warning logs once per continuous breach, then logs a clear message once the condition returns to normal.
 - Changed overtemp UI style to match the above voltage/current warning style

Notes about how this works:
- Voltage warnings only run when the supply reports CV Mode.
- Current warnings only run when the supply reports CC Mode.
- During ramps, the sent value updates at each ramp step and the warning timer is cleared each time. So the feature mostly warns after the commanded value has stopped changing or if a mismatch persists long enough between updates.
- If the sent value is 0, invalid, missing, NaN, or infinite, no warning is generated.
- A threshold of 0% is allowed; that means any nonzero difference can warn after the delay.
- Changing a threshold clears any active warning for that measurement type.
- Turning output off, clearing a goal, losing readback, or marking the supply unavailable clears the warning highlight.

Merge Note: This branch is based off of PR #192. That branch should be reviewed and merged before this one is. 