### PR TITLE
Correct 972B Relay 1 state label

### DIFF
--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -311,7 +311,7 @@ class VTRXSubsystem:
             "Pumps Power ON", 
             "Turbo Rotor ON", 
             "Turbo Vent OPEN",
-            "972b Power ON", 
+            "972B Relay 1 ON",
             "Turbo Gate CLOSED",
             "Turbo Gate OPEN", 
             "Argon Gate OPEN", 
@@ -572,4 +572,3 @@ class VTRXSubsystem:
             self.log(f"Closed serial port {self.serial_port}", LogLevel.INFO)
         else:
             self.log(f"{self.serial_port} port already closed", LogLevel.INFO)
-          


### PR DESCRIPTION
## Summary

- Renames the VTRX bit 4 dashboard indicator from `972b Power ON` to `972B Relay 1 ON`.
- Preserves the existing Turbo and Argon gate indicator mappings.
- Leaves the serial packet, bit positions, parsing, `vacuumBits` logging, and documentation unchanged.

## Why

The signal carried in VTRX switch-state bit 4 is the state of the 972B pressure gauge's Relay 1 normally-open contact. It is not direct confirmation that the 972B is powered. The previous dashboard label could therefore mislead operators and developers into interpreting the signal as gauge power feedback.

The firmware continues to send the signal in the same bit position, so this correction only changes the operator-facing label.

Related firmware context: https://github.com/uw-loci/VTRX_firmware/pull/4

## Validation

- Confirmed the one-hot state `00010000` activates `972B Relay 1 ON`.
- Confirmed all other VTRX labels remain in their existing order.
- Confirmed no stale `972b Power ON` references remain in this repository.
- Ran `python -m pytest citestfiles -v`: 85 tests passed, with four pre-existing thread warnings.