### PR TITLE
Bugfix: Laser Monitor Updates

### DIFF
--- a/citestfiles/beam_energy_warning_limits_test.py
+++ b/citestfiles/beam_energy_warning_limits_test.py
@@ -83,6 +83,7 @@ def make_beam_energy():
     beam_energy.latest_actual_current_values = [None for _ in SUPPLY_KEYS]
     beam_energy.ui_elements = [None for _ in SUPPLY_KEYS]
     beam_energy.radiation_indicator_callback = lambda _active: None
+    beam_energy._radiation_indicator_last_valid_state = None
     beam_energy._radiation_indicator_sent = None
     beam_energy._radiation_indicator_missing_callback_state = None
     beam_energy.beams_estop_callback = None
@@ -183,6 +184,73 @@ class BeamEnergyWarningLimitSetterTest(unittest.TestCase):
                     beam_energy.warning_limits[POS20KV_SUPPLY_KEY]["max_current_ma"],
                     max_current,
                 )
+
+
+class BeamEnergyRadiationIndicatorTest(unittest.TestCase):
+    def test_initial_missing_pos20kv_readback_does_not_send_indicator_state(self):
+        beam_energy = make_beam_energy()
+        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
+        sent_states = []
+        beam_energy.radiation_indicator_callback = sent_states.append
+
+        beam_energy.apply_warning_indicators(pos20kv_index, None, None)
+
+        self.assertEqual(sent_states, [])
+
+    def test_missing_pos20kv_readback_preserves_asserted_indicator(self):
+        beam_energy = make_beam_energy()
+        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
+        sent_states = []
+        beam_energy.radiation_indicator_callback = sent_states.append
+
+        beam_energy.apply_warning_indicators(pos20kv_index, 12000.0, 0)
+        beam_energy.apply_warning_indicators(pos20kv_index, None, None)
+
+        self.assertEqual(sent_states, [True])
+
+    def test_invalid_pos20kv_readback_preserves_asserted_indicator(self):
+        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
+
+        for invalid_readback in ("bad", float("nan"), float("inf")):
+            with self.subTest(invalid_readback=invalid_readback):
+                beam_energy = make_beam_energy()
+                sent_states = []
+                beam_energy.radiation_indicator_callback = sent_states.append
+
+                beam_energy.apply_warning_indicators(pos20kv_index, 12000.0, 0)
+                beam_energy.apply_warning_indicators(pos20kv_index, invalid_readback, None)
+
+                self.assertEqual(sent_states, [True])
+
+    def test_valid_below_threshold_readback_clears_asserted_indicator(self):
+        beam_energy = make_beam_energy()
+        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
+        sent_states = []
+        beam_energy.radiation_indicator_callback = sent_states.append
+
+        beam_energy.apply_warning_indicators(pos20kv_index, 12000.0, 0)
+        beam_energy.apply_warning_indicators(pos20kv_index, 9000.0, 0)
+
+        self.assertEqual(sent_states, [True, False])
+
+    def test_set_default_values_preserves_asserted_indicator(self):
+        beam_energy = make_beam_energy()
+        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
+        sent_states = []
+        beam_energy.radiation_indicator_callback = sent_states.append
+        beam_energy.set_voltages = [FakeVar() for _ in SUPPLY_KEYS]
+        beam_energy.actual_voltages = [FakeVar() for _ in SUPPLY_KEYS]
+        beam_energy.actual_currents = [FakeVar() for _ in SUPPLY_KEYS]
+        beam_energy.update_connection_status = lambda *_args, **_kwargs: None
+        beam_energy.update_output_status = lambda *_args, **_kwargs: None
+        beam_energy.update_reset_status = lambda *_args, **_kwargs: None
+        beam_energy.update_supply_interlock_status = lambda *_args, **_kwargs: None
+        beam_energy.update_indicators_panel = lambda *_args, **_kwargs: None
+
+        beam_energy.apply_warning_indicators(pos20kv_index, 12000.0, 0)
+        beam_energy.set_default_values(pos20kv_index)
+
+        self.assertEqual(sent_states, [True])
 
 
 class MainControlBeamsEstopLimitUiTest(unittest.TestCase):

