### PR TITLE
Feature: 902B Dashboard Integration

### DIFF
--- a/citestfiles/MKS902B/mks_902b_driver_test.py
+++ b/citestfiles/MKS902B/mks_902b_driver_test.py
@@ -29,6 +29,7 @@ class ScriptedSerial:
         self.open_thread_id = threading.get_ident()
         self.close_thread_id = None
         self.flush_calls = 0
+        self.reset_input_buffer_calls = 0
 
     @property
     def in_waiting(self):
@@ -55,6 +56,12 @@ class ScriptedSerial:
         self.thread_ids.add(threading.get_ident())
         self.flush_calls += 1
 
+    def reset_input_buffer(self):
+        """Discard unread response bytes on the serial-owner thread."""
+        self.thread_ids.add(threading.get_ident())
+        self.reset_input_buffer_calls += 1
+        self.pending.clear()
+
     def read(self, size):
         """Return the next response chunk."""
         self.thread_ids.add(threading.get_ident())
@@ -78,9 +85,13 @@ class TestMKS902BProtocol(unittest.TestCase):
     """Validate protocol parsing, initialization, conversion, and retry behavior."""
 
     def test_parse_response_returns_envelope_fields(self):
-        """Parse a documented ACK response."""
+        """Parse ACK responses with a semicolon or documented FF suffix."""
         self.assertEqual(
             driver_module.parse_response("@253ACK1.234E-3;FF"),
+            (253, "ACK", "1.234E-3"),
+        )
+        self.assertEqual(
+            driver_module.parse_response("@253ACK1.234E-3;"),
             (253, "ACK", "1.234E-3"),
         )
 
@@ -94,14 +105,23 @@ class TestMKS902BProtocol(unittest.TestCase):
         self.assertAlmostEqual(driver_module.convert_pressure_to_mbar(100.0, "PASCAL"), 1.0)
 
     def test_framer_preserves_concatenated_frames(self):
-        """Extract split protocol frames without relying on newlines."""
+        """End responses at semicolons while tolerating trailing FF text."""
         driver = driver_module.MKS902BDriver("COM9")
         driver._receive_buffer.extend(
             b"garbage@253ACK1.000E0;FF\r\n@253ACK2.000E0;FF"
         )
 
-        self.assertEqual(driver._extract_frame(), b"@253ACK1.000E0;FF")
-        self.assertEqual(driver._extract_frame(), b"@253ACK2.000E0;FF")
+        self.assertEqual(driver._extract_frame(), b"@253ACK1.000E0;")
+        self.assertEqual(driver._extract_frame(), b"@253ACK2.000E0;")
+
+    def test_framer_starts_at_most_recent_attention_character(self):
+        """Ignore an incomplete old response before the latest response."""
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._receive_buffer.extend(
+            b"@253ACK9.89E+02 FF@253ACK1.234E0;"
+        )
+
+        self.assertEqual(driver._extract_frame(), b"@253ACK1.234E0;")
 
     def test_incomplete_response_bytes_are_logged_before_timeout(self):
         """Log received bytes even when they never form a complete response frame."""
@@ -180,6 +200,32 @@ class TestMKS902BProtocol(unittest.TestCase):
             if level == LogLevel.DEBUG and message.startswith("PR4 attempt")
         ]
         self.assertEqual(len(debug_logs), 2)
+        self.assertEqual(driver._serial.reset_input_buffer_calls, 2)
+
+    def test_failed_poll_bytes_are_discarded_before_retry(self):
+        """Do not append a timed-out partial response to the next attempt."""
+        responses = iter(
+            [
+                b"@253ACK1.000E0",
+                b"@253ACK2.000E0;",
+            ]
+        )
+
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._serial = ScriptedSerial(response_factory=lambda _command: next(responses))
+        driver._address = 253
+        driver._pressure_unit = "MBAR"
+
+        with (
+            patch.object(driver_module, "RESPONSE_TIMEOUT_SECONDS", 0.01),
+            patch.object(driver_module, "POLL_RETRY_DELAY_SECONDS", 0),
+        ):
+            self.assertTrue(driver._poll_pressure())
+
+        self.assertEqual(driver._serial.reset_input_buffer_calls, 1)
+        self.assertEqual(driver._receive_buffer, bytearray())
+        _, pressure_mbar = driver.data_queue.get_nowait()
+        self.assertAlmostEqual(pressure_mbar, 2.0)
 
     def test_failed_poll_group_logs_each_attempt_without_publishing_data(self):
         """Log three request failures and one summary while leaving data empty."""

--- a/citestfiles/MKS902B/mks_902b_driver_test.py
+++ b/citestfiles/MKS902B/mks_902b_driver_test.py
@@ -128,16 +128,16 @@ class TestMKS902BProtocol(unittest.TestCase):
     def test_incomplete_response_bytes_are_logged_before_timeout(self):
         """Log received bytes even when they never form a complete response frame."""
         driver = driver_module.MKS902BDriver("COM9")
-        driver._serial = ScriptedSerial(responses=[b"@253ACK1.234E0"])
+        driver._serial = ScriptedSerial(responses=[b"@253ACK1.234"])
 
         with (
             patch.object(driver_module, "RESPONSE_TIMEOUT_SECONDS", 0.01),
             self.assertRaises(driver_module.MKS902BTimeoutError),
         ):
-            driver._request("@253PR4?;FF", expected_address=253)
+            driver._request("@253PR1?;FF", expected_address=253)
 
         self.assertIn(
-            ("RX b'@253ACK1.234E0'", LogLevel.VERBOSE),
+            ("RX b'@253ACK1.234'", LogLevel.VERBOSE),
             list(driver._log_queue.queue),
         )
 
@@ -177,7 +177,7 @@ class TestMKS902BProtocol(unittest.TestCase):
         )
 
     def test_poll_retries_three_total_attempts_and_publishes_only_success(self):
-        """Retry twice after failures and publish the third valid PR4 reply."""
+        """Retry twice after failures and publish the third valid PR1 reply."""
         response_count = 0
 
         def respond(_command):
@@ -186,7 +186,7 @@ class TestMKS902BProtocol(unittest.TestCase):
             response_count += 1
             if response_count < 3:
                 return "@253NAK160;FF"
-            return "@253ACK1.234E0;FF"
+            return "@253ACK1.234;FF"
 
         driver = driver_module.MKS902BDriver("COM9")
         driver._serial = ScriptedSerial(response_factory=respond)
@@ -203,7 +203,7 @@ class TestMKS902BProtocol(unittest.TestCase):
         debug_logs = [
             message
             for message, level in list(driver._log_queue.queue)
-            if level == LogLevel.DEBUG and message.startswith("PR4 attempt")
+            if level == LogLevel.DEBUG and message.startswith("PR1 attempt")
         ]
         self.assertEqual(len(debug_logs), 2)
         self.assertEqual(driver._serial.reset_input_buffer_calls, 2)
@@ -212,8 +212,8 @@ class TestMKS902BProtocol(unittest.TestCase):
         """Do not append a timed-out partial response to the next attempt."""
         responses = iter(
             [
-                b"@253ACK1.000E0",
-                b"@253ACK2.000E0;",
+                b"@253ACK1.000",
+                b"@253ACK2.000;",
             ]
         )
 
@@ -245,7 +245,7 @@ class TestMKS902BProtocol(unittest.TestCase):
 
         self.assertTrue(driver.data_queue.empty())
         queued_logs = list(driver._log_queue.queue)
-        debug_logs = [level for message, level in queued_logs if message.startswith("PR4 attempt")]
+        debug_logs = [level for message, level in queued_logs if message.startswith("PR1 attempt")]
         error_logs = [
             message
             for message, level in queued_logs
@@ -280,7 +280,7 @@ class TestMKS902BWorker(unittest.TestCase):
                 "@254MD?;FF": "@253ACK902B;FF",
                 "@253BR?;FF": "@253ACK9600;FF",
                 "@253U?;FF": "@253ACKMBAR;FF",
-                "@253PR4?;FF": "@253ACK1.234E0;FF",
+                "@253PR1?;FF": "@253ACK1.234;FF",
             }
             return responses[command]
 

--- a/citestfiles/MKS902B/mks_902b_driver_test.py
+++ b/citestfiles/MKS902B/mks_902b_driver_test.py
@@ -1,0 +1,255 @@
+"""Tests for the threaded MKS 902B serial driver."""
+
+import os
+import queue
+import sys
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from instrumentctl.mks_902b import mks_902b_driver as driver_module
+from utils import LogLevel
+
+
+class ScriptedSerial:
+    """Provide deterministic command responses while recording serial thread use."""
+
+    def __init__(self, responses=None, response_factory=None, max_chunk=None):
+        """Initialize a fake open serial connection."""
+        self.responses = list(responses or [])
+        self.response_factory = response_factory
+        self.max_chunk = max_chunk
+        self.is_open = True
+        self.writes = []
+        self.pending = bytearray()
+        self.thread_ids = {threading.get_ident()}
+        self.open_thread_id = threading.get_ident()
+        self.close_thread_id = None
+
+    @property
+    def in_waiting(self):
+        """Return the number of response bytes ready to read."""
+        return len(self.pending)
+
+    def write(self, data):
+        """Record a command and queue its scripted response."""
+        self.thread_ids.add(threading.get_ident())
+        command = data.decode("ascii").strip()
+        self.writes.append(command)
+        if self.response_factory is not None:
+            response = self.response_factory(command)
+        elif self.responses:
+            response = self.responses.pop(0)
+        else:
+            response = None
+        if response is not None:
+            self.pending.extend(response.encode("ascii") if isinstance(response, str) else response)
+        return len(data)
+
+    def flush(self):
+        """Record that flushing occurred on the serial-owner thread."""
+        self.thread_ids.add(threading.get_ident())
+
+    def read(self, size):
+        """Return the next response chunk."""
+        self.thread_ids.add(threading.get_ident())
+        if not self.pending:
+            time.sleep(0.001)
+            return b""
+        if self.max_chunk is not None:
+            size = min(size, self.max_chunk)
+        chunk = bytes(self.pending[:size])
+        del self.pending[:size]
+        return chunk
+
+    def close(self):
+        """Record closure and mark the fake connection closed."""
+        self.thread_ids.add(threading.get_ident())
+        self.close_thread_id = threading.get_ident()
+        self.is_open = False
+
+
+class TestMKS902BProtocol(unittest.TestCase):
+    """Validate protocol parsing, initialization, conversion, and retry behavior."""
+
+    def test_parse_response_returns_envelope_fields(self):
+        """Parse a documented ACK response."""
+        self.assertEqual(
+            driver_module.parse_response("@253ACK1.234E-3;FF"),
+            (253, "ACK", "1.234E-3"),
+        )
+
+    def test_unit_conversion_returns_mbar(self):
+        """Convert every supported configured unit to mbar."""
+        self.assertAlmostEqual(driver_module.convert_pressure_to_mbar(1.0, "MBAR"), 1.0)
+        self.assertAlmostEqual(
+            driver_module.convert_pressure_to_mbar(1.0, "TORR"),
+            1.333223684,
+        )
+        self.assertAlmostEqual(driver_module.convert_pressure_to_mbar(100.0, "PASCAL"), 1.0)
+
+    def test_framer_preserves_concatenated_frames(self):
+        """Extract split protocol frames without relying on newlines."""
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._receive_buffer.extend(
+            b"garbage@253ACK1.000E0;FF\r\n@253ACK2.000E0;FF"
+        )
+
+        self.assertEqual(driver._extract_frame(), b"@253ACK1.000E0;FF")
+        self.assertEqual(driver._extract_frame(), b"@253ACK2.000E0;FF")
+
+    def test_initialization_discovers_address_and_queries_read_only_metadata(self):
+        """Use broadcast only for discovery and never send a setting command."""
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._serial = ScriptedSerial(
+            responses=[
+                "@247ACK902B;FF",
+                "@247ACK9600;FF",
+                "@247ACKTORR;FF",
+            ],
+            max_chunk=3,
+        )
+
+        driver._initialize_transducer()
+
+        self.assertEqual(driver._address, 247)
+        self.assertEqual(driver._pressure_unit, "TORR")
+        self.assertEqual(
+            driver._serial.writes,
+            ["@254MD?;FF", "@247BR?;FF", "@247U?;FF"],
+        )
+        self.assertTrue(all("!" not in command for command in driver._serial.writes))
+        queued_logs = list(driver._log_queue.queue)
+        self.assertIn(
+            (
+                "902B pressure unit: TORR; dashboard will convert TORR to mbar",
+                LogLevel.INFO,
+            ),
+            queued_logs,
+        )
+
+    def test_poll_retries_three_total_attempts_and_publishes_only_success(self):
+        """Retry twice after failures and publish the third valid PR4 reply."""
+        response_count = 0
+
+        def respond(_command):
+            """Return two NAK replies followed by a valid pressure reply."""
+            nonlocal response_count
+            response_count += 1
+            if response_count < 3:
+                return "@253NAK160;FF"
+            return "@253ACK1.234E0;FF"
+
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._serial = ScriptedSerial(response_factory=respond)
+        driver._address = 253
+        driver._pressure_unit = "MBAR"
+
+        with patch.object(driver_module, "POLL_RETRY_DELAY_SECONDS", 0):
+            self.assertTrue(driver._poll_pressure())
+
+        self.assertEqual(response_count, 3)
+        timestamp, pressure_mbar = driver.data_queue.get_nowait()
+        self.assertLessEqual(timestamp, time.time())
+        self.assertAlmostEqual(pressure_mbar, 1.234)
+        debug_logs = [
+            message
+            for message, level in list(driver._log_queue.queue)
+            if level == LogLevel.DEBUG and message.startswith("PR4 attempt")
+        ]
+        self.assertEqual(len(debug_logs), 2)
+
+    def test_failed_poll_group_logs_each_attempt_without_publishing_data(self):
+        """Log three request failures and one summary while leaving data empty."""
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._serial = ScriptedSerial(response_factory=lambda _command: "@253NAK160;FF")
+        driver._address = 253
+        driver._pressure_unit = "MBAR"
+
+        with patch.object(driver_module, "POLL_RETRY_DELAY_SECONDS", 0):
+            self.assertFalse(driver._poll_pressure())
+
+        self.assertTrue(driver.data_queue.empty())
+        queued_logs = list(driver._log_queue.queue)
+        debug_logs = [level for message, level in queued_logs if message.startswith("PR4 attempt")]
+        error_logs = [
+            message
+            for message, level in queued_logs
+            if level == LogLevel.ERROR and "failed after 3 attempts" in message
+        ]
+        self.assertEqual(debug_logs, [LogLevel.DEBUG] * 3)
+        self.assertEqual(len(error_logs), 1)
+
+    def test_bounded_data_queue_discards_oldest_measurement(self):
+        """Keep recent measurements when the UI consumer falls behind."""
+        driver = driver_module.MKS902BDriver("COM9")
+        for value in range(driver_module.DATA_QUEUE_MAXSIZE + 1):
+            driver._put_latest_data((float(value), float(value)))
+
+        timestamps = []
+        while not driver.data_queue.empty():
+            timestamps.append(driver.data_queue.get_nowait()[0])
+        self.assertEqual(timestamps[0], 1.0)
+        self.assertEqual(timestamps[-1], float(driver_module.DATA_QUEUE_MAXSIZE))
+
+
+class TestMKS902BWorker(unittest.TestCase):
+    """Validate worker lifecycle and serial ownership."""
+
+    def test_worker_is_sole_serial_owner(self):
+        """Open, read, write, and close the serial connection on one worker thread."""
+        serial_instances = []
+
+        def respond(command):
+            """Return a valid response for every driver command."""
+            responses = {
+                "@254MD?;FF": "@253ACK902B;FF",
+                "@253BR?;FF": "@253ACK9600;FF",
+                "@253U?;FF": "@253ACKMBAR;FF",
+                "@253PR4?;FF": "@253ACK1.234E0;FF",
+            }
+            return responses[command]
+
+        def serial_factory(**_kwargs):
+            """Create a fake connection in whichever thread opens the port."""
+            serial_connection = ScriptedSerial(response_factory=respond)
+            serial_instances.append(serial_connection)
+            return serial_connection
+
+        main_thread_id = threading.get_ident()
+        driver = driver_module.MKS902BDriver("COM9", logger=MagicMock())
+        with (
+            patch.object(driver_module.serial, "Serial", side_effect=serial_factory),
+            patch.object(driver_module, "POLL_INTERVAL_SECONDS", 0.01),
+            patch.object(driver_module, "THREAD_JOIN_TIMEOUT_MS", 1000),
+        ):
+            driver.start()
+            driver.data_queue.get(timeout=1.0)
+            driver.close()
+
+        self.assertEqual(len(serial_instances), 1)
+        serial_connection = serial_instances[0]
+        self.assertNotEqual(serial_connection.open_thread_id, main_thread_id)
+        self.assertEqual(serial_connection.close_thread_id, serial_connection.open_thread_id)
+        self.assertEqual(serial_connection.thread_ids, {serial_connection.open_thread_id})
+
+    def test_flush_queued_logs_uses_902b_tag(self):
+        """Forward severity and message through the timestamping central logger."""
+        logger = MagicMock()
+        driver = driver_module.MKS902BDriver("COM9", logger=logger)
+        driver._queue_log("unit test message", LogLevel.INFO)
+
+        driver.flush_queued_logs()
+
+        logger.log.assert_called_once_with(
+            "unit test message",
+            LogLevel.INFO,
+            tag="902B",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/citestfiles/MKS902B/mks_902b_driver_test.py
+++ b/citestfiles/MKS902B/mks_902b_driver_test.py
@@ -28,6 +28,7 @@ class ScriptedSerial:
         self.thread_ids = {threading.get_ident()}
         self.open_thread_id = threading.get_ident()
         self.close_thread_id = None
+        self.flush_calls = 0
 
     @property
     def in_waiting(self):
@@ -52,6 +53,7 @@ class ScriptedSerial:
     def flush(self):
         """Record that flushing occurred on the serial-owner thread."""
         self.thread_ids.add(threading.get_ident())
+        self.flush_calls += 1
 
     def read(self, size):
         """Return the next response chunk."""
@@ -101,6 +103,22 @@ class TestMKS902BProtocol(unittest.TestCase):
         self.assertEqual(driver._extract_frame(), b"@253ACK1.000E0;FF")
         self.assertEqual(driver._extract_frame(), b"@253ACK2.000E0;FF")
 
+    def test_incomplete_response_bytes_are_logged_before_timeout(self):
+        """Log received bytes even when they never form a complete response frame."""
+        driver = driver_module.MKS902BDriver("COM9")
+        driver._serial = ScriptedSerial(responses=[b"@253ACK1.234E0"])
+
+        with (
+            patch.object(driver_module, "RESPONSE_TIMEOUT_SECONDS", 0.01),
+            self.assertRaises(driver_module.MKS902BTimeoutError),
+        ):
+            driver._request("@253PR4?;FF", expected_address=253)
+
+        self.assertIn(
+            ("RX b'@253ACK1.234E0'", LogLevel.VERBOSE),
+            list(driver._log_queue.queue),
+        )
+
     def test_initialization_discovers_address_and_queries_read_only_metadata(self):
         """Use broadcast only for discovery and never send a setting command."""
         driver = driver_module.MKS902BDriver("COM9")
@@ -121,6 +139,7 @@ class TestMKS902BProtocol(unittest.TestCase):
             driver._serial.writes,
             ["@254MD?;FF", "@247BR?;FF", "@247U?;FF"],
         )
