### PR TITLE
Bugfix: Data Log (Webmonitor log) Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ venv/
 build/
 dist/
 EBEAM-Dashboard-Logs/
-EBEAM-Dashboard-WMLogs/
+EBEAM-Dashboard-Datalogs/
 citestfiles/_tmp/
 .env

--- a/citestfiles/startup_logging_test.py
+++ b/citestfiles/startup_logging_test.py
@@ -55,7 +55,7 @@ class TestStartupLogger(unittest.TestCase):
             contents = file.read()
 
         self.assertIn("INFO (Utils) > Log file created at", contents)
-        self.assertIn("INFO (Utils) > WebMonitor log file created at", contents)
+        self.assertIn("INFO (Utils) > Data Log file created at", contents)
         self.assertIn("INFO (Main) > Process launch", contents)
 
     def test_logger_formats_tag_for_widget_and_file_output(self):

--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -1,4 +1,5 @@
 """Tests for Supabase integration: SupabaseClient and Logger Supabase features."""
+import copy
 import datetime
 import io
 import json
@@ -430,7 +431,168 @@ class TestDatalogFormat(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 5: Data Log rotation
+# Class 5: Data Log write coalescing and preservation
+# ---------------------------------------------------------------------------
+
+class TestDatalogWriteControl(unittest.TestCase):
+    """Tests for local Data Log throttling, preflushes, and heartbeat writes."""
+
+    def setUp(self):
+        self.sb_patcher = patch("utils._create_supabase_client")
+        mock_sb_class = self.sb_patcher.start()
+        mock_sb_class.return_value = MagicMock()
+
+        self.logger = Logger(text_widget=None, log_to_file=False)
+        self.logger.supabase_client = None
+        self.buf = io.StringIO()
+        self.logger.datalog_file = self.buf
+        self.logger.datalog_start_time = datetime.datetime.now()
+        self.logger.log_to_file = True
+
+    def tearDown(self):
+        try:
+            self.logger.close()
+        finally:
+            self.sb_patcher.stop()
+
+    def _entries(self):
+        self.buf.seek(0)
+        return [
+            json.loads(line)
+            for line in self.buf.read().splitlines()
+            if line.strip()
+        ]
+
+    def test_first_changed_field_writes_immediately(self):
+        self.logger.update_field("pressure", 1.0)
+
+        entries = self._entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["status"]["pressure"], 1.0)
+        self.assertEqual(self.logger._last_written_datalog_snapshot["pressure"], 1.0)
+        self.assertIsNotNone(self.logger._last_datalog_write_completed_monotonic)
+
+    def test_unchanged_field_skips_only_local_file_logic(self):
+        self.logger.update_field("pressure", 1.0)
+        entries_before = self._entries()
+
+        with patch.object(self.logger, "_enqueue_supabase_update") as enqueue:
+            self.logger.update_field("pressure", 1.0)
+
+        self.assertEqual(self._entries(), entries_before)
+        enqueue.assert_called_once()
+        self.assertEqual(self.logger.dict_logger["pressure"], 1.0)
+
+    def test_different_fields_coalesce_until_100ms_has_elapsed(self):
+        self.logger.update_field("pressure", 1.0)
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+
+        with patch("utils.time.monotonic", return_value=10.05):
+            self.logger.update_field("vacuumBits", 3)
+        self.assertEqual(len(self._entries()), 1)
+
+        with patch("utils.time.monotonic", return_value=10.11):
+            self.logger.update_field("temperatures", [20.0, 21.0])
+
+        entries = self._entries()
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[-1]["status"]["vacuumBits"], 3)
+        self.assertEqual(entries[-1]["status"]["temperatures"], [20.0, 21.0])
+
+    def test_pending_same_field_is_flushed_before_overwrite_without_throttle(self):
+        self.logger.update_field("pressure", 1.0)
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+
+        with patch("utils.time.monotonic", return_value=10.05):
+            self.logger.update_field("pressure", 2.0)
+        self.assertEqual(len(self._entries()), 1)
+
+        with patch("utils.time.monotonic", return_value=10.06):
+            self.logger.update_field("pressure", 3.0)
+
+        entries = self._entries()
+        self.assertEqual([entry["status"]["pressure"] for entry in entries], [1.0, 2.0])
+        self.assertEqual(self.logger.dict_logger["pressure"], 3.0)
+        self.assertEqual(self.logger._last_written_datalog_snapshot["pressure"], 2.0)
+        self.assertEqual(self.logger._last_datalog_write_completed_monotonic, 10.06)
+
+    def test_nested_cathode_fields_are_compared_at_the_exact_subfield_path(self):
+        self.assertTrue(self.logger.check_datalog_heartbeat())
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+
+        with patch("utils.time.monotonic", return_value=10.01):
+            self.logger.update_cathode_field("A", "heater_current", 1.0)
+        with patch("utils.time.monotonic", return_value=10.02):
+            self.logger.update_cathode_field("A", "heater_voltage", 2.0)
+
+        self.assertEqual(len(self._entries()), 1)
+
+        with patch("utils.time.monotonic", return_value=10.03):
+            self.logger.update_cathode_field("A", "heater_current", 3.0)
+
+        entries = self._entries()
+        self.assertEqual(len(entries), 2)
+        flushed_cathode = entries[-1]["status"]["cathode"]["A"]
+        self.assertEqual(flushed_cathode["heater_current"], 1.0)
+        self.assertEqual(flushed_cathode["heater_voltage"], 2.0)
+        self.assertEqual(
+            self.logger.dict_logger["cathode"]["A"]["heater_current"],
+            3.0,
+        )
+
+    def test_heartbeat_writes_unchanged_snapshot_after_one_second_idle(self):
+        self.logger.update_field("pressure", 1.0)
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+
+        with patch("utils.time.monotonic", return_value=10.999):
+            self.assertFalse(self.logger.check_datalog_heartbeat())
+        self.assertEqual(len(self._entries()), 1)
+
+        with patch("utils.time.monotonic", return_value=11.0):
+            self.assertTrue(self.logger.check_datalog_heartbeat())
+
+        entries = self._entries()
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["status"], entries[1]["status"])
+
+    def test_failed_preflush_applies_live_update_and_skips_postupdate_retry(self):
+        self.logger.update_field("pressure", 1.0)
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+        with patch("utils.time.monotonic", return_value=10.05):
+            self.logger.update_field("pressure", 2.0)
+
+        snapshot_before = copy.deepcopy(self.logger._last_written_datalog_snapshot)
+        completed_before = self.logger._last_datalog_write_completed_monotonic
+        with patch.object(
+            self.logger,
+            "_write_datalog_snapshot",
+            return_value=False,
+        ) as write_snapshot:
+            self.logger.update_field("pressure", 3.0)
+
+        write_snapshot.assert_called_once()
+        self.assertEqual(self.logger.dict_logger["pressure"], 3.0)
+        self.assertEqual(self.logger._last_written_datalog_snapshot, snapshot_before)
+        self.assertEqual(
+            self.logger._last_datalog_write_completed_monotonic,
+            completed_before,
+        )
+
+    def test_preflush_does_not_create_an_extra_supabase_update(self):
+        self.logger.update_field("pressure", 1.0)
+        self.logger._last_datalog_write_completed_monotonic = 10.0
+        with patch("utils.time.monotonic", return_value=10.05):
+            self.logger.update_field("pressure", 2.0)
+
+        with patch.object(self.logger, "_enqueue_supabase_update") as enqueue, \
+             patch("utils.time.monotonic", return_value=10.06):
+            self.logger.update_field("pressure", 3.0)
+
+        enqueue.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Class 6: Data Log rotation
 # ---------------------------------------------------------------------------
 
 class TestDatalogRotation(unittest.TestCase):