--- a/instrumentctl/laser_monitor/README.md
+++ b/instrumentctl/laser_monitor/README.md
@@ -4,9 +4,9 @@ Dashboard-side USB serial driver for the EBEAM Laser Monitor indicator.
 
 This module complements the `ebeam-laser-monitor` Arduino firmware. The
 firmware drives the physical radiation and beams-on indicator outputs; this
-dashboard driver owns the host-side serial connection, periodically verifies
-that the Arduino is alive, and sends state changes from the dashboard
-subsystems.
+dashboard driver owns the host-side serial connection and periodically sends
+the complete desired state from the dashboard subsystems. Each state exchange
+also verifies that the Arduino is alive.
 
 ## System Overview
 
@@ -69,7 +69,26 @@ the connection is treated as unhealthy and the worker reconnects.
 
 ### Poll
 
-Sent every `0.5 s`:
+Sent on initial connection and every `0.5 s` thereafter:
+
+```text
+STATE beams=<0|1> radiation=<0|1>
+```
+
+Expected response:
+
+```text
+OK
+```
+
+Successful polls set `is_connected()` to `True` and refresh both physical
+outputs, even when the desired dashboard values have not changed.
+
+### Diagnostic Ping
+
+The firmware's liveness-only command remains available for diagnostics, but the
+dashboard does not use it as its regular poll because it cannot resynchronize
+indicator outputs:
 
 ```text
 PING
@@ -81,21 +100,7 @@ Expected response:
 PONG
 ```
 
-Successful polls set `is_connected()` to `True`.
-
-### State Update
-
-Sent after reconnect and whenever either desired indicator value changes:
-
-```text
-STATE beams=<0|1> radiation=<0|1>
-```
-
-Expected response:
-
-```text
-OK
-```
+### State Values
 
 Examples:
 
@@ -131,12 +136,14 @@ The worker handles serial failures without blocking dashboard callbacks:
 1. If the port is closed or a transaction fails, mark the driver disconnected.
 2. Close the serial object.
 3. Reconnect with exponential backoff from `0.5 s` up to `5.0 s`.
-4. After a successful reconnect, send the latest desired state again.
+4. After a successful reconnect, resume polling with the latest desired state.
 
 Unexpected responses, missing responses, write failures, and decode issues are
 recorded in `last_error`.
 
 The firmware also has its own dashboard communication watchdog. If it receives
 no valid dashboard message for 4 seconds, it forces only the beams-on output LOW
-and leaves the radiation indicator unchanged. The driver therefore polls every
-500 ms to keep the firmware watchdog satisfied during normal operation.
+and leaves the radiation indicator unchanged. The driver therefore sends the
+complete state every 500 ms. This both keeps the firmware watchdog satisfied
+during normal operation and restores the desired outputs after communication
+resumes without requiring a dashboard state change.

--- a/instrumentctl/laser_monitor/laser_monitor_driver.py
+++ b/instrumentctl/laser_monitor/laser_monitor_driver.py
@@ -66,10 +66,9 @@ class LaserMonitorDriver:
         self._status_lock = threading.Lock()
 
         # Desired output state. These values are updated by public setters and
-        # sent by the worker thread after a successful communication poll.
+        # sent by the worker thread on every communication poll.
         self._beams_on = False
         self._radiation_indicator = False
-        self._last_sent_state = None
 
         # Status state. These values are intentionally separate from desired
         # output state so callers can distinguish "what should be displayed"
@@ -113,7 +112,6 @@ class LaserMonitorDriver:
             try:
                 command = self._build_state_command(*state)
                 self._write_line_expect(command, STATE_OK_RESPONSE)
-                self._last_sent_state = state
             except Exception as exc:
                 self._record_error(exc)
 
@@ -141,8 +139,9 @@ class LaserMonitorDriver:
     def _worker_loop(self) -> None:
         # Main lifecycle loop:
         # 1. Connect/reconnect if needed.
