### PR TITLE
Bugfix: CCS toggle output button state on unknown output state

### DIFF
--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -190,6 +190,25 @@ When the output toggle is switched on, `toggle_output()` also verifies:
 
 If any of those checks fail, output is not enabled.
 
+### Output Disable And Uncertain State
+
+Cathode Heating treats `PowerSupply9104.disable_output()` success as the point at
+which the dashboard may show a cathode output as off. `disable_output()` sends
+`SOUT0` without preset-voltage or OVP validation and returns true only when the
+9104 command response contains `OK`. It does not perform a separate `GOUT`
+readback.
+
+If `disable_output()` fails, the hardware output state is uncertain. This can
+happen if the serial lock cannot be acquired, the COM port is closed or
+disconnected, the 9104 does not respond, the response does not contain `OK`, or
+serial I/O raises an exception.
+
+When output disable cannot be confirmed, the dashboard logs a critical message
+and keeps the affected cathode output toggle showing ON. For ramp-start failures
+after `set_output("1")` has already succeeded, a failed cleanup disable also
+sets the toggle to ON, because the output may already be energized. The dashboard
+only changes the toggle to OFF after a successful disable acknowledgement.
+
 ## BCON Disconnect Guard
 
 Main Control gives Cathode Heating:

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2571,6 +2571,17 @@ class CathodeHeatingSubsystem:
             self.ramp_toggle_buttons[index].config(text="RAMP OFF", style='RampOff.TButton')
             self.log(f"Disabled voltage ramping for Cathode {['A', 'B', 'C'][index]} - voltage changes will be immediate", LogLevel.INFO)
 
+    def _set_output_toggle_state(self, index: int, state: bool):
+        self.toggle_states[index] = bool(state)
+        current_image = self.toggle_on_image if self.toggle_states[index] else self.toggle_off_image
+        self.toggle_buttons[index].config(image=current_image)
+
+    def _log_uncertain_output_state(self, index: int, reason: str):
+        self.log(
+            f"Cathode {['A', 'B', 'C'][index]} output disable failed after {reason}; output state is uncertain.",
+            LogLevel.CRITICAL,
+        )
+
     def toggle_output(self, index, control_mode: str = None):
         if not self.power_supplies_initialized or not self.power_supplies:
             self.log("Power supplies not properly initialized or list is empty.", LogLevel.ERROR)
@@ -2714,7 +2725,9 @@ class CathodeHeatingSubsystem:
                     )
                     if not ramp_started:
                         self.log(f"Failed to start current ramp for Cathode {['A', 'B', 'C'][index]}", LogLevel.ERROR)
-                        self.power_supplies[index].disable_output()
+                        if not self.power_supplies[index].disable_output():
+                            self._set_output_toggle_state(index, True)
+                            self._log_uncertain_output_state(index, "current ramp start failure")
                         return
                     self.on_ramp_start(index)
                 elif target_voltage is not None and control_mode == "voltage":
@@ -2752,7 +2765,9 @@ class CathodeHeatingSubsystem:
                     )
                     if not ramp_started:
                         self.log(f"Failed to start voltage ramp for Cathode {['A', 'B', 'C'][index]}", LogLevel.ERROR)
-                        self.power_supplies[index].disable_output()
+                        if not self.power_supplies[index].disable_output():
+                            self._set_output_toggle_state(index, True)
+                            self._log_uncertain_output_state(index, "voltage ramp start failure")
                         return
                     self.on_ramp_start(index)
             else: # ramp is off; Immediate Set both voltage and current
@@ -2772,13 +2787,13 @@ class CathodeHeatingSubsystem:
             if output_disabled:
                 self.log(f"Disabled output for Cathode {['A', 'B', 'C'][index]}", LogLevel.INFO)
             else:
-                self.log(f"Failed to disable output for Cathode {['A', 'B', 'C'][index]}", LogLevel.ERROR)
+                self._log_uncertain_output_state(index, "manual OFF request")
+                self.on_ramp_complete(index)
+                return
             self.on_ramp_complete(index)
 
         # Update the toggle state and button image
-        self.toggle_states[index] = new_state
-        current_image = self.toggle_on_image if self.toggle_states[index] else self.toggle_off_image
-        self.toggle_buttons[index].config(image=current_image)
+        self._set_output_toggle_state(index, new_state)
 
     def turn_off_all_beams(self):
         """
@@ -3615,9 +3630,10 @@ class CathodeHeatingSubsystem:
                     if not self.power_supplies[index].set_current(3, new_current, sent_callback=sent_current_callback):
                         # Log, disable output, and prevent ramp operation
                         self.log(f"Failed to set current for Cathode {['A', 'B', 'C'][index]} power supply prior to voltage ramp", LogLevel.ERROR)
-                        self.power_supplies[index].disable_output()
-                        self.toggle_states[index] = False
-                        self.toggle_buttons[index].config(image=self.toggle_off_image)
+                        if self.power_supplies[index].disable_output():
+                            self._set_output_toggle_state(index, False)
+                        else:
+                            self._log_uncertain_output_state(index, "current setup failure before voltage ramp")
                         return
 
                     # Ramp Voltage
@@ -3692,9 +3708,10 @@ class CathodeHeatingSubsystem:
                     if not self.power_supplies[index].set_voltage(3, new_voltage, sent_callback=sent_voltage_callback):
                         # Log, disable output, and prevent ramp operation
                         self.log(f"Failed to set voltage for Cathode {['A', 'B', 'C'][index]} power supply prior to current ramp", LogLevel.ERROR)
-                        self.power_supplies[index].disable_output()
-                        self.toggle_states[index] = False
-                        self.toggle_buttons[index].config(image=self.toggle_off_image)
+                        if self.power_supplies[index].disable_output():
+                            self._set_output_toggle_state(index, False)
+                        else:
+                            self._log_uncertain_output_state(index, "voltage setup failure before current ramp")
                         return
 
                     # Ramp Current

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -186,6 +186,10 @@ Dashboard callbacks.
   latest valid VTRX pressure is greater than 1e-5 mbar.
 - BEAMS E-STOP is the Main Control path that combines BCON stop, Cathode Heating
   output shutdown, Beam Pulse disarm, and Main Control UI reset.
+- If Cathode Heating cannot confirm a 9104 output-disable command during
+  E-STOP, BCON-disconnect shutdown, or VTRX-pressure CCS shutdown, it logs a
+  critical message and leaves the affected cathode output toggle showing ON
+  because the hardware output state is uncertain.
 - Disable CCS Output on BCON Disconnect is a runtime Main Control setting. When
   enabled, an unexpected BCON disconnect turns off active CCS outputs, and a
   manual BCON disconnect asks for confirmation before it shuts those outputs


### PR DESCRIPTION
This PR addresses #189. 

Prior to this PR, when disable_output() failed, the UI toggle button would be updated as if it had succeeded. This PR now changes unknown output states to display output=ON for CCS. Anytime an unknown output state occurs from a failed disable_output(), a CRITICAL message is logged in the UI log to inform the user, an the toggle button remains (or is set to) ON until a disable message from the 9104 is confirmed. 