### PR TITLE
Bugfix: Directly map heater current to beam current within LUT domain

### DIFF
--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -303,6 +303,8 @@ Manual setpoint handlers now actively update predictions before applying output 
 
 Those handlers call either `update_predictions_from_current()` or `update_predictions_from_voltage()` after validation. LUT selector changes call `refresh_predictions()`, which recomputes predictions from the currently requested setpoint when one exists.
 
+Within the selected LUT, beam-current interpolation follows the binding heater constraint. Current-limited operation maps heater current directly to beam current. Voltage-limited operation retains the voltage-to-beam-current mapping and uses voltage to resolve heater current. This avoids converting a current-limited request through the potentially non-monotonic heater current-to-voltage relationship before predicting beam current. Above the applicable LUT domain, both modes continue to use the dataset-calibrated ES440 temperature and Richardson-Dushman fallback.
+
 The prediction path is still display-side guidance for Cathode Heating output behavior. Output behavior is still governed by validation, output state, and the selected immediate/ramp mode.
 
 Predicted emission current is also published to Beam Pulse for its output-start guard. Unknown or unavailable emission predictions are stored and returned as `None`, while a real predicted `0.0 mA` remains numeric. The UI displays unknown predictions as `--`, and Beam Pulse blocks projected beam-output starts when the emission-current limit is enabled and a projected cathode has an unknown or invalid emission prediction.

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -3496,7 +3496,9 @@ class CathodeHeatingSubsystem:
                 )
                 return False
 
-            # Predict beam current from the new voltage; may be reworked to use current for greater accuracy
+            # Predict beam current from whichever heater constraint is binding.
+            # Current control uses heater_current->beam_current directly; voltage
+            # control retains the voltage-keyed LUT path.
             _,_, pred_beam_current = self.emission_cur_vlt_converter(
                 index,
                 pred_heater_voltage,
@@ -3595,7 +3597,9 @@ class CathodeHeatingSubsystem:
                 )
                 return False
 
-            # Predict beam current from the new voltage; may be reworked to use current for greater accuracy
+            # Predict beam current from whichever heater constraint is binding.
+            # Current control uses heater_current->beam_current directly; voltage
+            # control retains the voltage-keyed LUT path.
             _,_, pred_beam_current = self.emission_cur_vlt_converter(
                 index,
                 pred_heater_voltage,
@@ -3671,16 +3675,18 @@ class CathodeHeatingSubsystem:
         controlling_mode=None,
     ):
         """
-        Convert between voltage and current using the DataFrame lookup.
+        Resolve heater and beam values from the selected LUT or physics fallback.
 
-        LUT data is treated as a function for voltage->(heater current, beam current)
-        lookups. For a given voltage, there must be exactly one output pair.
-        Above the LUT voltage/current domain, beam current falls back to a
+        In-range beam-current lookup follows the binding heater constraint:
+        current control uses heater_current->beam_current directly, while voltage
+        control uses voltage->beam_current and voltage->heater_current. Duplicate
+        input coordinates are collapsed to their median by the shared interpolation
+        helper. Above the applicable LUT domain, beam current falls back to a
         Richardson-Dushman estimate based on the ES440 temperature model.
 
         Args:
             index (int): Index of the cathode (0-2)
-            val (float): Input value (voltage or current)
+            val (float): Resolved physical heater voltage.
             target_heater_current (float | None): Resolved heater current from
                 the active setpoint path. Used by the above-LUT Richardson
                 fallback because temperature is estimated from heater current.
@@ -3695,15 +3701,26 @@ class CathodeHeatingSubsystem:
             above_voltage_lut = self._is_above_lut_domain(index, val, "voltage", "beam_current")
             above_current_lut = (
                 target_heater_current is not None
-                and self._is_above_lut_domain(index, target_heater_current, "heater_current", "voltage")
+                and self._is_above_lut_domain(index, target_heater_current, "heater_current", "beam_current")
             )
+            if controlling_mode == "current" and target_heater_current is not None:
+                outside_lut = above_current_lut
+            elif controlling_mode == "voltage":
+                outside_lut = above_voltage_lut
+            else:
+                # Preserve voltage-keyed compatibility for callers that have not
+                # identified which physical constraint is binding.
+                outside_lut = above_voltage_lut
+
             reason_parts = []
-            if above_voltage_lut:
+            if outside_lut and controlling_mode == "voltage":
                 reason_parts.append("heater voltage above LUT")
-            if above_current_lut:
+            elif outside_lut and controlling_mode == "current":
                 reason_parts.append("heater current above LUT")
+            elif outside_lut:
+                reason_parts.append("heater voltage above LUT")
             reason = " and ".join(reason_parts) if reason_parts else "outside LUT"
-            if above_voltage_lut or above_current_lut:
+            if outside_lut:
                 fallback = self._richardson_fallback_beam_current_ma(
                     index,
                     val,
@@ -3718,8 +3735,17 @@ class CathodeHeatingSubsystem:
                         float(fallback["beam_current_ma"]),
                     )
 
-            heater_current = self._interpolate_lut_value(index, val, "voltage", "heater_current")
-            beam_current = self._interpolate_lut_value(index, val, "voltage", "beam_current")
+            if controlling_mode == "current" and target_heater_current is not None:
+                heater_current = float(target_heater_current)
+                beam_current = self._interpolate_lut_value(
+                    index,
+                    heater_current,
+                    "heater_current",
+                    "beam_current",
+                )
+            else:
+                heater_current = self._interpolate_lut_value(index, val, "voltage", "heater_current")
+                beam_current = self._interpolate_lut_value(index, val, "voltage", "beam_current")
             if heater_current is None or beam_current is None:
                 fallback = self._richardson_fallback_beam_current_ma(
                     index,


### PR DESCRIPTION
Resolves issue #202 

Updated LUT functionality to directly map heater current or voltage to beam current depending on which variable is predicted to be the controlling value. Implemented after the Richardson-Dushman fallback so predictions above the LUT domain remain intact. 

When reviewing the LUT documentation it was noted that the LUT is explicitly cleaned into a voltage-keyed function taking only the maximum heater current for each heater voltage 'bin'. This could reduce the overall accuracy of the dataset, particularly when predicting using heater current.

https://github.com/uw-loci/EBEAM_dashboard/blob/a0a06e2fc8347c0c6c1d66a86cdc42082057e428/data/lut/README.md?plain=1#L25-L33

Direct mapping from heater current to beam current would still likely be preferable to avoid multiple interpolations for the same prediction, however for improved accuracy it is worth revisiting how we clean our LUT data. 