-        # 2. Poll Arduino with PING/PONG every 500 ms.
-        # 3. Send STATE after reconnect or when desired state changes.
+        # 2. Poll Arduino with the complete desired state every 500 ms.
+        # A successful OK response both confirms link health and resynchronizes
+        # outputs if the firmware watchdog changed them during a quiet period.
         reconnect_backoff = RECONNECT_BACKOFF_INITIAL_SECONDS
         next_reconnect_time = 0.0
 
@@ -167,13 +166,9 @@ class LaserMonitorDriver:
 
                     reconnect_backoff = RECONNECT_BACKOFF_INITIAL_SECONDS
                     next_reconnect_time = 0.0
-                    self._last_sent_state = None
 
-                self._send_ping()
+                self._send_state()
                 self._set_connected(True)
-
-                if self._state_needs_send():
-                    self._send_state()
 
                 self._sleep_or_stop(POLL_INTERVAL_SECONDS)
 
@@ -238,7 +233,6 @@ class LaserMonitorDriver:
         state = self._get_state()
         command = self._build_state_command(*state)
         self._write_line_expect(command, STATE_OK_RESPONSE)
-        self._last_sent_state = state
 
     def _write_line_expect(self, command: str, expected_response: str) -> None:
         # Serial transactions are intentionally request/response. A missing or
@@ -259,9 +253,6 @@ class LaserMonitorDriver:
             raise LaserMonitorProtocolError(
                 f"Expected {expected_response!r}, received {response!r}"
             )
-
-    def _state_needs_send(self) -> bool:
-        return self._last_sent_state != self._get_state()
 
     def _get_state(self):
         with self._state_lock:

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -141,6 +141,8 @@ class BeamEnergySubsystem:
         # Dashboard wires this to LaserMonitorDriver.set_radiation_indicator().
         # The last-sent value prevents repeated sends during unchanged 500 ms polls.
         self.radiation_indicator_callback = None
+        # Last valid readback-derived state; missing/invalid readbacks preserve it.
+        self._radiation_indicator_last_valid_state = None
         self._radiation_indicator_sent = None
         self._radiation_indicator_missing_callback_state = None
         self.warning_limit_entry_vars = [
@@ -585,13 +587,15 @@ class BeamEnergySubsystem:
             return False
 
     def _update_radiation_indicator(self, voltage):
-        # Missing/invalid +20kV readback clears the indicator; valid readings
-        # at or above the threshold assert it.
         voltage = self._coerce_reading(voltage)
-        active = (
-            voltage is not None
-            and voltage >= self.RADIATION_INDICATOR_THRESHOLD_V
-        )
+        if voltage is None:
+            active = getattr(self, "_radiation_indicator_last_valid_state", None)
+            if active is None:
+                return
+        else:
+            active = voltage >= self.RADIATION_INDICATOR_THRESHOLD_V
+            self._radiation_indicator_last_valid_state = active
+
         if active == getattr(self, "_radiation_indicator_sent", None):
             return
 


### PR DESCRIPTION
This PR addresses laser-monitor related issues found in #187 and #203

Summary of Changes in this PR:
- Laser monitor driver now sends `STATE beams=<0|1> radiation=<0|1>` on every 500 ms poll instead of using `PING` for regular liveness checks.
- Removed `_last_sent_state` / `_state_needs_send` logic, so the Arduino is continuously resynchronized even when dashboard state has not changed.
- Laser monitor README was updated to document `STATE` as the normal poll, `PING` as diagnostic-only, and the watchdog/resync behavior.
- Beam energy radiation indicator now preserves the last valid +20kV-derived state when the readback is missing, invalid, NaN, or infinite.
- Initial missing/invalid +20kV readback sends no radiation indicator update instead of forcing a clear.
- Tests were added in `citestfiles/beam_energy_warning_limits_test.py` covering missing/invalid +20kV readbacks, valid clear behavior, and `set_default_values()` preserving the asserted indicator.