+        self.assertEqual(driver._serial.flush_calls, 0)
         self.assertTrue(all("!" not in command for command in driver._serial.writes))
         queued_logs = list(driver._log_queue.queue)
         self.assertIn(
@@ -224,7 +243,7 @@ class TestMKS902BWorker(unittest.TestCase):
         with (
             patch.object(driver_module.serial, "Serial", side_effect=serial_factory),
             patch.object(driver_module, "POLL_INTERVAL_SECONDS", 0.01),
-            patch.object(driver_module, "THREAD_JOIN_TIMEOUT_MS", 1000),
+            patch.object(driver_module, "THREAD_JOIN_TIMEOUT_SECONDS", 1.0),
         ):
             driver.start()
             driver.data_queue.get(timeout=1.0)

--- a/citestfiles/MKS902B/mks_902b_driver_test.py
+++ b/citestfiles/MKS902B/mks_902b_driver_test.py
@@ -24,6 +24,7 @@ class ScriptedSerial:
         self.max_chunk = max_chunk
         self.is_open = True
         self.writes = []
+        self.raw_writes = []
         self.pending = bytearray()
         self.thread_ids = {threading.get_ident()}
         self.open_thread_id = threading.get_ident()
@@ -39,6 +40,7 @@ class ScriptedSerial:
     def write(self, data):
         """Record a command and queue its scripted response."""
         self.thread_ids.add(threading.get_ident())
+        self.raw_writes.append(data)
         command = data.decode("ascii").strip()
         self.writes.append(command)
         if self.response_factory is not None:
@@ -158,6 +160,10 @@ class TestMKS902BProtocol(unittest.TestCase):
         self.assertEqual(
             driver._serial.writes,
             ["@254MD?;FF", "@247BR?;FF", "@247U?;FF"],
+        )
+        self.assertEqual(
+            driver._serial.raw_writes,
+            [b"@254MD?;FF", b"@247BR?;FF", b"@247U?;FF"],
         )
         self.assertEqual(driver._serial.flush_calls, 0)
         self.assertTrue(all("!" not in command for command in driver._serial.writes))

--- a/citestfiles/VTRX/vtrx_902b_integration_test.py
+++ b/citestfiles/VTRX/vtrx_902b_integration_test.py
@@ -62,14 +62,14 @@ class TestVTRX902BConsumer(unittest.TestCase):
         )
         subsystem.logger.clear_value.assert_not_called()
 
-    def test_three_second_stale_limit_clears_display_and_webmonitor_once(self):
+    def test_six_second_stale_limit_clears_display_and_webmonitor_once(self):
         """Show no data and clear publication once when the last sample is stale."""
         subsystem = make_vtrx_consumer()
         subsystem.latest_902b_pressure_mbar = 1.234e-3
         subsystem.last_valid_902b_timestamp = 1000.0
         subsystem._902b_webmonitor_cleared = False
 
-        with patch("subsystem.vtrx.vtrx.time.time", return_value=1003.01):
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1006.01):
             subsystem._process_902b_data()
             subsystem._process_902b_data()
 
@@ -83,7 +83,7 @@ class TestVTRX902BConsumer(unittest.TestCase):
         subsystem.last_valid_902b_timestamp = 1000.0
         subsystem.label_902b_pressure.config(text="1.234E-03 mbar")
 
-        with patch("subsystem.vtrx.vtrx.time.time", return_value=1002.99):
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1005.99):
             subsystem._process_902b_data()
 
         self.assertEqual(subsystem.label_902b_pressure.options["text"], "1.234E-03 mbar")

--- a/citestfiles/VTRX/vtrx_902b_integration_test.py
+++ b/citestfiles/VTRX/vtrx_902b_integration_test.py
@@ -5,6 +5,8 @@ import queue
 import sys
 import threading
 import unittest
+import datetime
+import math
 from unittest.mock import MagicMock, patch
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
@@ -25,6 +27,17 @@ def make_vtrx_consumer():
     subsystem.last_valid_902b_timestamp = None
     subsystem._902b_webmonitor_cleared = True
     subsystem._902b_widget_suppressed = False
+    subsystem.MAX_HISTORY_SECONDS = 7 * 24 * 60 * 60
+    subsystem.display_window = 300
+    subsystem.full_history_x = []
+    subsystem.full_history_y = []
+    subsystem.x_data = []
+    subsystem.y_data = []
+    subsystem.full_history_902b_x = []
+    subsystem.full_history_902b_y = []
+    subsystem.x_data_902b = []
+    subsystem.y_data_902b = []
+    subsystem._902b_plot_gap_pending = False
     subsystem.stop_event = threading.Event()
     subsystem._background_log_queue = queue.SimpleQueue()
     subsystem._main_thread_id = threading.get_ident()
@@ -46,6 +59,17 @@ class TestVTRX902BConsumer(unittest.TestCase):
 
         self.assertEqual(subsystem.latest_902b_pressure_mbar, 1.234e-3)
         self.assertEqual(subsystem.last_valid_902b_timestamp, 1000.0)
+        self.assertEqual(
+            subsystem.full_history_902b_x,
+            [
+                datetime.datetime.fromtimestamp(999.0),
+                datetime.datetime.fromtimestamp(1000.0),
+            ],
+        )
+        self.assertEqual(
+            subsystem.full_history_902b_y,
+            [2.0e-3, 1.234e-3],
+        )
         subsystem.logger.update_field.assert_called_once_with(
             "pressure_902b_mbar",
             1.234e-3,
@@ -91,6 +115,9 @@ class TestVTRX902BConsumer(unittest.TestCase):
         subsystem.last_valid_pressure_value = 0.999
         subsystem.last_successful_read_time = 1000.0
         subsystem._902b_webmonitor_cleared = False
+        original_timestamp = datetime.datetime.fromtimestamp(999.0)
+        subsystem.full_history_902b_x = [original_timestamp]
+        subsystem.full_history_902b_y = [5.0e-3]
         subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
 
         with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
@@ -99,6 +126,9 @@ class TestVTRX902BConsumer(unittest.TestCase):
 
         self.assertEqual(subsystem.latest_902b_pressure_mbar, 4.5e-3)
         self.assertTrue(subsystem._902b_widget_suppressed)
+        self.assertEqual(subsystem.full_history_902b_x, [original_timestamp])
+        self.assertEqual(subsystem.full_history_902b_y, [5.0e-3])
+        self.assertTrue(subsystem._902b_plot_gap_pending)
         subsystem.logger.update_field.assert_not_called()
         subsystem.logger.clear_value.assert_called_once_with("pressure_902b_mbar")
 

--- a/citestfiles/VTRX/vtrx_902b_integration_test.py
+++ b/citestfiles/VTRX/vtrx_902b_integration_test.py
@@ -1,0 +1,94 @@
+"""Tests for 902B measurement consumption in the VTRX dashboard pane."""
+
+import os
+import queue
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from subsystem.vtrx.vtrx import VTRXSubsystem
+
+
+class FakeLabel:
+    """Record Tk label configuration without creating a GUI."""
+
+    def __init__(self):
+        """Initialize an empty configuration snapshot."""
+        self.options = {}
+
+    def config(self, **options):
+        """Store the newest widget options."""
+        self.options.update(options)
+
+
+def make_vtrx_consumer():
+    """Build only the VTRX state needed by the 902B queue consumer."""
+    subsystem = VTRXSubsystem.__new__(VTRXSubsystem)
+    subsystem.mks_902b_driver = MagicMock()
+    subsystem.mks_902b_driver.data_queue = queue.Queue()
+    subsystem.label_902b_pressure = FakeLabel()
+    subsystem.logger = MagicMock()
+    subsystem.latest_902b_pressure_mbar = None
+    subsystem.last_valid_902b_timestamp = None
+    subsystem._902b_webmonitor_cleared = True
+    subsystem.stop_event = threading.Event()
+    subsystem._background_log_queue = queue.SimpleQueue()
+    subsystem._main_thread_id = threading.get_ident()
+    subsystem.ser = None
+    return subsystem
+
+
+class TestVTRX902BConsumer(unittest.TestCase):
+    """Validate latest-value display, publishing, and stale clearing."""
+
+    def test_newest_measurement_updates_display_and_webmonitor(self):
+        """Drain accumulated measurements and publish only the newest one."""
+        subsystem = make_vtrx_consumer()
+        subsystem.mks_902b_driver.data_queue.put((999.0, 2.0e-3))
+        subsystem.mks_902b_driver.data_queue.put((1000.0, 1.234e-3))
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+
+        self.assertEqual(subsystem.latest_902b_pressure_mbar, 1.234e-3)
+        self.assertEqual(subsystem.last_valid_902b_timestamp, 1000.0)
+        self.assertEqual(subsystem.label_902b_pressure.options["text"], "1.234E-03 mbar")
+        subsystem.logger.update_field.assert_called_once_with(
+            "pressure_902b_mbar",
+            1.234e-3,
+        )
+        subsystem.logger.clear_value.assert_not_called()
+
+    def test_three_second_stale_limit_clears_display_and_webmonitor_once(self):
+        """Show no data and clear publication once when the last sample is stale."""
+        subsystem = make_vtrx_consumer()
+        subsystem.latest_902b_pressure_mbar = 1.234e-3
+        subsystem.last_valid_902b_timestamp = 1000.0
+        subsystem._902b_webmonitor_cleared = False
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1003.01):
+            subsystem._process_902b_data()
+            subsystem._process_902b_data()
+
+        self.assertEqual(subsystem.label_902b_pressure.options["text"], "No data...")
+        subsystem.logger.clear_value.assert_called_once_with("pressure_902b_mbar")
+
+    def test_fresh_value_remains_visible_during_brief_poll_failures(self):
+        """Retain the latest pressure while it remains within the freshness window."""
+        subsystem = make_vtrx_consumer()
+        subsystem.latest_902b_pressure_mbar = 1.234e-3
+        subsystem.last_valid_902b_timestamp = 1000.0
+        subsystem.label_902b_pressure.config(text="1.234E-03 mbar")
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1002.99):
+            subsystem._process_902b_data()
+
+        self.assertEqual(subsystem.label_902b_pressure.options["text"], "1.234E-03 mbar")
+        subsystem.logger.clear_value.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/citestfiles/VTRX/vtrx_902b_integration_test.py
+++ b/citestfiles/VTRX/vtrx_902b_integration_test.py
@@ -12,28 +12,19 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from subsystem.vtrx.vtrx import VTRXSubsystem
 
 
-class FakeLabel:
-    """Record Tk label configuration without creating a GUI."""
-
-    def __init__(self):
-        """Initialize an empty configuration snapshot."""
-        self.options = {}
-
-    def config(self, **options):
-        """Store the newest widget options."""
-        self.options.update(options)
-
-
 def make_vtrx_consumer():
     """Build only the VTRX state needed by the 902B queue consumer."""
     subsystem = VTRXSubsystem.__new__(VTRXSubsystem)
     subsystem.mks_902b_driver = MagicMock()
     subsystem.mks_902b_driver.data_queue = queue.Queue()
