### PR TITLE
Bugfix: Abort BCON disconnect on failed CCS Shutoff

### DIFF
--- a/citestfiles/CathodeHeating/beams_off_test.py
+++ b/citestfiles/CathodeHeating/beams_off_test.py
@@ -25,7 +25,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supplies_initialized = True
         self.subsys.power_supplies = [self.make_power_supply(), None, self.make_power_supply()]
         self.subsys.power_supply_status = [True, False, True]
-        self.subsys.toggle_states = [True, True, True]
+        self.subsys.toggle_states = [True, False, True]
         self.subsys.toggle_off_image = object()
         self.subsys.toggle_buttons = [MagicMock(), MagicMock(), MagicMock()]
         # Simple logger hook
@@ -36,7 +36,7 @@ class TestBeamsOff(unittest.TestCase):
         self.turn_off_all_beams = self.subsys.turn_off_all_beams
 
     def test_turns_off_available_ps_handles_and_updates_ui_on_success(self):
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         self.subsys.power_supplies[0].disable_output.assert_called_once_with()
         self.subsys.power_supplies[2].disable_output.assert_called_once_with()
@@ -53,7 +53,7 @@ class TestBeamsOff(unittest.TestCase):
         # Simulate failure on index 0, success on index 2
         self.subsys.power_supplies[0].disable_output.return_value = False
 
-        self.turn_off_all_beams()
+        self.assertFalse(self.turn_off_all_beams())
 
         # UI should not change for failed OFF
         self.assertTrue(self.subsys.toggle_states[0])
@@ -67,7 +67,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supplies[0].disable_output.side_effect = RuntimeError("boom")
 
         # Should not raise
-        self.turn_off_all_beams()
+        self.assertFalse(self.turn_off_all_beams())
 
         self.subsys.power_supplies[2].disable_output.assert_called_once_with()
         self.assertFalse(self.subsys.toggle_states[2])
@@ -83,7 +83,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supply_status = [False, False, False]
 
         # Act
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         # Assert: E-stop path still tries every existing handle
         for ps in self.subsys.power_supplies:
@@ -93,7 +93,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supplies = []
         self.subsys.power_supplies_initialized = False
 
-        self.turn_off_all_beams()
+        self.assertFalse(self.turn_off_all_beams())
 
         for btn in self.subsys.toggle_buttons:
             btn.config.assert_not_called()
@@ -108,7 +108,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supply_status = [True, False, True]
 
         # Act
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         # Assert
         self.subsys.power_supplies[1].disable_output.assert_called_once_with()
@@ -116,7 +116,7 @@ class TestBeamsOff(unittest.TestCase):
 
     def test_updates_button_with_correct_image_on_success(self):
         # Act
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         # Assert exact image argument used
         self.subsys.toggle_buttons[0].config.assert_called_once_with(image=self.subsys.toggle_off_image)
@@ -128,7 +128,7 @@ class TestBeamsOff(unittest.TestCase):
         self.subsys.power_supply_status = [True, True, True]
 
         # Act (should not raise)
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         # Assert: others still called, middle skipped
         self.subsys.power_supplies[0].disable_output.assert_called_once_with()
@@ -137,10 +137,15 @@ class TestBeamsOff(unittest.TestCase):
         # Button 1 should not be touched since ps is None
         self.subsys.toggle_buttons[1].config.assert_not_called()
 
+    def test_returns_false_when_active_cathode_has_no_power_supply_handle(self):
+        self.subsys.toggle_states = [False, True, False]
+
+        self.assertFalse(self.turn_off_all_beams())
+
     def test_second_call_is_idempotent_and_keeps_off_state(self):
         # Act: call twice
-        self.turn_off_all_beams()
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
+        self.assertTrue(self.turn_off_all_beams())
 
         # Assert: disable_output called twice for available handles
         self.assertEqual(self.subsys.power_supplies[0].disable_output.call_count, 2)
@@ -156,7 +161,7 @@ class TestBeamsOff(unittest.TestCase):
             self.make_power_supply(has_disable=False),
         ]
 
-        self.turn_off_all_beams()
+        self.assertTrue(self.turn_off_all_beams())
 
         self.subsys.power_supplies[0].set_output.assert_called_once_with("0")
         self.subsys.power_supplies[2].set_output.assert_called_once_with("0")

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -2797,18 +2797,23 @@ class CathodeHeatingSubsystem:
             - Disables output on all available power supply handles
             - Updates toggle button states and images
             - Logs actions and any errors
+        Returns:
+            True when every required output-off command is acknowledged; False otherwise.
         """
         if not self.power_supplies:
             self.log("Power supply list is empty; cannot turn off heaters.", LogLevel.ERROR)
-            return
+            return False
 
         if not self.power_supplies_initialized:
             self.log("Power supplies are not marked initialized; attempting OFF for any available handles.", LogLevel.WARNING)
 
+        all_off = True
         for i, ps in enumerate(self.power_supplies):
             cathode_label = ['A', 'B', 'C'][i]
             if not ps:
                 self.log(f"Power supply handle for Cathode {cathode_label} is unavailable; cannot turn off heater.", LogLevel.WARNING)
+                if i < len(self.toggle_states) and self.toggle_states[i]:
+                    all_off = False
                 continue
 
             try:
@@ -2826,9 +2831,12 @@ class CathodeHeatingSubsystem:
                     self.toggle_states[i] = False
                     self.toggle_buttons[i].config(image=self.toggle_off_image)
                 else:
+                    all_off = False
                     self.log(f"Failed to turn off heater for Cathode {cathode_label}", LogLevel.ERROR)
             except Exception as e:
+                all_off = False
                 self.log(f"Error turning off heater for Cathode {cathode_label}: {str(e)}", LogLevel.ERROR)
+        return all_off
 
     def reset_related_variables(self, index):
         """

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -1408,8 +1408,13 @@ class MainControlPanel:
                 return False
             turn_off = getattr(cathode, "turn_off_all_beams", None)
             if callable(turn_off):
-                self.logger.warning("BCON manual disconnect requested; disabling CCS output")
-                turn_off()
+                self._log_warning("BCON manual disconnect requested; disabling CCS output")
+                if not turn_off():
+                    self._log_error("BCON manual disconnect blocked; CCS output shutdown was not confirmed")
+                    return False
+            elif ccs_output_active:
+                self._log_error("BCON manual disconnect blocked; Cathode Heating turn_off_all_beams API is unavailable")
+                return False
         return True
 
     def _handle_bcon_disconnected(self):


### PR DESCRIPTION
This PR addresses Issue #198 

Changes:
- cathode_heating.py (line 2791): turn_off_all_beams() now returns True only when all required beam-off commands succeed, and False on empty supply list, failed disable calls, exceptions, or an active cathode missing a power supply handle.
- main_control.py (line 1402): manual BCON disconnect is now blocked if CCS shutdown is not confirmed successful.
- beams_off_test.py (line 25): tests were updated to assert the new boolean return value and add coverage for the missing-power-supply-handle failure case.