### PR TITLE
Feature: Machine Status Milestones Uploaded to Supabase

### DIFF
--- a/citestfiles/supabase/supabase_integration_test.py
+++ b/citestfiles/supabase/supabase_integration_test.py
@@ -30,6 +30,7 @@ EXPECTED_DICT_LOGGER_KEYS = {
     "vacuumBits",
     "cathode",
     "beam_energy",
+    "machine_status",
 }
 
 

--- a/subsystem/machine_status/README.md
+++ b/subsystem/machine_status/README.md
@@ -245,6 +245,9 @@ Machine Status logs color transitions under the "Machine Status" tag:
 - Red transitions are logged as warnings.
 - Evaluation failures are logged as errors and recovery is logged when normal
   evaluation resumes.
+- The complete displayed state is published to the logger's `machine_status`
+  dictionary field whenever any segment changes. The existing logger pipeline
+  includes that snapshot in `short_term_logs.data`.
 
 During dashboard shutdown, Dashboard cancels Machine Status first because the
 Machine Status worker reads subsystem state. Pending Tk callbacks are cancelled,

--- a/subsystem/machine_status/machine_status.py
+++ b/subsystem/machine_status/machine_status.py
@@ -597,6 +597,7 @@ class MachineStatus:
             return
 
         display_states = calculate_display_states(status_conditions)
+        states_changed = self._previous_display_states != display_states
         self._display_states = display_states
         self._draw_status_bar()
 
@@ -606,6 +607,13 @@ class MachineStatus:
         ):
             status_text = STATE_LOG_TEXT.get(current, current)
             self._log(f"{name} Status Indicator set to: {status_text}", level)
+
+        if (
+            states_changed
+            and self.logger
+            and hasattr(self.logger, "update_field")
+        ):
+            self.logger.update_field("machine_status", dict(display_states))
 
         self._previous_display_states = display_states
 

--- a/subsystem/machine_status/machine_status.py
+++ b/subsystem/machine_status/machine_status.py
@@ -597,7 +597,6 @@ class MachineStatus:
             return
 
         display_states = calculate_display_states(status_conditions)
-        states_changed = self._previous_display_states != display_states
         self._display_states = display_states
         self._draw_status_bar()
 
@@ -609,8 +608,7 @@ class MachineStatus:
             self._log(f"{name} Status Indicator set to: {status_text}", level)
 
         if (
-            states_changed
-            and self.logger
+            self.logger
             and hasattr(self.logger, "update_field")
         ):
             self.logger.update_field("machine_status", dict(display_states))

--- a/utils.py
+++ b/utils.py
@@ -90,7 +90,8 @@ class Logger:
                 "B": {"heater_current": None, "heater_voltage": None, "clamp_temperature": None},
                 "C": {"heater_current": None, "heater_voltage": None, "clamp_temperature": None},
             },
-            "beam_energy": None
+            "beam_energy": None,
+            "machine_status": None,
             }
         if log_to_file:
             self.setup_log_file()


### PR DESCRIPTION
This branch publishes the Machine Status dictionary to the supabase dictionary so that the Webmonitor can display the machine status milestones.

Corresponding Web Monitor PR: https://github.com/uw-loci/EBEAM_webmonitor/pull/37