-    subsystem.label_902b_pressure = FakeLabel()
     subsystem.logger = MagicMock()
+    subsystem.error_state = False
+    subsystem.last_valid_pressure_value = None
+    subsystem.last_successful_read_time = None
     subsystem.latest_902b_pressure_mbar = None
     subsystem.last_valid_902b_timestamp = None
     subsystem._902b_webmonitor_cleared = True
+    subsystem._902b_widget_suppressed = False
     subsystem.stop_event = threading.Event()
     subsystem._background_log_queue = queue.SimpleQueue()
     subsystem._main_thread_id = threading.get_ident()
@@ -42,10 +33,10 @@ def make_vtrx_consumer():
 
 
 class TestVTRX902BConsumer(unittest.TestCase):
-    """Validate latest-value display, publishing, and stale clearing."""
+    """Validate threshold-gated publication and stale clearing."""
 
-    def test_newest_measurement_updates_display_and_webmonitor(self):
-        """Drain accumulated measurements and publish only the newest one."""
+    def test_newest_measurement_is_published_when_972b_is_unavailable(self):
+        """An unavailable 972B does not suppress the newest 902B measurement."""
         subsystem = make_vtrx_consumer()
         subsystem.mks_902b_driver.data_queue.put((999.0, 2.0e-3))
         subsystem.mks_902b_driver.data_queue.put((1000.0, 1.234e-3))
@@ -55,39 +46,217 @@ class TestVTRX902BConsumer(unittest.TestCase):
 
         self.assertEqual(subsystem.latest_902b_pressure_mbar, 1.234e-3)
         self.assertEqual(subsystem.last_valid_902b_timestamp, 1000.0)
-        self.assertEqual(subsystem.label_902b_pressure.options["text"], "1.234E-03 mbar")
         subsystem.logger.update_field.assert_called_once_with(
             "pressure_902b_mbar",
             1.234e-3,
         )
         subsystem.logger.clear_value.assert_not_called()
 
-    def test_six_second_stale_limit_clears_display_and_webmonitor_once(self):
-        """Show no data and clear publication once when the last sample is stale."""
+    def test_six_second_stale_limit_clears_publication_once(self):
+        """Clear publication once when the last 902B sample is stale."""
         subsystem = make_vtrx_consumer()
         subsystem.latest_902b_pressure_mbar = 1.234e-3
         subsystem.last_valid_902b_timestamp = 1000.0
         subsystem._902b_webmonitor_cleared = False
+        subsystem.label_902b_pressure = MagicMock()
 
         with patch("subsystem.vtrx.vtrx.time.time", return_value=1006.01):
             subsystem._process_902b_data()
             subsystem._process_902b_data()
 
-        self.assertEqual(subsystem.label_902b_pressure.options["text"], "No data...")
         subsystem.logger.clear_value.assert_called_once_with("pressure_902b_mbar")
+        subsystem.label_902b_pressure.config.assert_called_with(
+            text="No data...",
+            bg="white",
+            fg="black",
+        )
+        self.assertFalse(subsystem._902b_widget_suppressed)
 
-    def test_fresh_value_remains_visible_during_brief_poll_failures(self):
-        """Retain the latest pressure while it remains within the freshness window."""
+    def test_fresh_value_remains_published_during_brief_poll_failures(self):
+        """Retain publication while the 902B value remains fresh."""
         subsystem = make_vtrx_consumer()
         subsystem.latest_902b_pressure_mbar = 1.234e-3
         subsystem.last_valid_902b_timestamp = 1000.0
-        subsystem.label_902b_pressure.config(text="1.234E-03 mbar")
+        subsystem._902b_webmonitor_cleared = False
 
         with patch("subsystem.vtrx.vtrx.time.time", return_value=1005.99):
             subsystem._process_902b_data()
 
-        self.assertEqual(subsystem.label_902b_pressure.options["text"], "1.234E-03 mbar")
+        subsystem.logger.update_field.assert_not_called()
         subsystem.logger.clear_value.assert_not_called()
