### PR TITLE
Avoid static PyInstaller splash import warning

### DIFF
--- a/EBEAM_DASHBOARD.spec
+++ b/EBEAM_DASHBOARD.spec
@@ -7,7 +7,8 @@ a = Analysis(
     binaries=[],
     datas=[
         ('scripts', './scripts'),
-        ('media', './media')
+        ('media', './media'),
+        ('data', './data'),
     ],
     hiddenimports=['pyi_splash'],
     hookspath=[],

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import importlib
 import tkinter as tk
 from tkinter import ttk, messagebox
 import serial.tools.list_ports
@@ -253,8 +254,8 @@ def config_com_ports(saved_com_ports, logger=None):
     # Close the PyInstaller splash if running as bundled executable
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
         try:
-            import pyi_splash
-            pyi_splash.close()
+            splash = importlib.import_module("pyi_splash")
+            getattr(splash, "close")()
         except ImportError:
             pass
     


### PR DESCRIPTION
**Description**

main.py always has a warning and a red squiggle in main.py prior to this.

This PR replaces the direct `pyi_splash` import with a dynamic import inside the existing PyInstaller-only startup path.

`pyi_splash` is injected by PyInstaller at bundled runtime, so VS Code/Pylance flags it as an unresolved import in the normal development environment even though the bundled app path is valid. Using `importlib.import_module("pyi_splash")` keeps the behavior local to the splash-close block while avoiding the editor diagnostic.

Verification:

```powershell
.\.venv\Scripts\python.exe -m py_compile main.py
```