@@ -474,6 +636,26 @@ class TestDatalogRotation(unittest.TestCase):
     def test_setup_datalog_file_uses_timestamped_filename(self):
         filename = os.path.basename(self.logger.datalog_filepath)
         self.assertRegex(filename, r"^datalog_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.txt$")
+
+    def test_reenable_creates_new_file_with_immediate_full_baseline(self):
+        first_path = self.logger.datalog_filepath
+        self.logger.dict_logger["pressure"] = 4.2
+        self.logger.datalog_file.close()
+        self.logger.datalog_file = None
+
+        self.logger.setup_datalog_file(write_baseline=True)
+
+        second_path = self.logger.datalog_filepath
+        self.assertNotEqual(second_path, first_path)
+        lines = self._read_datalog_lines(second_path)
+        self.assertEqual(len(lines), 1)
+        entry = json.loads(lines[0])
+        self.assertEqual(entry["status"]["pressure"], 4.2)
+        self.assertEqual(set(entry["status"].keys()), EXPECTED_DICT_LOGGER_KEYS)
+        self.assertEqual(
+            self.logger._last_written_datalog_snapshot,
+            self.logger.dict_logger,
+        )
 
     def test_datalog_rotates_after_one_hour_into_new_file(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
@@ -544,7 +726,7 @@ class TestDatalogRotation(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 6: dict_logger field management
+# Class 7: dict_logger field management
 # ---------------------------------------------------------------------------
 
 class TestDictLoggerFieldManagement(unittest.TestCase):

--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -227,9 +227,11 @@ class TestSupabaseRateLimiting(unittest.TestCase):
         self.mock_sb_class.return_value = self.mock_sb_instance
 
         self.logger = Logger(text_widget=None, log_to_file=True)
-        # Inject a mock webMonitor_log_file so the file-write branch doesn't crash
-        self.logger.webMonitor_log_file = MagicMock()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now()
+        if self.logger.datalog_file:
+            self.logger.datalog_file.close()
+        # Inject a mock datalog_file so the file-write branch doesn't crash
+        self.logger.datalog_file = MagicMock()
+        self.logger.datalog_start_time = datetime.datetime.now()
 
     def tearDown(self):
         try:
@@ -369,11 +371,11 @@ class TestSupabaseRateLimiting(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 4: WebMonitor log format
+# Class 4: Data Log format
 # ---------------------------------------------------------------------------
 
-class TestWebMonitorLogFormat(unittest.TestCase):
-    """Tests for the JSON structure written to webMonitor_log_file."""
+class TestDatalogFormat(unittest.TestCase):
+    """Tests for the JSON structure written to datalog_file."""
 
     def setUp(self):
         self.sb_patcher = patch("utils._create_supabase_client")
@@ -383,8 +385,8 @@ class TestWebMonitorLogFormat(unittest.TestCase):
         self.logger = Logger(text_widget=None, log_to_file=False)
         # Inject StringIO so log_dict_update writes to it
         self.buf = io.StringIO()
-        self.logger.webMonitor_log_file = self.buf
-        self.logger.webMonitor_log_start_time = datetime.datetime.now()
+        self.logger.datalog_file = self.buf
+        self.logger.datalog_start_time = datetime.datetime.now()
         self.logger.log_to_file = True
 
     def tearDown(self):
@@ -398,26 +400,26 @@ class TestWebMonitorLogFormat(unittest.TestCase):
         line = self.buf.readline().strip()
         return json.loads(line)
 
-    def test_webmonitor_log_entry_is_valid_json(self):
+    def test_datalog_entry_is_valid_json(self):
         self.logger.log_dict_update({"pressure": 1.2e-5})
         self.buf.seek(0)
         line = self.buf.readline().strip()
         # Should not raise
         json.loads(line)
 
-    def test_webmonitor_log_entry_has_timestamp_and_status_keys(self):
+    def test_datalog_entry_has_timestamp_and_status_keys(self):
         self.logger.log_dict_update({"pressure": 1.0})
         entry = self._get_entry()
         self.assertIn("timestamp", entry)
         self.assertIn("status", entry)
 
-    def test_webmonitor_log_timestamp_format(self):
+    def test_datalog_timestamp_format(self):
         self.logger.log_dict_update({"pressure": 1.0})
         entry = self._get_entry()
         # Should not raise if format matches
         datetime.datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S.%f")
 
-    def test_webmonitor_log_status_contains_dict_logger_snapshot(self):
+    def test_datalog_status_contains_dict_logger_snapshot(self):
         self.logger.dict_logger["pressure"] = 9.9e-6
         self.logger.log_dict_update(self.logger.dict_logger)
         entry = self._get_entry()
@@ -428,25 +430,25 @@ class TestWebMonitorLogFormat(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Class 5: WebMonitor rotation
+# Class 5: Data Log rotation
 # ---------------------------------------------------------------------------
 
-class TestWebMonitorRotation(unittest.TestCase):
-    """Tests for 1-hour web monitor rollover with timestamped filenames."""
+class TestDatalogRotation(unittest.TestCase):
+    """Tests for one-hour Data Log rollover with timestamped filenames."""
 
     def setUp(self):
         self.sb_patcher = patch("utils._create_supabase_client")
         mock_sb_class = self.sb_patcher.start()
         mock_sb_class.return_value = MagicMock()
 
-        self.test_root = os.path.join(TEST_TMP_ROOT, f"wm_rotation_{uuid.uuid4().hex}")
+        self.test_root = os.path.join(TEST_TMP_ROOT, f"datalog_rotation_{uuid.uuid4().hex}")
         os.makedirs(self.test_root, exist_ok=True)
         self.base_path_patcher = patch.object(Logger, "_get_dashboard_base_path", return_value=self.test_root)
         self.base_path_patcher.start()
 
         self.logger = Logger(text_widget=None, log_to_file=False)
         self.logger.supabase_client = None
-        self.logger.setup_wm_logfile()
+        self.logger.setup_datalog_file()
         self.logger.log_to_file = True
 
     def tearDown(self):
@@ -457,66 +459,66 @@ class TestWebMonitorRotation(unittest.TestCase):
             self.sb_patcher.stop()
             shutil.rmtree(self.test_root, ignore_errors=True)
 
-    def _read_wm_lines(self, filepath=None):
-        target = filepath or self.logger.webMonitor_log_filepath
+    def _read_datalog_lines(self, filepath=None):
+        target = filepath or self.logger.datalog_filepath
         with open(target, "r", encoding="utf-8") as fh:
             return [line.rstrip("\n") for line in fh]
 
-    def _list_wm_files(self):
-        wm_dir = os.path.dirname(self.logger.webMonitor_log_filepath)
+    def _list_datalog_files(self):
+        datalog_dir = os.path.dirname(self.logger.datalog_filepath)
         return sorted(
-            entry for entry in os.listdir(wm_dir)
-            if entry.startswith("webMonitor_log_") and entry.endswith(".txt")
+            entry for entry in os.listdir(datalog_dir)
+            if entry.startswith("datalog_") and entry.endswith(".txt")
         )
 
-    def test_setup_wm_logfile_uses_timestamped_filename(self):
-        filename = os.path.basename(self.logger.webMonitor_log_filepath)
-        self.assertRegex(filename, r"^webMonitor_log_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.txt$")
+    def test_setup_datalog_file_uses_timestamped_filename(self):
+        filename = os.path.basename(self.logger.datalog_filepath)
+        self.assertRegex(filename, r"^datalog_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.txt$")
 
-    def test_webmonitor_log_rotates_after_one_hour_into_new_file(self):
+    def test_datalog_rotates_after_one_hour_into_new_file(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        first_path = self.logger.webMonitor_log_filepath
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now() - datetime.timedelta(hours=1, seconds=1)
+        first_path = self.logger.datalog_filepath
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
+        self.logger.datalog_start_time = datetime.datetime.now() - datetime.timedelta(hours=1, seconds=1)
         time.sleep(1.1)
 
         self.logger.log_dict_update({"pressure": 1.0})
 
-        second_path = self.logger.webMonitor_log_filepath
+        second_path = self.logger.datalog_filepath
         self.assertNotEqual(second_path, first_path)
-        self.assertEqual(len(self._list_wm_files()), 2)
-        self.assertEqual(self._read_wm_lines(first_path), [seed_entry])
-        lines = self._read_wm_lines(second_path)
+        self.assertEqual(len(self._list_datalog_files()), 2)
+        self.assertEqual(self._read_datalog_lines(first_path), [seed_entry])
+        lines = self._read_datalog_lines(second_path)
         self.assertEqual(len(lines), 1)
         entry = json.loads(lines[0])
         self.assertEqual(entry["status"]["pressure"], 1.0)
         datetime.datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S.%f")
 
-    def test_webmonitor_log_does_not_rotate_before_one_hour(self):
+    def test_datalog_does_not_rotate_before_one_hour(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
         original_start_time = datetime.datetime.now() - datetime.timedelta(minutes=59, seconds=59)
-        self.logger.webMonitor_log_start_time = original_start_time
-        original_path = self.logger.webMonitor_log_filepath
+        self.logger.datalog_start_time = original_start_time
+        original_path = self.logger.datalog_filepath
 
         self.logger.log_dict_update({"pressure": 2.0})
 
-        self.assertEqual(self.logger.webMonitor_log_filepath, original_path)
-        lines = self._read_wm_lines()
+        self.assertEqual(self.logger.datalog_filepath, original_path)
+        lines = self._read_datalog_lines()
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], seed_entry)
-        self.assertEqual(self.logger.webMonitor_log_start_time, original_start_time)
+        self.assertEqual(self.logger.datalog_start_time, original_start_time)
         entry = json.loads(lines[1])
         self.assertEqual(entry["status"]["pressure"], 2.0)
 
-    def test_webmonitor_retry_reopens_in_append_mode_within_window(self):
+    def test_datalog_retry_reopens_in_append_mode_within_window(self):
         seed_entry = json.dumps({"timestamp": "seed", "status": {"pressure": 0}})
-        self.logger.webMonitor_log_file.write(seed_entry + "\n")
-        self.logger.webMonitor_log_file.flush()
-        self.logger.webMonitor_log_start_time = datetime.datetime.now() - datetime.timedelta(minutes=30)
-        original_path = self.logger.webMonitor_log_filepath
+        self.logger.datalog_file.write(seed_entry + "\n")
+        self.logger.datalog_file.flush()
+        self.logger.datalog_start_time = datetime.datetime.now() - datetime.timedelta(minutes=30)
+        original_path = self.logger.datalog_filepath
 
         class FailingWriter:
             def write(self, _message):
@@ -528,12 +530,13 @@ class TestWebMonitorRotation(unittest.TestCase):
             def close(self):
                 pass
 
-        self.logger.webMonitor_log_file = FailingWriter()
+        self.logger.datalog_file.close()
+        self.logger.datalog_file = FailingWriter()
 
         self.logger.log_dict_update({"pressure": 3.0})
 
-        self.assertEqual(self.logger.webMonitor_log_filepath, original_path)
-        lines = self._read_wm_lines()
+        self.assertEqual(self.logger.datalog_filepath, original_path)
+        lines = self._read_datalog_lines()
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], seed_entry)
         entry = json.loads(lines[1])

--- a/instrumentctl/G9SP_interlock/g9_driver.py
+++ b/instrumentctl/G9SP_interlock/g9_driver.py
@@ -564,7 +564,7 @@ class G9Driver:
         if queue_field_updates:
             self._queue_status_field_updates(binary_data)
 
-        # Store data flags to be logged in interlock.py for web monitor
+        # Store data flags to be logged in interlock.py for the Data Log.
         debug_data = {
             'sotdf': binary_data['sotdf'],
             'sitdf': binary_data['sitdf'],

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -1140,7 +1140,7 @@ class BeamEnergySubsystem:
         return True
 
     def _build_disconnected_beam_energy_payload(self):
-        """Build a Web Monitor payload that explicitly clears every Beam Energy supply."""
+        """Build a Data Log payload that explicitly clears every Beam Energy supply."""
         supplies = {
             supply_key: {
                 "connected": False,
@@ -1193,7 +1193,7 @@ class BeamEnergySubsystem:
         return set_voltage, actual_voltage, actual_current
 
     def _build_supplies_payload(self, knob_box, data_snapshot):
-        """Build a structured payload of 4 power supply statuses for the Web Monitor."""
+        """Build a structured payload of four power supply statuses for the Data Log."""
         supplies = {}
 
         for supply_key, unit_id in self.supply_payload_map:
@@ -1320,7 +1320,7 @@ class BeamEnergySubsystem:
 
             self.update_supply_interlock_statuses(data_snapshot, knob_box)
             
-            # Build a web monitor log payload
+            # Build a Data Log payload.
             if self.logger and hasattr(self.logger, "update_field"):
 
                 # Build keyed per-supply payload entries.
@@ -1338,7 +1338,7 @@ class BeamEnergySubsystem:
                     for key in self.beam_energy_flag_keys
                 }
 
-                # Update the Web Monitor log with the latest data and flags.
+                # Update the Data Log with the latest data and flags.
                 self.logger.update_field("beam_energy", {**supply_payload, "flags": flags})
 
 

--- a/subsystem/interlocks/interlocks.py
+++ b/subsystem/interlocks/interlocks.py
@@ -335,7 +335,7 @@ class InterlocksSubsystem:
                 
                 sitsf_bits, sitdf_bits, g9_output, unit_status, input_terms, output_terms, debug_data = status
 
-                # Log debug data for web monitor
+                # Log debug data for the Data Log.
                 self.log(f"Safety Output Terminal Data Flags: {debug_data['sotdf']}", LogLevel.VERBOSE)
                 self.log(f"Safety Input Terminal Data Flags: {debug_data['sitdf']}", LogLevel.VERBOSE)
 

--- a/subsystem/vtrx/vtrx.py
+++ b/subsystem/vtrx/vtrx.py
@@ -283,10 +283,10 @@ class VTRXSubsystem:
             canvas.itemconfig(oval_id, fill='red')
         self.canvas.draw_idle()
 
-        #Clear the webmonitor fields if error state
+        # Clear the Data Log fields while in an error state.
         if self.logger and hasattr(self.logger, "clear_value"):
             if not self.vacuum_fields_cleared:
-                self.log("Clearing VTRX web monitor vacuum fields.", LogLevel.DEBUG)
+                self.log("Clearing VTRX Data Log vacuum fields.", LogLevel.DEBUG)
                 self.vacuum_fields_cleared = True
             self.logger.clear_value("vacuumBits")
             self.logger.clear_value("pressure")

--- a/utils.py
+++ b/utils.py
@@ -56,10 +56,10 @@ class Logger:
         self.log_to_file = log_to_file
         self.log_file = None
         self.log_start_time = None
-        self.webMonitor_log_start_time = None
+        self.datalog_start_time = None
         self.log_filepath = None
-        self.webMonitor_log_file = None
-        self.webMonitor_log_filepath = None
+        self.datalog_file = None
+        self.datalog_filepath = None
         self._pending_widget_messages = deque(maxlen=self.STARTUP_BUFFER_MAX)
         self._startup_buffer_overflow_logged = False
         self._log_file_unavailable_reported = False
@@ -94,7 +94,7 @@ class Logger:
             }
         if log_to_file:
             self.setup_log_file()
-            self.setup_wm_logfile()
+            self.setup_datalog_file()
 
     def _get_dashboard_base_path(self):
         return os.path.abspath(os.path.join(os.path.expanduser("~"), "EBEAM_dashboard"))
@@ -194,32 +194,32 @@ class Logger:
         except Exception as e:
             self._log_internal(f"Error creating log file: {str(e)}")
 
-    def setup_wm_logfile(self):
-        """Setup a new web monitor log file in the 'EBEAM_dashboard/EBEAM-Dashboard-Logs/' directory."""
+    def setup_datalog_file(self):
+        """Set up a new Data Log file for sensor snapshots."""
         try:
-            wm_log_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-WMLogs")
-            os.makedirs(wm_log_dir, exist_ok=True)
+            datalog_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Datalogs")
+            os.makedirs(datalog_dir, exist_ok=True)
 
-            # Create the web monitor log file with the same timestamped pattern used by the main log.
-            webMonitor_log_file_name = f"webMonitor_log_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
-            if self.webMonitor_log_file != None:
-                self.webMonitor_log_file.close()
-            self.webMonitor_log_filepath = os.path.join(wm_log_dir, webMonitor_log_file_name)
-            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'w')
-            self.webMonitor_log_start_time = datetime.datetime.now()
-            self.info(f"WebMonitor log file created at {self.webMonitor_log_filepath}", tag="Utils")
+            # Create the Data Log file with the same timestamped pattern used by the main log.
+            datalog_file_name = f"datalog_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
+            if self.datalog_file != None:
+                self.datalog_file.close()
+            self.datalog_filepath = os.path.join(datalog_dir, datalog_file_name)
+            self.datalog_file = open(self.datalog_filepath, 'w')
+            self.datalog_start_time = datetime.datetime.now()
+            self.info(f"Data Log file created at {self.datalog_filepath}", tag="Utils")
         except Exception as e:
-            self._log_internal(f"Error creating web monitor log file: {str(e)}")
+            self._log_internal(f"Error creating Data Log file: {str(e)}")
 
-    def _reopen_wm_logfile_append(self):
-        """Reopen the current web monitor log file without resetting its rotation window."""
+    def _reopen_datalog_append(self):
+        """Reopen the current Data Log file without resetting its rotation window."""
         try:
-            if self.webMonitor_log_filepath is None:
-                self.setup_wm_logfile()
+            if self.datalog_filepath is None:
+                self.setup_datalog_file()
                 return
-            self.webMonitor_log_file = open(self.webMonitor_log_filepath, 'a')
+            self.datalog_file = open(self.datalog_filepath, 'a')
         except Exception as e:
-            self._log_internal(f"Error opening web monitor log file: {str(e)}")
+            self._log_internal(f"Error opening Data Log file: {str(e)}")
 
     def log(self, msg, level=LogLevel.INFO, tag=None):
         """Log a message to the text widget and optionally to local file."""
@@ -309,39 +309,39 @@ class Logger:
         self._enqueue_supabase_update(update_dict, now)
 
         if self.log_to_file:
-            if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
-                if self.webMonitor_log_file:
-                    self.webMonitor_log_file.close()
-                self.setup_wm_logfile()
-            elif self.webMonitor_log_file is None:
-                self._reopen_wm_logfile_append()
-            if self.webMonitor_log_file:
+            if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
+                if self.datalog_file:
+                    self.datalog_file.close()
+                self.setup_datalog_file()
+            elif self.datalog_file is None:
+                self._reopen_datalog_append()
+            if self.datalog_file:
                 entry = {
                     "timestamp": timestamp,
                     "status": update_dict
                 }
                 try:
-                    self.webMonitor_log_file.write(json.dumps(entry) + "\n")
-                    self.webMonitor_log_file.flush()
+                    self.datalog_file.write(json.dumps(entry) + "\n")
+                    self.datalog_file.flush()
                 except Exception as e:
                     try:
-                        self.webMonitor_log_file.close()
+                        self.datalog_file.close()
                     except Exception:
                         pass
-                    self.webMonitor_log_file = None
+                    self.datalog_file = None
                     try:
-                        if self.webMonitor_log_start_time is None or (now - self.webMonitor_log_start_time).total_seconds() >= 60 * 60:
-                            self.setup_wm_logfile()
+                        if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
+                            self.setup_datalog_file()
                         else:
-                            self._reopen_wm_logfile_append()
-                        if self.webMonitor_log_file:
-                            self.webMonitor_log_file.write(json.dumps(entry) + "\n")
-                            self.webMonitor_log_file.flush()
-                            self.warning(f"Web Monitor log write failed once and succeeded after retry: {e}", tag="Utils")
+                            self._reopen_datalog_append()
+                        if self.datalog_file:
+                            self.datalog_file.write(json.dumps(entry) + "\n")
+                            self.datalog_file.flush()
+                            self.warning(f"Data Log write failed once and succeeded after retry: {e}", tag="Utils")
                         else:
-                            self._log_internal(f"Error writing web monitor updates: {e}")
+                            self._log_internal(f"Error writing Data Log updates: {e}")
                     except Exception as retry_error:
-                        self._log_internal(f"Error writing web monitor updates: {retry_error}")
+                        self._log_internal(f"Error writing Data Log updates: {retry_error}")
 
     def _enqueue_supabase_update(self, update_dict, now):
         if self._closed or not self.supabase_client or not self.log_to_file:
@@ -476,12 +476,12 @@ class Logger:
                 self.log_file = None
             except Exception as e:
                 self._log_internal(f"Error closing log file {str(e)}")
-        if self.webMonitor_log_file:
+        if self.datalog_file:
             try:
-                self.webMonitor_log_file.close()
-                self.webMonitor_log_file = None
+                self.datalog_file.close()
+                self.datalog_file = None
             except Exception as e:
-                self._log_internal(f"Error closing web monitor log file: {str(e)}")
+                self._log_internal(f"Error closing Data Log file: {str(e)}")
 
 import tkinter as tk
 import sys
@@ -564,12 +564,12 @@ class MessagesFrame:
                 except Exception as e:
                     self.logger.error(f"Error closing log file: {e}", tag="Utils")
                 self.logger.log_file = None
-            if self.logger.webMonitor_log_file:
+            if self.logger.datalog_file:
                 try:
-                    self.logger.webMonitor_log_file.close()
+                    self.logger.datalog_file.close()
                 except Exception as e:
-                    self.logger.error(f"Error closing web monitor log file: {e}", tag="Utils")
-                self.logger.webMonitor_log_file = None
+                    self.logger.error(f"Error closing Data Log file: {e}", tag="Utils")
+                self.logger.datalog_file = None
             self.toggle_file_logging_button.config(text="Record Log: OFF")
             self.logging_indicator_canvas.itemconfig(self.logging_indicator_circle, fill="gray")
         else:
@@ -579,8 +579,8 @@ class MessagesFrame:
             
             if not self.logger.log_file:  # if no file is open, set up a new one
                 self.logger.setup_log_file()
-            if not self.logger.webMonitor_log_file:
-                self.logger.setup_wm_logfile()
+            if not self.logger.datalog_file:
+                self.logger.setup_datalog_file()
             self.toggle_file_logging_button.config(text="Record Log: ON")
             self.logging_indicator_canvas.itemconfig(
                 self.logging_indicator_circle, 

--- a/utils.py
+++ b/utils.py
@@ -44,6 +44,10 @@ class LogLevel(enum.IntEnum):
 
 class Logger:
     STARTUP_BUFFER_MAX = 500
+    DATALOG_WRITE_MIN_INTERVAL_SECONDS = 0.1
+    DATALOG_HEARTBEAT_INTERVAL_SECONDS = 1.0
+    DATALOG_HEARTBEAT_CHECK_INTERVAL_MS = 1000
+    DATALOG_ROTATION_INTERVAL_SECONDS = 60 * 60
     SUPABASE_WRITE_MIN_INTERVAL_SECONDS = 3
     SUPABASE_WRITE_MAX_ATTEMPTS = 2
     SUPABASE_WRITE_RETRY_DELAY_SECONDS = 0.25
@@ -60,6 +64,8 @@ class Logger:
         self.log_filepath = None
         self.datalog_file = None
         self.datalog_filepath = None
+        self._last_written_datalog_snapshot = None
+        self._last_datalog_write_completed_monotonic = None
         self._pending_widget_messages = deque(maxlen=self.STARTUP_BUFFER_MAX)
         self._startup_buffer_overflow_logged = False
         self._log_file_unavailable_reported = False
@@ -194,20 +200,32 @@ class Logger:
         except Exception as e:
             self._log_internal(f"Error creating log file: {str(e)}")
 
-    def setup_datalog_file(self):
+    def setup_datalog_file(self, write_baseline=False):
         """Set up a new Data Log file for sensor snapshots."""
         try:
             datalog_dir = os.path.join(self._get_dashboard_base_path(), "EBEAM-Dashboard-Datalogs")
             os.makedirs(datalog_dir, exist_ok=True)
 
             # Create the Data Log file with the same timestamped pattern used by the main log.
-            datalog_file_name = f"datalog_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.txt"
+            datalog_name_base = f"datalog_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+            datalog_file_name = f"{datalog_name_base}.txt"
+            datalog_filepath = os.path.join(datalog_dir, datalog_file_name)
+            suffix = 1
+            while os.path.exists(datalog_filepath):
+                datalog_file_name = f"{datalog_name_base}_{suffix}.txt"
+                datalog_filepath = os.path.join(datalog_dir, datalog_file_name)
+                suffix += 1
             if self.datalog_file != None:
                 self.datalog_file.close()
-            self.datalog_filepath = os.path.join(datalog_dir, datalog_file_name)
+                self.datalog_file = None
+            self.datalog_filepath = datalog_filepath
             self.datalog_file = open(self.datalog_filepath, 'w')
             self.datalog_start_time = datetime.datetime.now()
+            self._last_written_datalog_snapshot = None
+            self._last_datalog_write_completed_monotonic = None
             self.info(f"Data Log file created at {self.datalog_filepath}", tag="Utils")
+            if write_baseline:
+                self._write_datalog_snapshot(self.dict_logger, allow_rotation=False)
         except Exception as e:
             self._log_internal(f"Error creating Data Log file: {str(e)}")
 
@@ -265,12 +283,21 @@ class Logger:
             self.error(message, tag="Utils")
             raise KeyError(message)
         if field in self.dict_logger:
+            value_changed = not self._datalog_values_equal(self.dict_logger[field], value)
+            preflush_failed = False
+            if value_changed:
+                preflush_failed = not self._flush_pending_datalog_path((field,))
             self.dict_logger[field] = value
-            self.log_dict_update(self.dict_logger)
+            self.log_dict_update(
+                self.dict_logger,
+                write_datalog=value_changed,
+                datalog_write_blocked=preflush_failed,
+            )
         else:
             message = f"'{field}' is not a valid key in status dict."
             self.error(message, tag="Utils")
             raise KeyError(message)
+
     def update_cathode_field(self, cathode_label, subfield, value):
         cathode = self.dict_logger["cathode"]
         if not isinstance(cathode, dict):
@@ -285,63 +312,187 @@ class Logger:
             message = f"'{subfield}' is not a valid cathode subfield. Expected one of {list(cathode[cathode_label].keys())}."
             self.error(message, tag="Utils")
             raise KeyError(message)
+        value_changed = not self._datalog_values_equal(cathode[cathode_label][subfield], value)
+        preflush_failed = False
+        if value_changed:
+            preflush_failed = not self._flush_pending_datalog_path(("cathode", cathode_label, subfield))
         cathode[cathode_label][subfield] = value
-        self.log_dict_update(self.dict_logger)
+        self.log_dict_update(
+            self.dict_logger,
+            write_datalog=value_changed,
+            datalog_write_blocked=preflush_failed,
+        )
+
     def clear_value(self, field):
         if field == "cathode":
             message = "'cathode' cannot be cleared with clear_value; use update_cathode_field to reset individual subfields."
             self.error(message, tag="Utils")
             raise KeyError(message)
         if field in self.dict_logger:
+            value_changed = not self._datalog_values_equal(self.dict_logger[field], None)
+            preflush_failed = False
+            if value_changed:
+                preflush_failed = not self._flush_pending_datalog_path((field,))
             self.dict_logger[field] = None
-            self.log_dict_update(self.dict_logger)
+            self.log_dict_update(
+                self.dict_logger,
+                write_datalog=value_changed,
+                datalog_write_blocked=preflush_failed,
+            )
         else:
             message = f"'{field}' is not a valid key in status dict."
             self.error(message, tag="Utils")
             raise KeyError(message)
-    def log_dict_update(self, update_dict):
-        if self._closed:
-            return
+
+    @staticmethod
+    def _datalog_values_equal(left, right):
+        """Compare Data Log values using their exact Python equality semantics."""
+        try:
+            return bool(left == right)
+        except Exception:
+            return False
+
+    @staticmethod
+    def _datalog_value_at_path(status, path, missing):
+        value = status
+        try:
+            for key in path:
+                value = value[key]
+            return value
+        except (KeyError, TypeError):
+            return missing
+
+    def _flush_pending_datalog_path(self, path):
+        """Flush a pending value at one exact field path before it is overwritten."""
+        if self._closed or not self.log_to_file:
+            return True
+        if self._last_written_datalog_snapshot is None:
+            return True
+
+        missing = object()
+        current_value = self._datalog_value_at_path(self.dict_logger, path, missing)
+        written_value = self._datalog_value_at_path(
+            self._last_written_datalog_snapshot,
+            path,
+            missing,
+        )
+        if current_value is not missing and written_value is not missing:
+            if self._datalog_values_equal(current_value, written_value):
+                return True
+
+        # This pre-update flush intentionally bypasses the 100 ms throttle.
+        return self._write_datalog_snapshot(self.dict_logger)
+
+    def _datalog_write_interval_elapsed(self):
+        if self._last_datalog_write_completed_monotonic is None:
+            return True
+        return (
+            time.monotonic() - self._last_datalog_write_completed_monotonic
+            >= self.DATALOG_WRITE_MIN_INTERVAL_SECONDS
+        )
+
+    def _datalog_rotation_due(self, now):
+        return (
+            self.datalog_start_time is None
+            or (now - self.datalog_start_time).total_seconds()
+            >= self.DATALOG_ROTATION_INTERVAL_SECONDS
+        )
+
+    @staticmethod
+    def _datalog_entry(snapshot):
+        return {
+            "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+            "status": snapshot,
+        }
+
+    def _write_datalog_snapshot(self, status, allow_rotation=True):
+        """Write one full local snapshot and update state only after a successful flush."""
+        if self._closed or not self.log_to_file:
+            return False
+
+        try:
+            snapshot = copy.deepcopy(status)
+        except Exception as e:
+            self._log_internal(f"Error copying Data Log update: {str(e)}")
+            return False
+
         now = datetime.datetime.now()
-        # Timestamp includes microseconds for sub-second logging rates by cbmark logger
-        timestamp = now.strftime("%Y-%m-%d %H:%M:%S.%f")
+        if allow_rotation and self._datalog_rotation_due(now):
+            self.setup_datalog_file()
+        elif self.datalog_file is None:
+            self._reopen_datalog_append()
 
-        self._enqueue_supabase_update(update_dict, now)
+        if self.datalog_file is None:
+            self._log_internal("Data Log file is not open; snapshot could not be written.")
+            return False
 
-        if self.log_to_file:
-            if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
-                if self.datalog_file:
-                    self.datalog_file.close()
-                self.setup_datalog_file()
-            elif self.datalog_file is None:
-                self._reopen_datalog_append()
-            if self.datalog_file:
-                entry = {
-                    "timestamp": timestamp,
-                    "status": update_dict
-                }
-                try:
-                    self.datalog_file.write(json.dumps(entry) + "\n")
-                    self.datalog_file.flush()
-                except Exception as e:
+        first_error = None
+        for attempt in range(2):
+            try:
+                entry = self._datalog_entry(snapshot)
+                self.datalog_file.write(json.dumps(entry) + "\n")
+                self.datalog_file.flush()
+                self._last_written_datalog_snapshot = snapshot
+                self._last_datalog_write_completed_monotonic = time.monotonic()
+                if first_error is not None:
+                    self.warning(
+                        f"Data Log write failed once and succeeded after retry: {first_error}",
+                        tag="Utils",
+                    )
+                return True
+            except Exception as e:
+                if attempt == 0:
+                    first_error = e
                     try:
                         self.datalog_file.close()
                     except Exception:
                         pass
                     self.datalog_file = None
-                    try:
-                        if self.datalog_start_time is None or (now - self.datalog_start_time).total_seconds() >= 60 * 60:
-                            self.setup_datalog_file()
-                        else:
-                            self._reopen_datalog_append()
-                        if self.datalog_file:
-                            self.datalog_file.write(json.dumps(entry) + "\n")
-                            self.datalog_file.flush()
-                            self.warning(f"Data Log write failed once and succeeded after retry: {e}", tag="Utils")
-                        else:
-                            self._log_internal(f"Error writing Data Log updates: {e}")
-                    except Exception as retry_error:
-                        self._log_internal(f"Error writing Data Log updates: {retry_error}")
+                    retry_now = datetime.datetime.now()
+                    if allow_rotation and self._datalog_rotation_due(retry_now):
+                        self.setup_datalog_file()
+                    else:
+                        self._reopen_datalog_append()
+                    if self.datalog_file is not None:
+                        continue
+                self._log_internal(f"Error writing Data Log updates: {str(e)}")
+                return False
+        return False
+
+    def check_datalog_heartbeat(self):
+        """Write a full snapshot when the fixed heartbeat finds a one-second idle period."""
+        if self._closed or not self.log_to_file:
+            return False
+        if self._last_datalog_write_completed_monotonic is None:
+            return self._write_datalog_snapshot(self.dict_logger)
+        if (
+            time.monotonic() - self._last_datalog_write_completed_monotonic
+            >= self.DATALOG_HEARTBEAT_INTERVAL_SECONDS
+        ):
+            return self._write_datalog_snapshot(self.dict_logger)
+        return False
+
+    def log_dict_update(self, update_dict, *, write_datalog=True, datalog_write_blocked=False):
+        if self._closed:
+            return
+        now = datetime.datetime.now()
+
+        self._enqueue_supabase_update(update_dict, now)
+
+        if (
+            self.log_to_file
+            and write_datalog
+            and not datalog_write_blocked
+            and self._datalog_write_interval_elapsed()
+        ):
+            if (
+                self._last_written_datalog_snapshot is None
+                or not self._datalog_values_equal(
+                    update_dict,
+                    self._last_written_datalog_snapshot,
+                )
+            ):
+                self._write_datalog_snapshot(update_dict)
 
     def _enqueue_supabase_update(self, update_dict, now):
         if self._closed or not self.supabase_client or not self.log_to_file:
@@ -540,6 +691,8 @@ class MessagesFrame:
 
         self.file_logging_enabled = self.logger.log_to_file
         self.logger.debug("Messages pane attached to logger", tag="Utils")
+        self._datalog_heartbeat_after_id = None
+        self._schedule_datalog_heartbeat()
 
         # Redirect stdout to the text widget
         sys.stdout = TextRedirector(self.text_widget, "stdout")
@@ -580,13 +733,33 @@ class MessagesFrame:
             if not self.logger.log_file:  # if no file is open, set up a new one
                 self.logger.setup_log_file()
             if not self.logger.datalog_file:
-                self.logger.setup_datalog_file()
+                self.logger.setup_datalog_file(write_baseline=True)
             self.toggle_file_logging_button.config(text="Record Log: ON")
             self.logging_indicator_canvas.itemconfig(
                 self.logging_indicator_circle, 
                 fill="#00FF24"
             )
             self.logger.info("Log recording has been turned ON.", tag="Utils")
+
+    def _schedule_datalog_heartbeat(self):
+        if self.logger._closed:
+            return
+        try:
+            self._datalog_heartbeat_after_id = self.frame.after(
+                self.logger.DATALOG_HEARTBEAT_CHECK_INTERVAL_MS,
+                self._run_datalog_heartbeat,
+            )
+        except tk.TclError:
+            self._datalog_heartbeat_after_id = None
+
+    def _run_datalog_heartbeat(self):
+        self._datalog_heartbeat_after_id = None
+        try:
+            self.logger.check_datalog_heartbeat()
+        except Exception as e:
+            self.logger._log_internal(f"Unexpected Data Log heartbeat error: {str(e)}")
+        finally:
+            self._schedule_datalog_heartbeat()
 
     def set_log_level(self, level):
         self.logger.set_log_level(level)


### PR DESCRIPTION
## Overview

This PR renames the Web Monitor log to Data Log and improves how JSON snapshots are written to the txt file. The new write controls reduce duplicate writes while preserving intermediate values, and adding a 1s regular heartbeat,

This PR fixes issue #104. The first commit since test/melt-metal-PRs-merged pretty much covers Cole's changes in PR #170 but updates them to the new dashboard. The next PR cleans up the webmonitor/data log write conditions so that we are not generating 5GB per day of txt files with 96% duplicate json frames. 

## Changes

- Renamed Web Monitor logging throughout the dashboard to Data Log.
- Changed the log directory from `EBEAM-Dashboard-WMLogs` to `EBEAM-Dashboard-Datalogs`.
- Changed generated filenames from `webMonitor_log_*.txt` to `datalog_*.txt`.
- Updated related logger fields, methods, messages, comments, tests, etc.

### Data Log writing

- Skip local writes when a field’s value has not changed.
- Coalesce changes across different fields using a 100 ms minimum write interval.
- Flush a pending snapshot before the same field is overwritten, preserving intermediate values.
- Write a full snapshot after one second without a completed write.
- Keep Data Log write controls listed above independent from Supabase scheduling.

### utils.py data log workflow updates

- Deep-copy snapshots before serialization.
- Update write-tracking state only after a successful write and flush.
- Retry failed writes once after reopening the current file in append mode.
- Add numeric suffixes when a timestamped filename already exists.
- Properly close and clear Data Log resources when logging is disabled or the application shuts down.

### Testing

Expanded test coverage for:

- Data Log JSON structure and timestamp formatting
- Duplicate-write suppression
- 100 ms change coalescing
- Pending-value preservation
- Nested cathode updates
- One-second heartbeat snapshots
- Failed writes and preflushes
- Supabase scheduling independence
- Hourly rotation and append-mode recovery
- Filename collisions
- Baseline creation after re-enabling logging