+
+    def test_confirmed_972b_below_one_mbar_suppresses_new_902b_data(self):
+        """Drain and retain a new 902B sample without publishing it below range."""
+        subsystem = make_vtrx_consumer()
+        subsystem.last_valid_pressure_value = 0.999
+        subsystem.last_successful_read_time = 1000.0
+        subsystem._902b_webmonitor_cleared = False
+        subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+            subsystem._process_902b_data()
+
+        self.assertEqual(subsystem.latest_902b_pressure_mbar, 4.5e-3)
+        self.assertTrue(subsystem._902b_widget_suppressed)
+        subsystem.logger.update_field.assert_not_called()
+        subsystem.logger.clear_value.assert_called_once_with("pressure_902b_mbar")
+
+    def test_972b_at_exactly_one_mbar_allows_902b_publication(self):
+        """The suppression threshold is strictly less than one mbar."""
+        subsystem = make_vtrx_consumer()
+        subsystem.last_valid_pressure_value = 1.0
+        subsystem.last_successful_read_time = 1000.0
+        subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+
+        subsystem.logger.update_field.assert_called_once_with(
+            "pressure_902b_mbar",
+            4.5e-3,
+        )
+        self.assertFalse(subsystem._902b_widget_suppressed)
+        subsystem.logger.clear_value.assert_not_called()
+
+    def test_stale_or_error_972b_does_not_suppress_902b(self):
+        """Only a fresh, valid low 972B measurement suppresses publication."""
+        for last_successful_read_time, error_state in (
+            (990.0, False),
+            (1000.0, True),
+        ):
+            with self.subTest(
+                last_successful_read_time=last_successful_read_time,
+                error_state=error_state,
+            ):
+                subsystem = make_vtrx_consumer()
+                subsystem.last_valid_pressure_value = 0.5
+                subsystem.last_successful_read_time = last_successful_read_time
+                subsystem.error_state = error_state
+                subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
+
+                with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+                    subsystem._process_902b_data()
+
+                subsystem.logger.update_field.assert_called_once_with(
+                    "pressure_902b_mbar",
+                    4.5e-3,
+                )
+                subsystem.logger.clear_value.assert_not_called()
+
+    def test_recovery_republishes_a_still_fresh_cached_902b_value(self):
+        """A cached 902B sample resumes publication when the 972B recovers."""
+        subsystem = make_vtrx_consumer()
+        subsystem.last_valid_pressure_value = 0.5
+        subsystem.last_successful_read_time = 1000.0
+        subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+
+        subsystem.last_valid_pressure_value = 1.0
+        subsystem.last_successful_read_time = 1001.0
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1001.5):
+            subsystem._process_902b_data()
+
+        subsystem.logger.update_field.assert_called_once_with(
+            "pressure_902b_mbar",
+            4.5e-3,
+        )
+        self.assertFalse(subsystem._902b_widget_suppressed)
+
+    def test_stale_972b_republishes_a_still_fresh_cached_902b_value(self):
+        """Loss of 972B confirmation ends low-pressure suppression."""
+        subsystem = make_vtrx_consumer()
+        subsystem.last_valid_pressure_value = 0.5
+        subsystem.last_successful_read_time = 1000.0
+        subsystem.mks_902b_driver.data_queue.put((1000.0, 4.5e-3))
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1003.01):
+            subsystem._process_902b_data()
+
+        subsystem.logger.update_field.assert_called_once_with(
+            "pressure_902b_mbar",
+            4.5e-3,
+        )
+        self.assertFalse(subsystem._902b_widget_suppressed)
+
+    def test_recovery_does_not_republish_a_stale_cached_902b_value(self):
+        """A cached 902B sample must still pass its own freshness rule."""
+        subsystem = make_vtrx_consumer()
+        subsystem.last_valid_pressure_value = 0.5
+        subsystem.last_successful_read_time = 1000.0
+        subsystem.latest_902b_pressure_mbar = 4.5e-3
+        subsystem.last_valid_902b_timestamp = 990.0
+        subsystem._902b_webmonitor_cleared = True
+
+        subsystem.last_valid_pressure_value = 1.0
+        subsystem.last_successful_read_time = 1000.0
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.5):
+            subsystem._process_902b_data()
+
+        subsystem.logger.update_field.assert_not_called()
+        subsystem.logger.clear_value.assert_not_called()
+
+    def test_suppression_hides_902b_and_centers_972b_until_restored(self):
+        """The pressure widgets follow the 972B publication gate."""
+        subsystem = make_vtrx_consumer()
+        subsystem.pressure_frame = MagicMock()
+        subsystem.label_972b_title = MagicMock()
+        subsystem.label_pressure = MagicMock()
+        subsystem.label_902b_title = MagicMock()
+        subsystem.label_902b_pressure = MagicMock()
+
+        subsystem._set_902b_widget_suppressed(True)
+
+        subsystem.label_902b_title.grid_remove.assert_called_once_with()
+        subsystem.label_902b_pressure.grid_remove.assert_called_once_with()
+        subsystem.label_972b_title.grid_configure.assert_called_with(column=1)
+        subsystem.label_pressure.grid_configure.assert_called_with(
+            column=2,
+            sticky='',
+        )
+
+        subsystem._set_902b_widget_suppressed(False)
+
+        subsystem.label_972b_title.grid_configure.assert_called_with(column=0)
+        subsystem.label_pressure.grid_configure.assert_called_with(
+            column=1,
+            sticky='ew',
+        )
+        subsystem.label_902b_title.grid.assert_called_once_with()
+        subsystem.label_902b_pressure.grid.assert_called_once_with()
+
+    def test_low_972b_clears_902b_before_updating_the_972b_gui(self):
+        """Prevent a low-pressure update from retaining a published 902B value."""
+        subsystem = make_vtrx_consumer()
+        subsystem._902b_webmonitor_cleared = False
+        subsystem.firmware_error = False
+        subsystem.vacuum_fields_cleared = False
+        subsystem.last_no_data_log_time = 0.0
+        subsystem.error_logged = False
+        subsystem.log = MagicMock()
+        events = []
+        subsystem.logger.clear_value.side_effect = (
+            lambda field: events.append(("clear", field))
+        )
+        subsystem.update_gui = MagicMock(
+            side_effect=lambda *_args: events.append(("update_gui", None))
+        )
+
+        with patch("subsystem.vtrx.vtrx.time.time", return_value=1000.0):
+            subsystem.handle_serial_data("0.5;5.0E-01;00000000")
+
+        self.assertEqual(
+            events,
+            [
+                ("clear", "pressure_902b_mbar"),
+                ("update_gui", None),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -22,6 +22,7 @@ os.makedirs(TEST_TMP_ROOT, exist_ok=True)
 
 EXPECTED_DICT_LOGGER_KEYS = {
     "pressure",
+    "pressure_902b_mbar",
     "safetyOutputDataFlags",
     "safetyInputDataFlags",
     "safetyOutputStatusFlags",

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,6 +4,7 @@ import subsystem
 import tkinter as tk
 from tkinter import ttk
 from instrumentctl.laser_monitor import LaserMonitorDriver
+from instrumentctl.mks_902b import MKS902BDriver
 from subsystem.main_control import MainControlPanel
 from subsystem.machine_status.machine_status import MachineStatus
 from utils import MessagesFrame, LogLevel
@@ -91,6 +92,7 @@ class EBEAMSystemDashboard:
 
         self.set_com_ports = set(serial.tools.list_ports.comports())
         self.ports_after_id = None
+        self.mks_902b_driver = None
 
         # Load toggle images
         try:
@@ -157,6 +159,14 @@ class EBEAMSystemDashboard:
                 machine_status.cancel_updates()
             except Exception as e:
                 self.logger.error(f"Error cancelling machine status updates: {e}", tag="Dashboard")
+
+        # Stop the Tk consumer before stopping its 902B producer. The worker
+        # remains responsible for closing its own serial connection.
+        vacuum_system = self.subsystems.get('Vacuum System')
+        if vacuum_system is not None and self.mks_902b_driver is not None:
+            vacuum_system.cancel_updates()
+            self.mks_902b_driver.close()
+            self.mks_902b_driver.flush_queued_logs()
 
         self._log_dashboard("Cleaning up com ports...", LogLevel.DEBUG)
         for subsystem_name, subsystem in self.subsystems.items():
@@ -428,13 +438,23 @@ class EBEAMSystemDashboard:
         Initialize all subsystem objects with their respective frames and settings.
         Each subsystem is configured with appropriate COM ports and logging.
         """
+        mks_902b_port = str(self.com_ports.get('902B', '') or '').strip()
+        if self._is_real_com_port(mks_902b_port):
+            self.mks_902b_driver = MKS902BDriver(mks_902b_port, logger=self.logger)
+        else:
+            self._log_dashboard(
+                "902B driver not started; no real COM port configured",
+                LogLevel.INFO,
+            )
+
         self.subsystems = {
             'Vacuum System': self._initialize_subsystem(
                 'Vacuum System',
                 lambda: subsystem.VTRXSubsystem(
                     self.frames['Vacuum System'],
                     serial_port=self.com_ports['VTRXSubsystem'],
-                    logger=self.logger
+                    logger=self.logger,
+                    mks_902b_driver=self.mks_902b_driver,
                 ),
             ),
             'Process Monitor [°C]': self._initialize_subsystem(
@@ -475,6 +495,9 @@ class EBEAMSystemDashboard:
                 ),
             )
         }
+
+        if self.mks_902b_driver is not None:
+            self.mks_902b_driver.start()
 
         if hasattr(self, "main_control"):
             self.main_control.subsystems = self.subsystems

--- a/instrumentctl/mks_902b/README.md
+++ b/instrumentctl/mks_902b/README.md
@@ -1,7 +1,7 @@
 # MKS 902B driver
 
 `MKS902BDriver` owns a 900USB virtual COM port on one worker thread. It
-discovers the 902B with `MD?`, reads `BR?` and `U?`, and polls `PR4?` every
+discovers the 902B with `MD?`, reads `BR?` and `U?`, and polls `PR1?` every
 500 ms. Valid readings are converted to mbar and published as
 `(timestamp, pressure_mbar)` tuples through `data_queue`.
 

--- a/instrumentctl/mks_902b/README.md
+++ b/instrumentctl/mks_902b/README.md
@@ -1,0 +1,11 @@
+# MKS 902B driver
+
+`MKS902BDriver` owns a 900USB virtual COM port on one worker thread. It
+discovers the 902B with `MD?`, reads `BR?` and `U?`, and polls `PR4?` every
+500 ms. Valid readings are converted to mbar and published as
+`(timestamp, pressure_mbar)` tuples through `data_queue`.
+
+The driver never changes transducer configuration. Background log entries are
+queued and must be drained from the Tk thread with `flush_queued_logs()`.
+Calling `close()` signals the worker and waits for it; the worker itself closes
+the serial connection.

--- a/instrumentctl/mks_902b/__init__.py
+++ b/instrumentctl/mks_902b/__init__.py
@@ -1,0 +1,5 @@
+"""MKS 902B pressure transducer driver package."""
+
+from .mks_902b_driver import MKS902BDriver
+
+__all__ = ["MKS902BDriver"]

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -12,15 +12,15 @@ from utils import LogLevel
 
 
 BAUDRATE = 115200
-SERIAL_READ_TIMEOUT_MS = 10
-SERIAL_WRITE_TIMEOUT_MS = 100
-RESPONSE_TIMEOUT_MS = 100
+SERIAL_READ_TIMEOUT_SECONDS = 0.01
+SERIAL_WRITE_TIMEOUT_SECONDS = 0.1
+RESPONSE_TIMEOUT_SECONDS = 0.1
 POLL_INTERVAL_SECONDS = 0.5
 POLL_RETRY_DELAY_SECONDS = 0.02
 POLL_ATTEMPTS = 3
 COMMUNICATION_LOSS_SECONDS = 5.0
 RECONNECT_INTERVAL_SECONDS = 5.0
-THREAD_JOIN_TIMEOUT_MS = 2000
+THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 DATA_QUEUE_MAXSIZE = 8
 LOG_QUEUE_MAXSIZE = 1000
 FRAME_TERMINATOR = b";FF"
@@ -40,8 +40,6 @@ UNIT_TO_MBAR = {
     "TORR": 1.333223684,
     "PASCAL": 0.01,
 }
-MIN_PRESSURE_MBAR = 0.1 * UNIT_TO_MBAR["TORR"]
-MAX_PRESSURE_MBAR = 1000.0 * UNIT_TO_MBAR["TORR"]
 
 _RESPONSE_RE = re.compile(r"^@(\d{3})(ACK|NAK)(.*);FF$")
 _SCIENTIFIC_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[Ee][+-]?\d+$")
@@ -77,10 +75,6 @@ def convert_pressure_to_mbar(pressure, unit):
     pressure_mbar = pressure * conversion_factor
     if not math.isfinite(pressure_mbar):
         raise MKS902BProtocolError("Pressure is not finite")
-    if not MIN_PRESSURE_MBAR <= pressure_mbar <= MAX_PRESSURE_MBAR:
-        raise MKS902BProtocolError(
-            f"Pressure {pressure_mbar:.6g} mbar is outside the 902B measurement range"
-        )
     return pressure_mbar
 
 
@@ -120,7 +114,7 @@ class MKS902BDriver:
         """Request worker shutdown and wait briefly without touching the serial port."""
         self._stop_event.set()
         if self._thread is not None and self._thread.is_alive():
-            self._thread.join(timeout=THREAD_JOIN_TIMEOUT_MS / 1000.0)
+            self._thread.join(timeout=THREAD_JOIN_TIMEOUT_SECONDS)
         if self._thread is not None and self._thread.is_alive():
             self._queue_log("902B worker did not stop before the join timeout", LogLevel.ERROR)
 
@@ -186,8 +180,8 @@ class MKS902BDriver:
                 bytesize=serial.EIGHTBITS,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
-                timeout=SERIAL_READ_TIMEOUT_MS / 1000.0,
-                write_timeout=SERIAL_WRITE_TIMEOUT_MS / 1000.0,
+                timeout=SERIAL_READ_TIMEOUT_SECONDS,
+                write_timeout=SERIAL_WRITE_TIMEOUT_SECONDS,
                 xonxoff=False,
                 rtscts=False,
                 dsrdtr=False,
@@ -324,13 +318,11 @@ class MKS902BDriver:
         wire_command = f"{command}\r\n"
         self._queue_log(f"TX {self._safe_log_text(wire_command)}", LogLevel.VERBOSE)
         self._serial.write(wire_command.encode("ascii"))
-        self._serial.flush()
 
-        deadline = time.monotonic() + RESPONSE_TIMEOUT_MS / 1000.0
+        deadline = time.monotonic() + RESPONSE_TIMEOUT_SECONDS
         last_unexpected = None
         while not self._stop_event.is_set():
             frame = self._read_frame(deadline)
-            self._queue_log(f"RX {self._safe_log_text(frame)}", LogLevel.VERBOSE)
             try:
                 address, response_type, payload = parse_response(frame)
             except MKS902BProtocolError as exc:
@@ -364,12 +356,13 @@ class MKS902BDriver:
 
             if time.monotonic() >= deadline:
                 raise MKS902BTimeoutError(
-                    f"Timed out after {RESPONSE_TIMEOUT_MS:g} ms waiting for ;FF"
+                    f"Timed out after {RESPONSE_TIMEOUT_SECONDS:g} seconds waiting for ;FF"
                 )
 
             bytes_waiting = self._serial.in_waiting
             chunk = self._serial.read(max(1, bytes_waiting))
             if chunk:
+                self._queue_log(f"RX {self._safe_log_text(chunk)}", LogLevel.VERBOSE)
                 self._receive_buffer.extend(chunk)
 
         raise MKS902BTimeoutError("Request stopped before a response was received")

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -14,11 +14,11 @@ from utils import LogLevel
 BAUDRATE = 115200
 SERIAL_READ_TIMEOUT_SECONDS = 0.01
 SERIAL_WRITE_TIMEOUT_SECONDS = 0.1
-RESPONSE_TIMEOUT_SECONDS = 0.1
-POLL_INTERVAL_SECONDS = 0.5
-POLL_RETRY_DELAY_SECONDS = 0.02
+RESPONSE_TIMEOUT_SECONDS = 0.5
+POLL_INTERVAL_SECONDS = 1.0
+POLL_RETRY_DELAY_SECONDS = 0.2
 POLL_ATTEMPTS = 3
-COMMUNICATION_LOSS_SECONDS = 5.0
+COMMUNICATION_LOSS_SECONDS = 10.0
 RECONNECT_INTERVAL_SECONDS = 5.0
 THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 DATA_QUEUE_MAXSIZE = 8
@@ -258,15 +258,10 @@ class MKS902BDriver:
         self._queue_log("902B initialization complete", LogLevel.INFO)
 
     def _poll_until_communication_loss(self):
-        """Poll on a 500 ms start-to-start schedule until five seconds are lost."""
+        """Wait one interval after each poll batch until communication is lost."""
         last_success = time.monotonic()
-        next_poll = last_success
 
         while not self._stop_event.is_set():
-            now = time.monotonic()
-            if now < next_poll and self._stop_event.wait(next_poll - now):
-                return
-
             if self._poll_pressure():
                 last_success = time.monotonic()
             elif time.monotonic() - last_success >= COMMUNICATION_LOSS_SECONDS:
@@ -276,11 +271,8 @@ class MKS902BDriver:
                 )
                 return
 
-            next_poll += POLL_INTERVAL_SECONDS
-            now = time.monotonic()
-            if next_poll <= now:
-                missed_intervals = math.floor((now - next_poll) / POLL_INTERVAL_SECONDS) + 1
-                next_poll += missed_intervals * POLL_INTERVAL_SECONDS
+            if self._stop_event.wait(POLL_INTERVAL_SECONDS):
+                return
 
     def _poll_pressure(self):
         """Try one PR4 polling group and publish a valid converted measurement."""

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -315,7 +315,12 @@ class MKS902BDriver:
         deadline = time.monotonic() + RESPONSE_TIMEOUT_SECONDS
         last_unexpected = None
         while not self._stop_event.is_set():
-            frame = self._read_frame(deadline)
+            try:
+                frame = self._read_frame(deadline)
+            except MKS902BTimeoutError as exc:
+                if last_unexpected is not None:
+                    raise MKS902BProtocolError(last_unexpected) from exc
+                raise
             try:
                 address, response_type, payload = parse_response(frame)
             except MKS902BProtocolError as exc:

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -118,15 +118,15 @@ class MKS902BDriver:
         if self._thread is not None and self._thread.is_alive():
             self._queue_log("902B worker did not stop before the join timeout", LogLevel.ERROR)
 
-    def flush_queued_logs(self, max_messages=200):
-        """Forward queued worker logs through the shared logger on the main thread."""
+    def flush_queued_logs(self, max_messages=200, max_level=None):
+        """Drain queued worker logs and forward messages at or below max_level."""
         if self.logger is None or threading.get_ident() != self._main_thread_id:
             return
 
         with self._dropped_log_lock:
             dropped_count = self._dropped_log_count
             self._dropped_log_count = 0
-        if dropped_count:
+        if dropped_count and (max_level is None or LogLevel.WARNING <= max_level):
             self.logger.log(
                 f"Dropped {dropped_count} queued 902B log message(s) because the queue was full",
                 LogLevel.WARNING,
@@ -138,6 +138,8 @@ class MKS902BDriver:
                 message, level = self._log_queue.get_nowait()
             except queue.Empty:
                 break
+            if max_level is not None and level > max_level:
+                continue
             self.logger.log(message, level, tag="902B")
 
     def _worker_loop(self):

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -308,7 +308,7 @@ class MKS902BDriver:
         if self._serial is None or not self._serial.is_open:
             raise MKS902BProtocolError("Serial port is not open")
 
-        wire_command = f"{command}\r\n"
+        wire_command = command
         self._queue_log(f"TX {self._safe_log_text(wire_command)}", LogLevel.VERBOSE)
         self._serial.write(wire_command.encode("ascii"))
 

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -23,7 +23,7 @@ RECONNECT_INTERVAL_SECONDS = 5.0
 THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 DATA_QUEUE_MAXSIZE = 8
 LOG_QUEUE_MAXSIZE = 1000
-FRAME_TERMINATOR = b";FF"
+RESPONSE_TERMINATOR = b";"
 SUPPORTED_BAUD_RATES = {4800, 9600, 19200, 38400, 57600, 115200, 230400}
 
 # Discover the model and responding device address using the reply-enabled broadcast address.
@@ -41,7 +41,7 @@ UNIT_TO_MBAR = {
     "PASCAL": 0.01,
 }
 
-_RESPONSE_RE = re.compile(r"^@(\d{3})(ACK|NAK)(.*);FF$")
+_RESPONSE_RE = re.compile(r"^@(\d{3})(ACK|NAK)(.*);(?:FF)?$")
 _SCIENTIFIC_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[Ee][+-]?\d+$")
 
 
@@ -300,6 +300,7 @@ class MKS902BDriver:
                     f"PR4 attempt {attempt}/{POLL_ATTEMPTS} failed: {type(exc).__name__}: {exc}",
                     LogLevel.DEBUG,
                 )
+                self._discard_invalid_response()
                 if attempt < POLL_ATTEMPTS and self._stop_event.wait(POLL_RETRY_DELAY_SECONDS):
                     return False
 
@@ -345,7 +346,7 @@ class MKS902BDriver:
         raise MKS902BTimeoutError("Request stopped before a response was received")
 
     def _read_frame(self, deadline):
-        """Read and return one ASCII frame terminated by the literal ;FF sequence."""
+        """Read and return one ASCII response ending at its semicolon."""
         while not self._stop_event.is_set():
             frame_bytes = self._extract_frame()
             if frame_bytes is not None:
@@ -356,7 +357,7 @@ class MKS902BDriver:
 
             if time.monotonic() >= deadline:
                 raise MKS902BTimeoutError(
-                    f"Timed out after {RESPONSE_TIMEOUT_SECONDS:g} seconds waiting for ;FF"
+                    f"Timed out after {RESPONSE_TIMEOUT_SECONDS:g} seconds waiting for ;"
                 )
 
             bytes_waiting = self._serial.in_waiting
@@ -369,18 +370,25 @@ class MKS902BDriver:
 
     def _extract_frame(self):
         """Remove and return the next complete frame from the receive buffer."""
-        terminator_index = self._receive_buffer.find(FRAME_TERMINATOR)
+        terminator_index = self._receive_buffer.find(RESPONSE_TERMINATOR)
         if terminator_index < 0:
             return None
 
-        frame_end = terminator_index + len(FRAME_TERMINATOR)
+        frame_end = terminator_index + len(RESPONSE_TERMINATOR)
         candidate = bytes(self._receive_buffer[:frame_end])
         del self._receive_buffer[:frame_end]
 
-        frame_start = candidate.find(b"@")
+        frame_start = candidate.rfind(b"@")
         if frame_start < 0:
             return candidate.strip()
         return candidate[frame_start:].strip()
+
+    def _discard_invalid_response(self):
+        """Discard a failed response so its bytes cannot contaminate a retry."""
+        self._receive_buffer.clear()
+        if self._serial is None or not self._serial.is_open:
+            return
+        self._serial.reset_input_buffer()
 
     def _put_latest_data(self, measurement):
         """Publish a measurement without allowing stale data to block the worker."""

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -32,8 +32,8 @@ COMMAND_MODEL_QUERY = "@254MD?;FF"
 COMMAND_BAUD_QUERY = "@{address:03d}BR?;FF"
 # Read the pressure unit currently configured on the transducer.
 COMMAND_UNIT_QUERY = "@{address:03d}U?;FF"
-# Read absolute Piezo pressure in scientific notation.
-COMMAND_PRESSURE_QUERY = "@{address:03d}PR4?;FF"
+# Read the absolute Piezo pressure as a decimal value.
+COMMAND_PRESSURE_QUERY = "@{address:03d}PR1?;FF"
 
 UNIT_TO_MBAR = {
     "MBAR": 1.0,
@@ -42,7 +42,7 @@ UNIT_TO_MBAR = {
 }
 
 _RESPONSE_RE = re.compile(r"^@(\d{3})(ACK|NAK)(.*);(?:FF)?$")
-_SCIENTIFIC_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[Ee][+-]?\d+$")
+_DECIMAL_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
 
 class MKS902BError(Exception):
@@ -277,21 +277,21 @@ class MKS902BDriver:
                 return
 
     def _poll_pressure(self):
-        """Try one PR4 polling group and publish a valid converted measurement."""
+        """Try one PR1 polling group and publish a valid converted measurement."""
         command = COMMAND_PRESSURE_QUERY.format(address=self._address)
         for attempt in range(1, POLL_ATTEMPTS + 1):
             try:
                 _, payload = self._request(command, expected_address=self._address)
-                if _SCIENTIFIC_RE.fullmatch(payload) is None:
+                if _DECIMAL_RE.fullmatch(payload) is None:
                     raise MKS902BProtocolError(
-                        f"PR4 did not return scientific notation: {payload!r}"
+                        f"PR1 did not return a decimal number: {payload!r}"
                     )
                 pressure_mbar = convert_pressure_to_mbar(float(payload), self._pressure_unit)
                 self._put_latest_data((time.time(), pressure_mbar))
                 return True
             except (MKS902BError, OSError, serial.SerialException) as exc:
                 self._queue_log(
-                    f"PR4 attempt {attempt}/{POLL_ATTEMPTS} failed: {type(exc).__name__}: {exc}",
+                    f"PR1 attempt {attempt}/{POLL_ATTEMPTS} failed: {type(exc).__name__}: {exc}",
                     LogLevel.DEBUG,
                 )
                 self._discard_invalid_response()
@@ -300,7 +300,7 @@ class MKS902BDriver:
 
         if not self._stop_event.is_set():
             self._queue_log(
-                f"PR4 pressure request failed after {POLL_ATTEMPTS} attempts",
+                f"PR1 pressure request failed after {POLL_ATTEMPTS} attempts",
                 LogLevel.ERROR,
             )
         return False

--- a/instrumentctl/mks_902b/mks_902b_driver.py
+++ b/instrumentctl/mks_902b/mks_902b_driver.py
@@ -1,0 +1,448 @@
+"""Threaded serial driver for an MKS 902B connected through a 900USB."""
+
+import math
+import queue
+import re
+import threading
+import time
+
+import serial
+
+from utils import LogLevel
+
+
+BAUDRATE = 115200
+SERIAL_READ_TIMEOUT_MS = 10
+SERIAL_WRITE_TIMEOUT_MS = 100
+RESPONSE_TIMEOUT_MS = 100
+POLL_INTERVAL_SECONDS = 0.5
+POLL_RETRY_DELAY_SECONDS = 0.02
+POLL_ATTEMPTS = 3
+COMMUNICATION_LOSS_SECONDS = 5.0
+RECONNECT_INTERVAL_SECONDS = 5.0
+THREAD_JOIN_TIMEOUT_MS = 2000
+DATA_QUEUE_MAXSIZE = 8
+LOG_QUEUE_MAXSIZE = 1000
+FRAME_TERMINATOR = b";FF"
+SUPPORTED_BAUD_RATES = {4800, 9600, 19200, 38400, 57600, 115200, 230400}
+
+# Discover the model and responding device address using the reply-enabled broadcast address.
+COMMAND_MODEL_QUERY = "@254MD?;FF"
+# Read the transducer-side communication baud rate.
+COMMAND_BAUD_QUERY = "@{address:03d}BR?;FF"
+# Read the pressure unit currently configured on the transducer.
+COMMAND_UNIT_QUERY = "@{address:03d}U?;FF"
+# Read absolute Piezo pressure in scientific notation.
+COMMAND_PRESSURE_QUERY = "@{address:03d}PR4?;FF"
+
+UNIT_TO_MBAR = {
+    "MBAR": 1.0,
+    "TORR": 1.333223684,
+    "PASCAL": 0.01,
+}
+MIN_PRESSURE_MBAR = 0.1 * UNIT_TO_MBAR["TORR"]
+MAX_PRESSURE_MBAR = 1000.0 * UNIT_TO_MBAR["TORR"]
+
+_RESPONSE_RE = re.compile(r"^@(\d{3})(ACK|NAK)(.*);FF$")
+_SCIENTIFIC_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[Ee][+-]?\d+$")
+
+
+class MKS902BError(Exception):
+    """Base error raised by the MKS 902B driver."""
+
+
+class MKS902BProtocolError(MKS902BError):
+    """Raised when a response violates the MKS 902B protocol."""
+
+
+class MKS902BTimeoutError(MKS902BError):
+    """Raised when a complete response does not arrive before the deadline."""
+
+
+def parse_response(frame):
+    """Return the address, response type, and payload from one 902B frame."""
+    match = _RESPONSE_RE.fullmatch(frame)
+    if match is None:
+        raise MKS902BProtocolError(f"Malformed response: {frame!r}")
+    return int(match.group(1)), match.group(2), match.group(3)
+
+
+def convert_pressure_to_mbar(pressure, unit):
+    """Convert a documented 902B pressure unit to mbar."""
+    try:
+        conversion_factor = UNIT_TO_MBAR[unit]
+    except KeyError as exc:
+        raise MKS902BProtocolError(f"Unsupported pressure unit: {unit!r}") from exc
+
+    pressure_mbar = pressure * conversion_factor
+    if not math.isfinite(pressure_mbar):
+        raise MKS902BProtocolError("Pressure is not finite")
+    if not MIN_PRESSURE_MBAR <= pressure_mbar <= MAX_PRESSURE_MBAR:
+        raise MKS902BProtocolError(
+            f"Pressure {pressure_mbar:.6g} mbar is outside the 902B measurement range"
+        )
+    return pressure_mbar
+
+
+class MKS902BDriver:
+    """Own the 902B serial connection and publish valid mbar measurements."""
+
+    def __init__(self, port, logger=None):
+        """Prepare a stopped driver for the selected 900USB COM port."""
+        self.port = str(port)
+        self.logger = logger
+        self.data_queue = queue.Queue(maxsize=DATA_QUEUE_MAXSIZE)
+        self._log_queue = queue.Queue(maxsize=LOG_QUEUE_MAXSIZE)
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._serial = None
+        self._receive_buffer = bytearray()
+        self._address = None
+        self._pressure_unit = None
+        self._main_thread_id = threading.get_ident()
+        self._dropped_log_count = 0
+        self._dropped_log_lock = threading.Lock()
+        self._has_connected = False
+
+    def start(self):
+        """Start the sole serial-owner worker if it is not already running."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._worker_loop,
+            name="MKS902BWorker",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self):
+        """Request worker shutdown and wait briefly without touching the serial port."""
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=THREAD_JOIN_TIMEOUT_MS / 1000.0)
+        if self._thread is not None and self._thread.is_alive():
+            self._queue_log("902B worker did not stop before the join timeout", LogLevel.ERROR)
+
+    def flush_queued_logs(self, max_messages=200):
+        """Forward queued worker logs through the shared logger on the main thread."""
+        if self.logger is None or threading.get_ident() != self._main_thread_id:
+            return
+
+        with self._dropped_log_lock:
+            dropped_count = self._dropped_log_count
+            self._dropped_log_count = 0
+        if dropped_count:
+            self.logger.log(
+                f"Dropped {dropped_count} queued 902B log message(s) because the queue was full",
+                LogLevel.WARNING,
+                tag="902B",
+            )
+
+        for _ in range(max_messages):
+            try:
+                message, level = self._log_queue.get_nowait()
+            except queue.Empty:
+                break
+            self.logger.log(message, level, tag="902B")
+
+    def _worker_loop(self):
+        """Connect, initialize, poll, and reconnect until shutdown is requested."""
+        self._queue_log(f"902B worker started for {self.port}", LogLevel.INFO)
+        try:
+            while not self._stop_event.is_set():
+                initialized = False
+                try:
+                    initialized = self._connect_and_initialize()
+                    if initialized:
+                        self._poll_until_communication_loss()
+                except Exception as exc:
+                    self._queue_log(
+                        f"Unexpected 902B communication failure: {type(exc).__name__}: {exc}",
+                        LogLevel.ERROR,
+                    )
+                finally:
+                    self._close_serial()
+
+                if self._stop_event.is_set():
+                    break
+                if initialized:
+                    self._queue_log(
+                        f"902B disconnected; retrying {self.port} in {RECONNECT_INTERVAL_SECONDS:g} seconds",
+                        LogLevel.ERROR,
+                    )
+                if self._stop_event.wait(RECONNECT_INTERVAL_SECONDS):
+                    break
+        finally:
+            self._close_serial()
+            self._queue_log("902B worker stopped", LogLevel.INFO)
+
+    def _connect_and_initialize(self):
+        """Open the port and complete all read-only initialization queries."""
+        try:
+            self._serial = serial.Serial(
+                port=self.port,
+                baudrate=BAUDRATE,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=SERIAL_READ_TIMEOUT_MS / 1000.0,
+                write_timeout=SERIAL_WRITE_TIMEOUT_MS / 1000.0,
+                xonxoff=False,
+                rtscts=False,
+                dsrdtr=False,
+            )
+            self._receive_buffer.clear()
+            self._address = None
+            self._pressure_unit = None
+            self._queue_log(f"Opened 902B serial connection on {self.port}", LogLevel.INFO)
+            self._initialize_transducer()
+        except Exception as exc:
+            self._queue_log(
+                f"Failed to initialize 902B on {self.port}: {type(exc).__name__}: {exc}",
+                LogLevel.ERROR,
+            )
+            return False
+
+        connection_message = "Reconnected to" if self._has_connected else "Connected to"
+        self._has_connected = True
+        self._queue_log(
+            f"{connection_message} 902B at address {self._address:03d} on {self.port}",
+            LogLevel.INFO,
+        )
+        return True
+
+    def _initialize_transducer(self):
+        """Discover the transducer and read its baud rate and pressure unit."""
+        model_address, model = self._request(COMMAND_MODEL_QUERY, expected_address=None)
+        if model != "902B" or not 1 <= model_address <= 253:
+            raise MKS902BProtocolError(
+                f"Expected a 902B at address 001-253, received address {model_address:03d} model {model!r}"
+            )
+        self._address = model_address
+        self._queue_log(
+            f"Detected 902B model at address {self._address:03d}",
+            LogLevel.INFO,
+        )
+
+        _, baud_payload = self._request(
+            COMMAND_BAUD_QUERY.format(address=self._address),
+            expected_address=self._address,
+        )
+        try:
+            transducer_baud = int(baud_payload)
+        except ValueError as exc:
+            raise MKS902BProtocolError(f"Invalid baud-rate response: {baud_payload!r}") from exc
+        if transducer_baud not in SUPPORTED_BAUD_RATES:
+            raise MKS902BProtocolError(f"Unsupported transducer baud rate: {transducer_baud}")
+        self._queue_log(
+            f"902B transducer-side baud rate: {transducer_baud}",
+            LogLevel.INFO,
+        )
+        if transducer_baud > 19200:
+            self._queue_log(
+                f"902B transducer-side baud rate {transducer_baud} exceeds the known reliable 900USB range",
+                LogLevel.WARNING,
+            )
+
+        _, unit_payload = self._request(
+            COMMAND_UNIT_QUERY.format(address=self._address),
+            expected_address=self._address,
+        )
+        pressure_unit = unit_payload.upper()
+        if pressure_unit not in UNIT_TO_MBAR:
+            raise MKS902BProtocolError(f"Unsupported pressure unit: {unit_payload!r}")
+        self._pressure_unit = pressure_unit
+        if pressure_unit == "MBAR":
+            unit_message = "902B pressure unit: MBAR"
+        else:
+            unit_message = (
+                f"902B pressure unit: {pressure_unit}; dashboard will convert "
+                f"{pressure_unit} to mbar"
+            )
+        self._queue_log(unit_message, LogLevel.INFO)
+        self._queue_log("902B initialization complete", LogLevel.INFO)
+
+    def _poll_until_communication_loss(self):
+        """Poll on a 500 ms start-to-start schedule until five seconds are lost."""
+        last_success = time.monotonic()
+        next_poll = last_success
+
+        while not self._stop_event.is_set():
+            now = time.monotonic()
+            if now < next_poll and self._stop_event.wait(next_poll - now):
+                return
+
+            if self._poll_pressure():
+                last_success = time.monotonic()
+            elif time.monotonic() - last_success >= COMMUNICATION_LOSS_SECONDS:
+                self._queue_log(
+                    f"No valid 902B pressure response for {COMMUNICATION_LOSS_SECONDS:g} seconds",
+                    LogLevel.ERROR,
+                )
+                return
+
+            next_poll += POLL_INTERVAL_SECONDS
+            now = time.monotonic()
+            if next_poll <= now:
+                missed_intervals = math.floor((now - next_poll) / POLL_INTERVAL_SECONDS) + 1
+                next_poll += missed_intervals * POLL_INTERVAL_SECONDS
+
+    def _poll_pressure(self):
+        """Try one PR4 polling group and publish a valid converted measurement."""
+        command = COMMAND_PRESSURE_QUERY.format(address=self._address)
+        for attempt in range(1, POLL_ATTEMPTS + 1):
+            try:
+                _, payload = self._request(command, expected_address=self._address)
+                if _SCIENTIFIC_RE.fullmatch(payload) is None:
+                    raise MKS902BProtocolError(
+                        f"PR4 did not return scientific notation: {payload!r}"
+                    )
+                pressure_mbar = convert_pressure_to_mbar(float(payload), self._pressure_unit)
+                self._put_latest_data((time.time(), pressure_mbar))
+                return True
+            except (MKS902BError, OSError, serial.SerialException) as exc:
+                self._queue_log(
+                    f"PR4 attempt {attempt}/{POLL_ATTEMPTS} failed: {type(exc).__name__}: {exc}",
+                    LogLevel.DEBUG,
+                )
+                if attempt < POLL_ATTEMPTS and self._stop_event.wait(POLL_RETRY_DELAY_SECONDS):
+                    return False
+
+        if not self._stop_event.is_set():
+            self._queue_log(
+                f"PR4 pressure request failed after {POLL_ATTEMPTS} attempts",
+                LogLevel.ERROR,
+            )
+        return False
+
+    def _request(self, command, expected_address):
+        """Send one command and return the matching ACK address and payload."""
+        if self._serial is None or not self._serial.is_open:
+            raise MKS902BProtocolError("Serial port is not open")
+
+        wire_command = f"{command}\r\n"
+        self._queue_log(f"TX {self._safe_log_text(wire_command)}", LogLevel.VERBOSE)
+        self._serial.write(wire_command.encode("ascii"))
+        self._serial.flush()
+
+        deadline = time.monotonic() + RESPONSE_TIMEOUT_MS / 1000.0
+        last_unexpected = None
+        while not self._stop_event.is_set():
+            frame = self._read_frame(deadline)
+            self._queue_log(f"RX {self._safe_log_text(frame)}", LogLevel.VERBOSE)
+            try:
+                address, response_type, payload = parse_response(frame)
+            except MKS902BProtocolError as exc:
+                last_unexpected = str(exc)
+                self._queue_log(last_unexpected, LogLevel.DEBUG)
+                continue
+
+            if expected_address is not None and address != expected_address:
+                last_unexpected = (
+                    f"Expected response from address {expected_address:03d}, received {address:03d}"
+                )
+                self._queue_log(last_unexpected, LogLevel.DEBUG)
+                continue
+            if response_type == "NAK":
+                raise MKS902BProtocolError(f"902B returned NAK {payload}")
+            return address, payload
+
+        if last_unexpected is not None:
+            raise MKS902BProtocolError(last_unexpected)
+        raise MKS902BTimeoutError("Request stopped before a response was received")
+
+    def _read_frame(self, deadline):
+        """Read and return one ASCII frame terminated by the literal ;FF sequence."""
+        while not self._stop_event.is_set():
+            frame_bytes = self._extract_frame()
+            if frame_bytes is not None:
+                try:
+                    return frame_bytes.decode("ascii")
+                except UnicodeDecodeError as exc:
+                    raise MKS902BProtocolError("Response contained non-ASCII data") from exc
+
+            if time.monotonic() >= deadline:
+                raise MKS902BTimeoutError(
+                    f"Timed out after {RESPONSE_TIMEOUT_MS:g} ms waiting for ;FF"
+                )
+
+            bytes_waiting = self._serial.in_waiting
+            chunk = self._serial.read(max(1, bytes_waiting))
+            if chunk:
+                self._receive_buffer.extend(chunk)
+
+        raise MKS902BTimeoutError("Request stopped before a response was received")
+
+    def _extract_frame(self):
+        """Remove and return the next complete frame from the receive buffer."""
+        terminator_index = self._receive_buffer.find(FRAME_TERMINATOR)
+        if terminator_index < 0:
+            return None
+
+        frame_end = terminator_index + len(FRAME_TERMINATOR)
+        candidate = bytes(self._receive_buffer[:frame_end])
+        del self._receive_buffer[:frame_end]
+
+        frame_start = candidate.find(b"@")
+        if frame_start < 0:
+            return candidate.strip()
+        return candidate[frame_start:].strip()
+
+    def _put_latest_data(self, measurement):
+        """Publish a measurement without allowing stale data to block the worker."""
+        try:
+            self.data_queue.put_nowait(measurement)
+            return
+        except queue.Full:
+            pass
+
+        try:
+            self.data_queue.get_nowait()
+        except queue.Empty:
+            pass
+        self.data_queue.put_nowait(measurement)
+
+    def _queue_log(self, message, level):
+        """Queue a log without blocking serial communication."""
+        try:
+            self._log_queue.put_nowait((message, level))
+            return
+        except queue.Full:
+            pass
+
+        try:
+            self._log_queue.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            with self._dropped_log_lock:
+                self._dropped_log_count += 1
+
+        try:
+            self._log_queue.put_nowait((message, level))
+        except queue.Full:
+            with self._dropped_log_lock:
+                self._dropped_log_count += 1
+
+    def _close_serial(self):
+        """Close and discard the worker-owned serial connection."""
+        serial_connection = self._serial
+        self._serial = None
+        self._receive_buffer.clear()
+        self._address = None
+        self._pressure_unit = None
+        if serial_connection is None:
+            return
+        try:
+            serial_connection.close()
+        except Exception as exc:
+            self._queue_log(
+                f"Failed to close 902B serial connection: {type(exc).__name__}: {exc}",
+                LogLevel.ERROR,
+            )
+
+    @staticmethod
+    def _safe_log_text(value):
+        """Escape control and non-ASCII characters for one-line serial logs."""
+        return str(value).encode("unicode_escape", "backslashreplace").decode("ascii")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ from utils import Logger, LogLevel
 
 
 SUBSYSTEMS = [
-    'VTRXSubsystem', 
+    'VTRXSubsystem',
+    '902B',
     'CathodeA PS', 
     'CathodeB PS', 
     'CathodeC PS', 

--- a/subsystem/vtrx/README.md
+++ b/subsystem/vtrx/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-The VTRX (Vacuum Electronics) subsystem provides real-time monitoring and visualization of vacuum system pressure and component states. It interfaces with a microcontroller in the VTRX system and uses serial communication to track pressure readings, valve states, and system safety conditions.
+The VTRX (Vacuum Electronics) subsystem provides real-time monitoring and visualization of vacuum system pressure and component states. It interfaces with a microcontroller in the VTRX system and uses serial communication to track 972B pressure readings, valve states, and system safety conditions. It also consumes 902B readings from the separate MKS driver for remote logging.
 
 ## Key Components
 ### Hardware Interface
 - Serial COM with VTRX chassis
 - 9600 baud
+- MKS 902B measurements supplied by `MKS902BDriver`
 
 ### Input serial Data Packet
 Parser expects semicolon-separated string containing at least three fields:
@@ -22,10 +23,20 @@ The subsystem maintains a rolling buffer of pressure readings with the following
 - Data points are automatically trimmed beyond this window
 
 ### GUI Elements
-- Real-time pressure plotting with configurable time window
+- Real-time 972B and 902B pressure displays
+- 972B pressure plotting with configurable time window
 - State indicator lights for system switches
 - Error state visualization
 - Plot save functionality with automatic timestamping
+
+### 902B publication
+- Fresh 902B measurements are published to the Web Monitor log and Supabase.
+- A fresh, valid 972B pressure strictly below `1.0 mbar` suppresses 902B publication and clears the published value to `null`.
+- A 972B pressure at or above `1.0 mbar` permits publication.
+- A stale, disconnected, malformed, or otherwise unavailable 972B does not suppress an independently fresh 902B measurement.
+- 902B measurements retain their own six-second freshness limit and are cleared when stale.
+- The local 902B pressure box is hidden only while 902B publication is suppressed by a confirmed low 972B pressure.
+- While the 902B box is hidden, the 972B label and pressure box are centered; the two-sensor layout returns when suppression ends.
 
 Flowchart: 
 ```mermaid

--- a/subsystem/vtrx/README.md
+++ b/subsystem/vtrx/README.md
@@ -24,7 +24,8 @@ The subsystem maintains a rolling buffer of pressure readings with the following
 
 ### GUI Elements
 - Real-time 972B and 902B pressure displays
-- 972B pressure plotting with configurable time window
+- 972B and 902B pressure plotting with a shared configurable time window
+- Combined visible-data pressure bounds and a permanent sensor legend
 - State indicator lights for system switches
 - Error state visualization
 - Plot save functionality with automatic timestamping
@@ -37,6 +38,13 @@ The subsystem maintains a rolling buffer of pressure readings with the following
 - 902B measurements retain their own six-second freshness limit and are cleared when stale.
 - The local 902B pressure box is hidden only while 902B publication is suppressed by a confirmed low 972B pressure.
 - While the 902B box is hidden, the 972B label and pressure box are centered; the two-sensor layout returns when suppression ends.
+
+### 902B graphing
+- Every unsuppressed 902B queue item is plotted at the acquisition timestamp carried by that item.
+- The latest item in each queue batch supplies the current 902B pressure display.
+- Suppressed queue items are not added to graph history; points accepted before suppression remain until they leave the selected time window.
+- The first accepted point after suppression begins a new indigo line segment so the suppressed interval remains visible as a gap.
+- The Y-axis bounds include all positive 972B and 902B values visible in the selected time window.
 
 Flowchart: 
 ```mermaid

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -31,6 +31,7 @@ class VTRXSubsystem:
     NO_DATA_LOG_INTERVAL_SECONDS = 10
     SERIAL_DATA_MAX_ATTEMPTS = 3
     PRESSURE_READING_FRESH_SECONDS = 3.0
+    PRESSURE_902B_READING_FRESH_SECONDS = 6.0
     WARNING_ERROR_CODES = {13, 14, 15, 16}
 
     ERROR_CODES = {
@@ -258,7 +259,8 @@ class VTRXSubsystem:
 
         if (
             self.last_valid_902b_timestamp is None
-            or time.time() - self.last_valid_902b_timestamp > self.PRESSURE_READING_FRESH_SECONDS
+            or time.time() - self.last_valid_902b_timestamp
+            > self.PRESSURE_902B_READING_FRESH_SECONDS
         ):
             self.label_902b_pressure.config(text="No data...", bg="white", fg="black")
             if not self._902b_webmonitor_cleared:

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -322,6 +322,16 @@ class VTRXSubsystem:
         if suppressed == self._902b_widget_suppressed:
             return
         self._902b_widget_suppressed = suppressed
+        if suppressed:
+            self.log(
+                "972B reached a pressure below 1mbar: Disabling 902B display data",
+                LogLevel.INFO,
+            )
+        else:
+            self.log(
+                "972B reached a pressure of/above 1mbar: Enabling 902B display data",
+                LogLevel.INFO,
+            )
 
         pressure_frame = getattr(self, "pressure_frame", None)
         if pressure_frame is None:

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -329,7 +329,7 @@ class VTRXSubsystem:
             )
         else:
             self.log(
-                "972B reached a pressure of/above 1mbar: Enabling 902B display data",
+                "972B reached a pressure of 1mbar: Enabling 902B display data",
                 LogLevel.INFO,
             )
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -53,11 +53,19 @@ class VTRXSubsystem:
         16: "UNSAFE FOR HV WARNING"
     }
 
-    def __init__(self, parent, serial_port='COM7', baud_rate=9600, logger=None):
+    def __init__(
+        self,
+        parent,
+        serial_port='COM7',
+        baud_rate=9600,
+        logger=None,
+        mks_902b_driver=None,
+    ):
         self.parent = parent
         self.serial_port = serial_port
         self.baud_rate = baud_rate
         self.logger = logger
+        self.mks_902b_driver = mks_902b_driver
         self.data_queue = queue.Queue()
         self._main_thread_id = threading.get_ident()
         self._background_log_queue = queue.SimpleQueue()
@@ -80,6 +88,9 @@ class VTRXSubsystem:
         self.last_data_received_time = time.time()
         self.last_successful_read_time = None
         self.last_valid_pressure_value = None
+        self.latest_902b_pressure_mbar = None
+        self.last_valid_902b_timestamp = None
+        self._902b_webmonitor_cleared = True
         self.last_gui_update_time = time.time()
         self.after_id = None
         self._serial_data_failure_count = 0
@@ -215,9 +226,45 @@ class VTRXSubsystem:
         except queue.Empty:
             pass
         finally:
+            self._process_902b_data()
             self.flush_queued_logs()
+            if self.mks_902b_driver is not None:
+                self.mks_902b_driver.flush_queued_logs()
             self._update_main_control()
             self.after_id = self.parent.after(500, self.process_queue)
+
+    def _process_902b_data(self):
+        """Display and publish the newest queued 902B measurement, if fresh."""
+        latest_measurement = None
+        if self.mks_902b_driver is not None:
+            while True:
+                try:
+                    latest_measurement = self.mks_902b_driver.data_queue.get_nowait()
+                except queue.Empty:
+                    break
+
+        if latest_measurement is not None:
+            timestamp, pressure_mbar = latest_measurement
+            self.last_valid_902b_timestamp = timestamp
+            self.latest_902b_pressure_mbar = pressure_mbar
+            self.label_902b_pressure.config(
+                text=f"{pressure_mbar:.3E} mbar",
+                bg="white",
+                fg="black",
+            )
+            if self.logger is not None:
+                self.logger.update_field("pressure_902b_mbar", pressure_mbar)
+            self._902b_webmonitor_cleared = False
+
+        if (
+            self.last_valid_902b_timestamp is None
+            or time.time() - self.last_valid_902b_timestamp > self.PRESSURE_READING_FRESH_SECONDS
+        ):
+            self.label_902b_pressure.config(text="No data...", bg="white", fg="black")
+            if not self._902b_webmonitor_cleared:
+                if self.logger is not None:
+                    self.logger.clear_value("pressure_902b_mbar")
+                self._902b_webmonitor_cleared = True
 
     def _pressure_reading_is_fresh(self):
         last_successful_read_time = getattr(self, "last_successful_read_time", None)
@@ -540,7 +587,15 @@ class VTRXSubsystem:
         # Pressure label setup
         pressure_frame = tk.Frame(layout_frame)
         pressure_frame.grid(row=1, column=1, sticky='ew', padx=(4, 6), pady=(2, 1))
-        pressure_frame.grid_columnconfigure(0, weight=1)
+        pressure_frame.grid_columnconfigure(1, weight=1)
+        pressure_frame.grid_columnconfigure(3, weight=1)
+
+        label_972b_title = tk.Label(
+            pressure_frame,
+            text="972B:",
+            font=('Helvetica', 10, 'bold'),
+        )
+        label_972b_title.grid(row=0, column=0, padx=(0, 4))
 
         self.label_pressure = tk.Label(
             pressure_frame,
@@ -552,7 +607,27 @@ class VTRXSubsystem:
             fg='black', 
             padx=3, pady=2
         )
-        self.label_pressure.grid(row=0, column=0, ipady=2)
+        self.label_pressure.grid(row=0, column=1, sticky='ew', ipady=2)
+
+        label_902b_title = tk.Label(
+            pressure_frame,
+            text="902B:",
+            font=('Helvetica', 10, 'bold'),
+        )
+        label_902b_title.grid(row=0, column=2, padx=(12, 4))
+
+        self.label_902b_pressure = tk.Label(
+            pressure_frame,
+            text="No data...",
+            anchor='center',
+            font=('Helvetica', 11, 'bold'),
+            relief='ridge',
+            bg='white',
+            fg='black',
+            padx=3,
+            pady=2,
+        )
+        self.label_902b_pressure.grid(row=0, column=3, sticky='ew', ipady=2)
      
     def update_gui(self, pressure_value, pressure_raw, switch_states):
         """

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -340,6 +340,7 @@ class VTRXSubsystem:
         if suppressed:
             self.label_902b_title.grid_remove()
             self.label_902b_pressure.grid_remove()
+            self.label_972b_title.config(text="972B Pressure:")
             pressure_frame.grid_columnconfigure(0, weight=1)
             pressure_frame.grid_columnconfigure(1, weight=0)
             pressure_frame.grid_columnconfigure(2, weight=0)
@@ -351,6 +352,7 @@ class VTRXSubsystem:
             pressure_frame.grid_columnconfigure(1, weight=1)
             pressure_frame.grid_columnconfigure(2, weight=0)
             pressure_frame.grid_columnconfigure(3, weight=1)
+            self.label_972b_title.config(text="972B:")
             self.label_972b_title.grid_configure(column=0)
             self.label_pressure.grid_configure(column=1, sticky='ew')
             self.label_902b_title.grid()

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -231,8 +231,7 @@ class VTRXSubsystem:
         finally:
             self._process_902b_data()
             self.flush_queued_logs()
-            if self.mks_902b_driver is not None:
-                self.mks_902b_driver.flush_queued_logs()
+            self._flush_902b_logs()
             self._update_main_control()
             self.after_id = self.parent.after(500, self.process_queue)
 
@@ -287,6 +286,15 @@ class VTRXSubsystem:
             and pressure_972b is not None
             and pressure_972b < self.PRESSURE_902B_MIN_VALID_972B_MBAR
         )
+
+    def _flush_902b_logs(self):
+        """Drain 902B logs while hiding operational severities during suppression."""
+        if self.mks_902b_driver is None:
+            return
+        if self._should_suppress_902b_publication():
+            self.mks_902b_driver.flush_queued_logs(max_level=LogLevel.DEBUG)
+            return
+        self.mks_902b_driver.flush_queued_logs()
 
     def _clear_902b_publication(self):
         if self._902b_webmonitor_cleared:

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -310,8 +310,8 @@ class VTRXSubsystem:
         if pressure_mbar is None:
             display_text = "No data..."
         else:
-            mantissa, exponent = f"{pressure_mbar:.3E}".split("E")
-            display_text = f"{mantissa}E{int(exponent):+d} mbar"
+            mantissa, exponent = f"{pressure_mbar:.2E}".split("E")
+            display_text = f"{mantissa}e{int(exponent):+d} mbar"
         label.config(
             text=display_text,
             bg="white",

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -307,8 +307,13 @@ class VTRXSubsystem:
         label = getattr(self, "label_902b_pressure", None)
         if label is None:
             return
+        if pressure_mbar is None:
+            display_text = "No data..."
+        else:
+            mantissa, exponent = f"{pressure_mbar:.3E}".split("E")
+            display_text = f"{mantissa}E{int(exponent):+d} mbar"
         label.config(
-            text="No data..." if pressure_mbar is None else f"{pressure_mbar:.3E} mbar",
+            text=display_text,
             bg="white",
             fg="black",
         )

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -32,6 +32,7 @@ class VTRXSubsystem:
     SERIAL_DATA_MAX_ATTEMPTS = 3
     PRESSURE_READING_FRESH_SECONDS = 3.0
     PRESSURE_902B_READING_FRESH_SECONDS = 6.0
+    PRESSURE_902B_MIN_VALID_972B_MBAR = 1.0
     WARNING_ERROR_CODES = {13, 14, 15, 16}
 
     ERROR_CODES = {
@@ -92,6 +93,7 @@ class VTRXSubsystem:
         self.latest_902b_pressure_mbar = None
         self.last_valid_902b_timestamp = None
         self._902b_webmonitor_cleared = True
+        self._902b_widget_suppressed = False
         self.last_gui_update_time = time.time()
         self.after_id = None
         self._serial_data_failure_count = 0
@@ -235,7 +237,7 @@ class VTRXSubsystem:
             self.after_id = self.parent.after(500, self.process_queue)
 
     def _process_902b_data(self):
-        """Display and publish the newest queued 902B measurement, if fresh."""
+        """Retain the newest queued 902B measurement and publish it when valid."""
         latest_measurement = None
         if self.mks_902b_driver is not None:
             while True:
@@ -248,25 +250,88 @@ class VTRXSubsystem:
             timestamp, pressure_mbar = latest_measurement
             self.last_valid_902b_timestamp = timestamp
             self.latest_902b_pressure_mbar = pressure_mbar
-            self.label_902b_pressure.config(
-                text=f"{pressure_mbar:.3E} mbar",
-                bg="white",
-                fg="black",
-            )
+
+        suppress_902b = self._should_suppress_902b_publication()
+        self._set_902b_widget_suppressed(suppress_902b)
+
+        if not self._902b_reading_is_fresh():
+            self._set_902b_pressure_display(None)
+            self._clear_902b_publication()
+            return
+
+        self._set_902b_pressure_display(self.latest_902b_pressure_mbar)
+        if suppress_902b:
+            self._clear_902b_publication()
+            return
+
+        if latest_measurement is not None or self._902b_webmonitor_cleared:
             if self.logger is not None:
-                self.logger.update_field("pressure_902b_mbar", pressure_mbar)
+                self.logger.update_field(
+                    "pressure_902b_mbar",
+                    self.latest_902b_pressure_mbar,
+                )
             self._902b_webmonitor_cleared = False
 
-        if (
-            self.last_valid_902b_timestamp is None
-            or time.time() - self.last_valid_902b_timestamp
-            > self.PRESSURE_902B_READING_FRESH_SECONDS
-        ):
-            self.label_902b_pressure.config(text="No data...", bg="white", fg="black")
-            if not self._902b_webmonitor_cleared:
-                if self.logger is not None:
-                    self.logger.clear_value("pressure_902b_mbar")
-                self._902b_webmonitor_cleared = True
+    def _902b_reading_is_fresh(self):
+        return (
+            self.last_valid_902b_timestamp is not None
+            and time.time() - self.last_valid_902b_timestamp
+            <= self.PRESSURE_902B_READING_FRESH_SECONDS
+        )
+
+    def _should_suppress_902b_publication(self):
+        pressure_972b = getattr(self, "last_valid_pressure_value", None)
+        return (
+            not getattr(self, "error_state", False)
+            and self._pressure_reading_is_fresh()
+            and pressure_972b is not None
+            and pressure_972b < self.PRESSURE_902B_MIN_VALID_972B_MBAR
+        )
+
+    def _clear_902b_publication(self):
+        if self._902b_webmonitor_cleared:
+            return
+        if self.logger is not None:
+            self.logger.clear_value("pressure_902b_mbar")
+        self._902b_webmonitor_cleared = True
+
+    def _set_902b_pressure_display(self, pressure_mbar):
+        label = getattr(self, "label_902b_pressure", None)
+        if label is None:
+            return
+        label.config(
+            text="No data..." if pressure_mbar is None else f"{pressure_mbar:.3E} mbar",
+            bg="white",
+            fg="black",
+        )
+
+    def _set_902b_widget_suppressed(self, suppressed):
+        if suppressed == self._902b_widget_suppressed:
+            return
+        self._902b_widget_suppressed = suppressed
+
+        pressure_frame = getattr(self, "pressure_frame", None)
+        if pressure_frame is None:
+            return
+
+        if suppressed:
+            self.label_902b_title.grid_remove()
+            self.label_902b_pressure.grid_remove()
+            pressure_frame.grid_columnconfigure(0, weight=1)
+            pressure_frame.grid_columnconfigure(1, weight=0)
+            pressure_frame.grid_columnconfigure(2, weight=0)
+            pressure_frame.grid_columnconfigure(3, weight=1)
+            self.label_972b_title.grid_configure(column=1)
+            self.label_pressure.grid_configure(column=2, sticky='')
+        else:
+            pressure_frame.grid_columnconfigure(0, weight=0)
+            pressure_frame.grid_columnconfigure(1, weight=1)
+            pressure_frame.grid_columnconfigure(2, weight=0)
+            pressure_frame.grid_columnconfigure(3, weight=1)
+            self.label_972b_title.grid_configure(column=0)
+            self.label_pressure.grid_configure(column=1, sticky='ew')
+            self.label_902b_title.grid()
+            self.label_902b_pressure.grid()
 
     def _pressure_reading_is_fresh(self):
         last_successful_read_time = getattr(self, "last_successful_read_time", None)
@@ -430,6 +495,10 @@ class VTRXSubsystem:
                 self.last_no_data_log_time = 0.0
                 self.last_successful_read_time = time.time()
                 self.last_valid_pressure_value = pressure_value
+                suppress_902b = self._should_suppress_902b_publication()
+                self._set_902b_widget_suppressed(suppress_902b)
+                if suppress_902b:
+                    self._clear_902b_publication()
                 self.update_gui(pressure_value, pressure_raw, switch_states)
             else:
                 self.update_gui_with_error_state()
@@ -587,20 +656,20 @@ class VTRXSubsystem:
         self.canvas_widget.pack(fill=tk.BOTH, expand=True, padx=4, pady=3)
 
         # Pressure label setup
-        pressure_frame = tk.Frame(layout_frame)
-        pressure_frame.grid(row=1, column=1, sticky='ew', padx=(4, 6), pady=(2, 1))
-        pressure_frame.grid_columnconfigure(1, weight=1)
-        pressure_frame.grid_columnconfigure(3, weight=1)
+        self.pressure_frame = tk.Frame(layout_frame)
+        self.pressure_frame.grid(row=1, column=1, sticky='ew', padx=(4, 6), pady=(2, 1))
+        self.pressure_frame.grid_columnconfigure(1, weight=1)
+        self.pressure_frame.grid_columnconfigure(3, weight=1)
 
-        label_972b_title = tk.Label(
-            pressure_frame,
+        self.label_972b_title = tk.Label(
+            self.pressure_frame,
             text="972B:",
             font=('Helvetica', 10, 'bold'),
         )
-        label_972b_title.grid(row=0, column=0, padx=(0, 4))
+        self.label_972b_title.grid(row=0, column=0, padx=(0, 4))
 
         self.label_pressure = tk.Label(
-            pressure_frame,
+            self.pressure_frame,
             text="No data...", 
             anchor='center',
             font=('Helvetica', 11, 'bold'), 
@@ -611,15 +680,15 @@ class VTRXSubsystem:
         )
         self.label_pressure.grid(row=0, column=1, sticky='ew', ipady=2)
 
-        label_902b_title = tk.Label(
-            pressure_frame,
+        self.label_902b_title = tk.Label(
+            self.pressure_frame,
             text="902B:",
             font=('Helvetica', 10, 'bold'),
         )
-        label_902b_title.grid(row=0, column=2, padx=(12, 4))
+        self.label_902b_title.grid(row=0, column=2, padx=(12, 4))
 
         self.label_902b_pressure = tk.Label(
-            pressure_frame,
+            self.pressure_frame,
             text="No data...",
             anchor='center',
             font=('Helvetica', 11, 'bold'),

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -9,10 +9,12 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from tkinter import ttk
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+from matplotlib.lines import Line2D
 import time
 import os
 import sys
 import queue
+import math
 
 def resource_path(relative_path):
     """ Get the absolute path to a resource, works for development and when running as bundled executable"""
@@ -33,6 +35,7 @@ class VTRXSubsystem:
     PRESSURE_READING_FRESH_SECONDS = 3.0
     PRESSURE_902B_READING_FRESH_SECONDS = 6.0
     PRESSURE_902B_MIN_VALID_972B_MBAR = 1.0
+    PRESSURE_902B_PLOT_COLOR = "#4B0082"
     WARNING_ERROR_CODES = {13, 14, 15, 16}
 
     ERROR_CODES = {
@@ -78,6 +81,11 @@ class VTRXSubsystem:
         self.full_history_y = []    # Complete pressure history
         self.x_data = []            # Display window data
         self.y_data = []            # Display window data
+        self.full_history_902b_x = []
+        self.full_history_902b_y = []
+        self.x_data_902b = []
+        self.y_data_902b = []
+        self._902b_plot_gap_pending = False
         self.display_window = 300   # Default 5 minutes
 
         self.circle_indicators = []
@@ -96,6 +104,7 @@ class VTRXSubsystem:
         self._902b_widget_suppressed = False
         self.last_gui_update_time = time.time()
         self.after_id = None
+        self._closing = False
         self._serial_data_failure_count = 0
 
         self.setup_serial()
@@ -218,6 +227,10 @@ class VTRXSubsystem:
 
         After processing all items, reschedules itself to run again after 500 ms.
         """
+        self.after_id = None
+        if self._closing:
+            return
+
         try:
             self.flush_queued_logs()
             while True:
@@ -229,22 +242,28 @@ class VTRXSubsystem:
         except queue.Empty:
             pass
         finally:
+            if self._closing:
+                return
             self._process_902b_data()
             self.flush_queued_logs()
             self._flush_902b_logs()
             self._update_main_control()
-            self.after_id = self.parent.after(500, self.process_queue)
+            if not self._closing:
+                self.after_id = self.parent.after(500, self.process_queue)
 
     def _process_902b_data(self):
-        """Retain the newest queued 902B measurement and publish it when valid."""
-        latest_measurement = None
+        """Consume queued 902B measurements, retaining their acquisition times."""
+        measurements = []
         if self.mks_902b_driver is not None:
             while True:
                 try:
-                    latest_measurement = self.mks_902b_driver.data_queue.get_nowait()
+                    measurements.append(
+                        self.mks_902b_driver.data_queue.get_nowait()
+                    )
                 except queue.Empty:
                     break
 
+        latest_measurement = measurements[-1] if measurements else None
         if latest_measurement is not None:
             timestamp, pressure_mbar = latest_measurement
             self.last_valid_902b_timestamp = timestamp
@@ -252,6 +271,14 @@ class VTRXSubsystem:
 
         suppress_902b = self._should_suppress_902b_publication()
         self._set_902b_widget_suppressed(suppress_902b)
+
+        if measurements and not suppress_902b:
+            self._append_902b_graph_measurements(measurements)
+            self._refresh_display_data(
+                datetime.datetime.fromtimestamp(time.time())
+            )
+            if hasattr(self, "line_902b") and hasattr(self, "canvas"):
+                self.update_plot()
 
         if not self._902b_reading_is_fresh():
             self._set_902b_pressure_display(None)
@@ -270,6 +297,78 @@ class VTRXSubsystem:
                     self.latest_902b_pressure_mbar,
                 )
             self._902b_webmonitor_cleared = False
