### PR TITLE
Bugfix: E5CN Thread Closing Error Reporting

### DIFF
--- a/citestfiles/E5CNModbus/E5CNModbus_test.py
+++ b/citestfiles/E5CNModbus/E5CNModbus_test.py
@@ -113,6 +113,7 @@ class TestE5CNModbus(unittest.TestCase):
         
         with patch('threading.Thread') as mock_thread:
             mock_thread_instance = MagicMock()
+            mock_thread_instance.is_alive.return_value = False
             mock_thread.return_value = mock_thread_instance
 
             # start reading
@@ -124,7 +125,39 @@ class TestE5CNModbus(unittest.TestCase):
             mock_thread_instance.start.assert_called()
 
             # stop reading
-            self.device.stop_reading()
+            self.device.disconnect = MagicMock(return_value=True)
+            self.assertTrue(self.device.stop_reading())
+            self.assertEqual(self.device.threads, [])
+
+    def test_stop_reading_returns_false_when_thread_stays_alive(self):
+        """A live reader thread makes shutdown unsafe even if disconnect succeeds."""
+        live_thread = MagicMock()
+        live_thread.name = "TempReader-Unit1"
+        live_thread.is_alive.return_value = True
+        self.device.threads = [live_thread]
+        self.device.disconnect = MagicMock(return_value=True)
+
+        result = self.device.stop_reading()
+
+        self.assertFalse(result)
+        live_thread.join.assert_called_once_with(timeout=self.device.THREAD_JOIN_TIMEOUT)
+        self.device.disconnect.assert_called_once()
+        self.assertEqual(self.device.threads, [live_thread])
+
+    def test_stop_reading_clears_stopped_threads(self):
+        """Stopped reader threads are removed after a clean shutdown."""
+        stopped_thread = MagicMock()
+        stopped_thread.name = "TempReader-Unit1"
+        stopped_thread.is_alive.return_value = False
+        self.device.threads = [stopped_thread]
+        self.device.disconnect = MagicMock(return_value=True)
+
+        result = self.device.stop_reading()
+
+        self.assertTrue(result)
+        stopped_thread.join.assert_called_once_with(timeout=self.device.THREAD_JOIN_TIMEOUT)
+        self.device.disconnect.assert_called_once()
+        self.assertEqual(self.device.threads, [])
 
     def test_error_handling(self):
         """Test error handling during temperature reading"""

--- a/citestfiles/E5CNModbus/E5CNModbus_test.py
+++ b/citestfiles/E5CNModbus/E5CNModbus_test.py
@@ -140,9 +140,32 @@ class TestE5CNModbus(unittest.TestCase):
         result = self.device.stop_reading()
 
         self.assertFalse(result)
-        live_thread.join.assert_called_once_with(timeout=self.device.THREAD_JOIN_TIMEOUT)
+        self.assertEqual(live_thread.join.call_count, 2)
+        live_thread.join.assert_called_with(timeout=self.device.THREAD_JOIN_TIMEOUT)
         self.device.disconnect.assert_called_once()
         self.assertEqual(self.device.threads, [live_thread])
+
+    def test_stop_reading_returns_true_when_disconnect_unblocks_thread(self):
+        """A reader unblocked by disconnect is cleared before reporting success."""
+        blocked_thread = MagicMock()
+        blocked_thread.name = "TempReader-Unit1"
+        disconnected = {"value": False}
+        blocked_thread.is_alive.side_effect = lambda: not disconnected["value"]
+
+        def disconnect():
+            disconnected["value"] = True
+            return True
+
+        self.device.threads = [blocked_thread]
+        self.device.disconnect = MagicMock(side_effect=disconnect)
+
+        result = self.device.stop_reading()
+
+        self.assertTrue(result)
+        self.assertEqual(blocked_thread.join.call_count, 2)
+        blocked_thread.join.assert_called_with(timeout=self.device.THREAD_JOIN_TIMEOUT)
+        self.device.disconnect.assert_called_once()
+        self.assertEqual(self.device.threads, [])
 
     def test_stop_reading_clears_stopped_threads(self):
         """Stopped reader threads are removed after a clean shutdown."""

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -174,18 +174,24 @@ class E5CNModbus:
         self.stop_event.set()
         self.connected = False
         
+        threads_stopped = True
+        remaining_threads = []
+
         # Wait for threads to finish
-        for thread in self.threads:
+        for thread in list(self.threads):
             thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
             if thread.is_alive():
+                threads_stopped = False
+                remaining_threads.append(thread)
                 self.log(f"Thread {thread.name} did not stop before timeout", LogLevel.WARNING)
             else:
                 self.log(f"Thread {thread.name} stopped", LogLevel.DEBUG)
             
-        self.threads.clear()
+        self.threads = remaining_threads
         
         try:
-            return self.disconnect()
+            disconnected = self.disconnect()
+            return threads_stopped and disconnected
         finally:
             self.is_initialized.clear()
             self.flush_queued_logs()

--- a/instrumentctl/E5CN_modbus/E5CN_modbus.py
+++ b/instrumentctl/E5CN_modbus/E5CN_modbus.py
@@ -174,14 +174,12 @@ class E5CNModbus:
         self.stop_event.set()
         self.connected = False
         
-        threads_stopped = True
         remaining_threads = []
 
         # Wait for threads to finish
         for thread in list(self.threads):
             thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
             if thread.is_alive():
-                threads_stopped = False
                 remaining_threads.append(thread)
                 self.log(f"Thread {thread.name} did not stop before timeout", LogLevel.WARNING)
             else:
@@ -191,7 +189,18 @@ class E5CNModbus:
         
         try:
             disconnected = self.disconnect()
-            return threads_stopped and disconnected
+
+            if self.threads:
+                remaining_threads = []
+                for thread in self.threads:
+                    thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
+                    if thread.is_alive():
+                        remaining_threads.append(thread)
+                    else:
+                        self.log(f"Thread {thread.name} stopped after disconnect", LogLevel.DEBUG)
+                self.threads = remaining_threads
+
+            return not self.threads and disconnected
         finally:
             self.is_initialized.clear()
             self.flush_queued_logs()


### PR DESCRIPTION
This PR addresses issue #197. 

Changes in this PR:
- Updated `E5CNModbus.stop_reading()` to return `False` if any temperature-reader thread remains alive after join timeout.
- Preserved still-alive thread references in `self.threads` so later cleanup attempts can detect them.
- Continued calling `disconnect()` as best effort even after a thread fails to stop.
- Added focused E5CN regression tests for stuck-thread and clean-shutdown behavior.