+
+    def _append_902b_graph_measurements(self, measurements):
+        """Append valid, unsuppressed samples using their queued timestamps."""
+        if not measurements:
+            return
+
+        if self._902b_plot_gap_pending:
+            gap_time = datetime.datetime.fromtimestamp(measurements[0][0])
+            self.full_history_902b_x.append(gap_time)
+            self.full_history_902b_y.append(math.nan)
+            self._902b_plot_gap_pending = False
+
+        for timestamp, pressure_mbar in measurements:
+            self.full_history_902b_x.append(
+                datetime.datetime.fromtimestamp(timestamp)
+            )
+            self.full_history_902b_y.append(pressure_mbar)
+
+    @staticmethod
+    def _trim_history_before(history_x, history_y, cutoff_time):
+        """Remove timestamp/value pairs older than the history cutoff."""
+        first_retained = 0
+        while (
+            first_retained < len(history_x)
+            and history_x[first_retained] < cutoff_time
+        ):
+            first_retained += 1
+        if first_retained:
+            del history_x[:first_retained]
+            del history_y[:first_retained]
+
+    @staticmethod
+    def _history_since(history_x, history_y, cutoff_time):
+        """Return aligned timestamp/value pairs at or after a cutoff."""
+        selected = [
+            (timestamp, value)
+            for timestamp, value in zip(history_x, history_y)
+            if timestamp >= cutoff_time
+        ]
+        if not selected:
+            return [], []
+        timestamps, values = zip(*selected)
+        return list(timestamps), list(values)
+
+    def _refresh_display_data(self, current_time):
+        """Apply the selected time window to both pressure histories."""
+        history_cutoff = current_time - datetime.timedelta(
+            seconds=self.MAX_HISTORY_SECONDS
+        )
+        self._trim_history_before(
+            self.full_history_x,
+            self.full_history_y,
+            history_cutoff,
+        )
+        self._trim_history_before(
+            self.full_history_902b_x,
+            self.full_history_902b_y,
+            history_cutoff,
+        )
+        display_cutoff = current_time - datetime.timedelta(
+            seconds=self.display_window
+        )
+        self.x_data, self.y_data = self._history_since(
+            self.full_history_x,
+            self.full_history_y,
+            display_cutoff,
+        )
+        self.x_data_902b, self.y_data_902b = self._history_since(
+            self.full_history_902b_x,
+            self.full_history_902b_y,
+            display_cutoff,
+        )
 
     def _902b_reading_is_fresh(self):
         return (
@@ -323,6 +422,11 @@ class VTRXSubsystem:
             return
         self._902b_widget_suppressed = suppressed
         if suppressed:
+            if any(
+                math.isfinite(value)
+                for value in getattr(self, "full_history_902b_y", [])
+            ):
+                self._902b_plot_gap_pending = True
             self.log(
                 "972B reached a pressure below 1mbar: Disabling 902B display data",
                 LogLevel.INFO,
@@ -383,10 +487,12 @@ class VTRXSubsystem:
         """
         Cancel scheduled GUI updates, to be called by dashboard when app is quit.
         """
-        if hasattr(self, 'after_id') and self.after_id:
+        self._closing = True
+        after_id = getattr(self, 'after_id', None)
+        self.after_id = None
+        if after_id:
             try:
-                self.parent.after_cancel(self.after_id)
-                self.after_id = None
+                self.parent.after_cancel(after_id)
                 if self.logger:
                     self.log('Canceled scheduled VTRX display update.', LogLevel.DEBUG)
             except Exception as e:
@@ -416,7 +522,7 @@ class VTRXSubsystem:
         to indicate error condition.
         """
         self.label_pressure.config(text="No data...", fg="red")
-        self.line.set_color('red')
+        self._set_972b_plot_color('red')
         self.ax.set_title('(Error)', fontsize=10, color='red', pad=self.PLOT_TITLE_PAD)
         for canvas, oval_id in self.circle_indicators:
             canvas.itemconfig(oval_id, fill='red')
@@ -664,16 +770,53 @@ class VTRXSubsystem:
         plot_frame = tk.Frame(layout_frame)
         plot_frame.grid(row=0, column=1, sticky='nsew', padx=(4, 6), pady=(3, 1)) 
         self.fig, self.ax = plt.subplots()
-        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.92, bottom=0.18)
+        self.fig.subplots_adjust(left=0.17, right=0.96, top=0.92, bottom=0.28)
         self.line, = self.ax.plot(self.x_data, self.y_data, 'g-')
+        self.line_902b, = self.ax.plot(
+            self.x_data_902b,
+            self.y_data_902b,
+            color=self.PRESSURE_902B_PLOT_COLOR,
+        )
         self.ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-        self.fig.autofmt_xdate()  
+        self.fig.autofmt_xdate(bottom=0.28)
         self.ax.set_title('', pad=self.PLOT_TITLE_PAD)
         self.ax.set_ylabel('Pressure [mbar]', fontsize=8)
         self.ax.set_yscale('log')
         self.ax.set_ylim(1e-7, 1e3)  
         self._apply_plot_label_sizes()
         self.ax.grid(True)
+        legend_handles = [
+            Line2D(
+                [],
+                [],
+                color="green",
+                marker="o",
+                linestyle="None",
+                markersize=5,
+                label="972B",
+            ),
+            Line2D(
+                [],
+                [],
+                color=self.PRESSURE_902B_PLOT_COLOR,
+                marker="o",
+                linestyle="None",
+                markersize=5,
+                label="902B",
+            ),
+        ]
+        self.plot_legend = self.ax.legend(
+            handles=legend_handles,
+            loc="upper center",
+            bbox_to_anchor=(0.5, -0.30),
+            ncol=2,
+            frameon=False,
+            fontsize=7,
+            handlelength=1,
+            handletextpad=0.3,
+            borderaxespad=0,
+        )
+        self.legend_972b_marker = self.plot_legend.get_lines()[0]
 
         self.canvas = FigureCanvasTkAgg(self.fig, master=plot_frame)
         self.canvas.draw()
@@ -743,16 +886,7 @@ class VTRXSubsystem:
         self.full_history_x.append(current_time)
         self.full_history_y.append(pressure_value)
         
-        # Trim history older than MAX_HISTORY_SECONDS
-        cutoff_time = current_time - datetime.timedelta(seconds=self.MAX_HISTORY_SECONDS)
-        while self.full_history_x and self.full_history_x[0] < cutoff_time:
-            self.full_history_x.pop(0)
-            self.full_history_y.pop(0)
-        
-        # Update display window data
-        display_cutoff = current_time - datetime.timedelta(seconds=self.display_window)
-        self.x_data = [x for x in self.full_history_x if x >= display_cutoff]
-        self.y_data = self.full_history_y[-len(self.x_data):]
+        self._refresh_display_data(current_time)
         
         if time.time() - self.last_gui_update_time > 0.5:
             self.last_gui_update_time = time.time()
@@ -770,7 +904,9 @@ class VTRXSubsystem:
                     bg="#FF0000",
                     fg="#FFB6B6"
                 )
-            self.line.set_color('green' if not self.error_state else 'red')
+            self._set_972b_plot_color(
+                'green' if not self.error_state else 'red'
+            )
             self.ax.set_title(
                 'VTRX Pressure Readout',
                 fontsize=8,
@@ -795,25 +931,39 @@ class VTRXSubsystem:
 
     def update_plot(self):
         """Update plot with current display window data."""
-        # Update the data for the line
+        # Update both sensor lines.
         self.line.set_data(self.x_data, self.y_data)
+        self.line_902b.set_data(self.x_data_902b, self.y_data_902b)
         self.ax.relim()
         self.ax.autoscale_view(True, True, False)
 
-        if self.y_data:
-            y_min = min(self.y_data)
-            y_max = max(self.y_data)
-            if y_min > 0 and y_max > 0:
-                self.ax.set_ylim(y_min * 0.5, y_max * 2)
+        visible_pressures = [
+            value
+            for value in self.y_data + self.y_data_902b
+            if math.isfinite(value) and value > 0
+        ]
+        if visible_pressures:
+            self.ax.set_ylim(
+                min(visible_pressures) * 0.5,
+                max(visible_pressures) * 2,
+            )
 
-        if self.x_data:
-            current_time = self.x_data[-1]
+        visible_timestamps = self.x_data + self.x_data_902b
+        if visible_timestamps:
+            current_time = max(visible_timestamps)
             start_time = current_time - datetime.timedelta(seconds=self.display_window)
             self.ax.set_xlim(start_time, current_time)
 
         self._apply_plot_label_sizes()
         self.canvas.draw_idle()
         self.canvas.flush_events()
+
+    def _set_972b_plot_color(self, color):
+        """Keep the 972B line and its legend marker in the same state color."""
+        self.line.set_color(color)
+        legend_marker = getattr(self, "legend_972b_marker", None)
+        if legend_marker is not None:
+            legend_marker.set_color(color)
 
     def _apply_plot_label_sizes(self):
         """Keep static and dynamically generated graph labels the same size."""
@@ -841,12 +991,8 @@ class VTRXSubsystem:
         current_time = datetime.datetime.now()
         self.display_window = seconds
         self.log(f"VTRX display window set to {seconds} seconds.", LogLevel.INFO)
-        
-        # Update display data from full history
-        display_cutoff = current_time - datetime.timedelta(seconds=seconds)
-        self.x_data = [x for x in self.full_history_x if x >= display_cutoff]
-        self.y_data = self.full_history_y[-len(self.x_data):]
-        
+
+        self._refresh_display_data(current_time)
         self.update_plot()
 
     def save_plot(self):

--- a/utils.py
+++ b/utils.py
@@ -79,6 +79,7 @@ class Logger:
             print(f"Warning: Supabase client failed to initialize: {e}")
         self.dict_logger = {
             "pressure": None,
+            "pressure_902b_mbar": None,
             "safetyOutputDataFlags": None,
             "safetyInputDataFlags": None,
             "safetyOutputStatusFlags": None,


### PR DESCRIPTION
## PR summary

Integrates an MKS 902B absolute Piezo pressure transducer into the VTRX subsystem through a 900USB serial adapter. The dashboard now displays, graphs, logs, and publishes 902B pressure alongside the existing 972B reading.

### Key changes

- Added a threaded `MKS902BDriver` that:

  - Owns all 900USB serial operations on a worker thread.
  - Discovers the connected 902B and its address.
  - Reads baud-rate and pressure-unit configuration.
  - Polls pressure using `PR1?`.
  - Converts Torr and Pascal readings to mbar.
  - Retries failed requests and reconnects after communication loss.
  - Uses bounded queues for measurements and background logs.
  - Supports clean worker shutdown without blocking on serial I/O.

- Integrated 902B lifecycle management into the dashboard:

  - Added 902B to startup COM-port configuration.
  - Starts the driver after VTRX initialization.
  - Passes its measurement queue to the VTRX subsystem.
  - Stops the VTRX consumer before shutting down the driver.

- Extended the VTRX interface:

  - Added separate 972B and 902B pressure readouts.
  - Added an indigo 902B trace and sensor legend to the pressure graph.
  - Uses acquisition timestamps for graph points.
  - Maintains aligned one-week histories and shared time-window selection.
  - Scales the Y-axis across visible readings from both sensors.
  - Inserts graph gaps across periods where 902B data is suppressed.

- Added data validity and suppression behavior:

  - Treats 902B readings as stale after six seconds.
  - Publishes fresh readings through `pressure_902b_mbar`.
  - Suppresses the 902B widget, graph samples, and remote publication when a fresh, valid 972B reading is below 1 mbar.
  - Restores 902B output at or above 1 mbar.
  - Does not suppress based on a stale, disconnected, malformed, or faulted 972B reading.
  - Reduces expected 902B operational logging while the gauge is suppressed.

- Updated documentation and integration coverage for the driver, VTRX consumption, suppression transitions, stale data, graph behavior, protocol parsing, retries, queue bounds, threading, and Supabase schema.

### Validation

- Full suite: **240 tests and 50 subtests passed**
- New focused driver/VTRX tests: **23 passed**
- Python compilation and whitespace checks passed.