### PR TITLE
Feature: Beams and Cathode Shutoff Settings Cleanup

### DIFF
--- a/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
+++ b/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
@@ -7,18 +7,18 @@ from unittest.mock import patch
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
-from subsystem.main_control.main_control import BEAM_ACTION_FAILURE_COLOR, MainControlPanel
+from subsystem.main_control.main_control import BEAM_ACTION_NEUTRAL_COLOR, MainControlPanel
 from usr.main_control_config import (
-    BEAMS_ESTOP_CURRENT_LIMIT_FIELD,
-    DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+    BEAMS_DISABLE_CURRENT_LIMIT_FIELD,
+    DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
     DEFAULT_TOTAL_MAX_EMISSION_CURRENT_MA,
     DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
     TOTAL_MAX_EMISSION_CURRENT_FIELD,
     VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD,
-    load_beams_estop_current_limit_ma,
+    load_beams_disable_current_limit_ma,
     load_total_max_emission_current,
     load_vtrx_ccs_disable_grace_period_s,
-    save_beams_estop_current_limit_ma,
+    save_beams_disable_current_limit_ma,
     save_total_max_emission_current,
     save_vtrx_ccs_disable_grace_period_s,
 )
@@ -131,7 +131,7 @@ def make_main_control(now=100.0, cathode=None, beam_pulse=None):
     main_control.disable_beams_on_vtrx_pressure_exceeded = False
     main_control.vtrx_ccs_pressure_shutdown_enabled = True
     main_control.total_max_emission_current_limit_enabled = True
-    main_control.beams_estop_current_limit_enabled = True
+    main_control.beams_disable_current_limit_enabled = True
     main_control._last_vtrx_pressure_mbar = None
     main_control.pressure_reading_is_fresh = False
     main_control.vtrx_firmware_error = False
@@ -194,8 +194,8 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
                 DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
             )
             self.assertEqual(
-                load_beams_estop_current_limit_ma(config_path),
-                DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+                load_beams_disable_current_limit_ma(config_path),
+                DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
             )
 
             self.assertTrue(save_vtrx_ccs_disable_grace_period_s(12.0, config_path))
@@ -205,8 +205,8 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
             self.assertEqual(saved[TOTAL_MAX_EMISSION_CURRENT_FIELD], 7.5)
             self.assertEqual(saved[VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD], 12.0)
             self.assertEqual(
-                saved[BEAMS_ESTOP_CURRENT_LIMIT_FIELD],
-                DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+                saved[BEAMS_DISABLE_CURRENT_LIMIT_FIELD],
+                DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
             )
 
     def test_object_config_preserves_other_setting_on_save(self):
@@ -217,7 +217,7 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
                     {
                         TOTAL_MAX_EMISSION_CURRENT_FIELD: 4.0,
                         VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD: 9.0,
-                        BEAMS_ESTOP_CURRENT_LIMIT_FIELD: 0.7,
+                        BEAMS_DISABLE_CURRENT_LIMIT_FIELD: 0.7,
                     },
                     file,
                 )
@@ -228,15 +228,15 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
 
             self.assertEqual(saved[TOTAL_MAX_EMISSION_CURRENT_FIELD], 5.0)
             self.assertEqual(saved[VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD], 9.0)
-            self.assertEqual(saved[BEAMS_ESTOP_CURRENT_LIMIT_FIELD], 0.7)
+            self.assertEqual(saved[BEAMS_DISABLE_CURRENT_LIMIT_FIELD], 0.7)
 
-            self.assertTrue(save_beams_estop_current_limit_ma(0.5, config_path))
+            self.assertTrue(save_beams_disable_current_limit_ma(0.5, config_path))
             with open(config_path, "r") as file:
                 saved = json.load(file)
 
             self.assertEqual(saved[TOTAL_MAX_EMISSION_CURRENT_FIELD], 5.0)
             self.assertEqual(saved[VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD], 9.0)
-            self.assertEqual(saved[BEAMS_ESTOP_CURRENT_LIMIT_FIELD], 0.5)
+            self.assertEqual(saved[BEAMS_DISABLE_CURRENT_LIMIT_FIELD], 0.5)
 
     def test_missing_config_uses_defaults(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -251,8 +251,8 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
                 DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
             )
             self.assertEqual(
-                load_beams_estop_current_limit_ma(config_path),
-                DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+                load_beams_disable_current_limit_ma(config_path),
+                DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
             )
             with open(config_path, "r") as file:
                 saved = json.load(file)
@@ -266,8 +266,8 @@ class MainControlConfigPersistenceTest(unittest.TestCase):
                 DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
             )
             self.assertEqual(
-                saved[BEAMS_ESTOP_CURRENT_LIMIT_FIELD],
-                DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+                saved[BEAMS_DISABLE_CURRENT_LIMIT_FIELD],
+                DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
             )
 
 
@@ -312,10 +312,10 @@ class MainControlBeamsOffTest(unittest.TestCase):
         self.assertEqual(beam_pulse.stop_all_calls, 1)
         self.assertEqual(beam_pulse.disarm_calls, 1)
 
-    def test_automatic_20kv_estop_retains_cause_after_bcon_confirmation(self):
+    def test_estop_retains_supplied_cause_after_bcon_confirmation(self):
         beam_pulse = FakeBeamPulseEstop()
         main_control = make_main_control_for_beams_off(beam_pulse=beam_pulse)
-        cause = "20kV E-Stop Current Limit exceeded: All Beams Disabled"
+        cause = "Operator-requested E-Stop: All Beams Disabled"
 
         main_control.handle_beams_off(cause)
         token = main_control._pending_bcon_operation["token"]
@@ -340,7 +340,7 @@ class MainControlBeamsOffTest(unittest.TestCase):
             ),
         )
         self.assertEqual(main_control._beam_action_status_outcome, "estop")
-        self.assertEqual(main_control._beam_action_status_color, BEAM_ACTION_FAILURE_COLOR)
+        self.assertEqual(main_control._beam_action_status_color, BEAM_ACTION_NEUTRAL_COLOR)
         self.assertEqual(beam_pulse.complete_disarm_calls, 1)
 
     def test_estop_timeout_preserves_arming_state_and_allows_recovery_action(self):

--- a/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
+++ b/citestfiles/MainControl/main_control_vtrx_ccs_pressure_guard_test.py
@@ -66,16 +66,17 @@ class FakeCathode:
 
 
 class FakeBeamPulse:
-    def __init__(self, connected=True):
+    def __init__(self, connected=True, disable_all_result=True):
         self.disable_all_calls = 0
         self.connected = connected
+        self.disable_all_result = disable_all_result
         self.operation_tokens = []
 
     def disable_all_beams(self, defer_ui=False, operation_token=None):
         self.disable_all_calls += 1
         self.defer_ui_values = getattr(self, "defer_ui_values", []) + [defer_ui]
         self.operation_tokens.append(operation_token)
-        return True
+        return self.disable_all_result
 
     def is_connected(self):
         return self.connected
@@ -442,6 +443,34 @@ class MainControlVtrxCcsGracePeriodUiTest(unittest.TestCase):
 
 
 class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
+    @staticmethod
+    def _start_sent_all_off(main_control, kind):
+        token = main_control._start_bcon_operation(
+            f"{kind} all-off",
+            range(3),
+            expected="all_off",
+            kind=kind,
+        )
+        main_control._handle_bcon_operation_event(
+            "operation_sent",
+            {"token": token, "sent_at": 100.0},
+        )
+        return token
+
+    @staticmethod
+    def _fail_operation(main_control, token, event_type):
+        info = {"operation_token": token}
+        if event_type == "operation_result":
+            info.update(rejected=True, last_reject_reason="TEST_REJECTION")
+        else:
+            info["reason"] = "test failure"
+        main_control._handle_bcon_operation_event(event_type, info)
+
+    @staticmethod
+    def _enable_beam_pressure_guard(main_control):
+        main_control.disable_beams_on_vtrx_pressure_exceeded = True
+        main_control._vtrx_pressure_beam_disable_latched = False
+
     def test_wire_vtrx_gives_cathode_pressure_guard_without_beam_pulse(self):
         cathode = FakeCathode(active=False)
         vtrx = FakeVtrx()
@@ -666,8 +695,7 @@ class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
     def test_stale_pressure_turns_off_bcon_channels_and_latches_until_fresh_safe(self):
         beam_pulse = FakeBeamPulse()
         main_control = make_main_control(beam_pulse=beam_pulse)
-        main_control.disable_beams_on_vtrx_pressure_exceeded = True
-        main_control._vtrx_pressure_beam_disable_latched = False
+        self._enable_beam_pressure_guard(main_control)
         main_control._beam_software_interlock_states = [True, True, True]
 
         main_control._handle_vtrx_pressure_update(5e-6, pressure_reading_is_fresh=False)
@@ -704,11 +732,339 @@ class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
 
         self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
 
+    def test_failed_estop_retries_pressure_shutdown_in_either_event_order(self):
+        for event_type in (
+            "operation_result",
+            "operation_failed",
+            "operation_cancelled",
+        ):
+            for failure_before_pressure in (True, False):
+                with self.subTest(
+                    event_type=event_type,
+                    failure_before_pressure=failure_before_pressure,
+                ):
+                    beam_pulse = FakeBeamPulse()
+                    main_control = make_main_control(beam_pulse=beam_pulse)
+                    self._enable_beam_pressure_guard(main_control)
+                    token = self._start_sent_all_off(main_control, "estop")
+
+                    if failure_before_pressure:
+                        self._fail_operation(main_control, token, event_type)
+                    else:
+                        main_control._handle_vtrx_pressure_update(
+                            2e-5,
+                            pressure_reading_is_fresh=True,
+                        )
+                        self.assertEqual(beam_pulse.disable_all_calls, 0)
+                        self.assertTrue(
+                            main_control._vtrx_pressure_beam_disable_latched
+                        )
+                        self._fail_operation(main_control, token, event_type)
+                        self.assertFalse(
+                            main_control._vtrx_pressure_beam_disable_latched
+                        )
+
+                    failed_estop = main_control._pending_bcon_operation
+                    self.assertEqual(failed_estop["token"], token)
+                    self.assertTrue(failed_estop["safety_failed"])
+
+                    main_control._handle_vtrx_pressure_update(
+                        2e-5,
+                        pressure_reading_is_fresh=True,
+                    )
+
+                    self.assertEqual(beam_pulse.disable_all_calls, 1)
+                    self.assertEqual(
+                        main_control._pending_bcon_operation["kind"],
+                        "disable_all",
+                    )
+                    self.assertNotEqual(
+                        main_control._pending_bcon_operation["token"],
+                        token,
+                    )
+                    self.assertTrue(
+                        main_control._vtrx_pressure_beam_disable_latched
+                    )
+
+    def test_healthy_pending_all_off_covers_pressure_until_safe(self):
+        for kind in ("disable_all", "disarm", "estop"):
+            with self.subTest(kind=kind):
+                beam_pulse = FakeBeamPulse()
+                main_control = make_main_control(beam_pulse=beam_pulse)
+                self._enable_beam_pressure_guard(main_control)
+                token = self._start_sent_all_off(main_control, kind)
+
+                main_control._handle_vtrx_pressure_update(
+                    2e-5,
+                    pressure_reading_is_fresh=True,
+                )
+                main_control._handle_vtrx_pressure_update(
+                    2e-5,
+                    pressure_reading_is_fresh=True,
+                )
+
+                self.assertEqual(beam_pulse.disable_all_calls, 0)
+                self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+                main_control._handle_bcon_operation_event(
+                    "operation_result",
+                    {
+                        "operation_token": token,
+                        "accepted": True,
+                        "last_command_result": "EXECUTED",
+                    },
+                )
+                main_control._handle_bcon_operation_event(
+                    "operation_poll",
+                    {"completed_at": 100.1},
+                )
+                main_control._handle_vtrx_pressure_update(
+                    2e-5,
+                    pressure_reading_is_fresh=True,
+                )
+
+                self.assertIsNone(main_control._pending_bcon_operation)
+                self.assertEqual(beam_pulse.disable_all_calls, 0)
+                self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+                main_control._handle_vtrx_pressure_update(
+                    5e-6,
+                    pressure_reading_is_fresh=True,
+                )
+                self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_unsuccessful_all_off_outcomes_release_pressure_latch(self):
+        event_types = (
+            "operation_result",
+            "operation_failed",
+            "operation_cancelled",
+        )
+        for event_type in event_types:
+            with self.subTest(outcome=event_type):
+                main_control = make_main_control()
+                token = self._start_sent_all_off(main_control, "disarm")
+                main_control._vtrx_pressure_beam_disable_latched = True
+
+                self._fail_operation(main_control, token, event_type)
+
+                self.assertIsNone(main_control._pending_bcon_operation)
+                self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        for state, phase in (
+            ("awaiting_send", "send"),
+            ("awaiting_ack", "ack"),
+            ("awaiting_poll", "ack"),
+        ):
+            with self.subTest(outcome="timeout", state=state):
+                main_control = make_main_control()
+                token = main_control._start_bcon_operation(
+                    "disarm all-off",
+                    range(3),
+                    expected="all_off",
+                    kind="disarm",
+                )
+                main_control._pending_bcon_operation["state"] = state
+                if state != "awaiting_send":
+                    main_control._pending_bcon_operation["sent_at"] = 100.0
+                main_control._vtrx_pressure_beam_disable_latched = True
+
+                main_control._expire_bcon_operation(token, phase)
+
+                self.assertIsNone(main_control._pending_bcon_operation)
+                self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control = make_main_control()
+        self._start_sent_all_off(main_control, "disarm")
+        main_control._vtrx_pressure_beam_disable_latched = True
+
+        main_control._terminate_pending_bcon_operation("test disconnect")
+
+        self.assertIsNone(main_control._pending_bcon_operation)
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_non_all_off_failures_do_not_release_pressure_latch(self):
+        for outcome in ("rejected", "failed", "cancelled", "timeout", "terminated"):
+            with self.subTest(outcome=outcome):
+                main_control = make_main_control()
+                token = main_control._start_bcon_operation(
+                    "normal operation",
+                    (0,),
+                    expected="poll",
+                    kind="normal",
+                )
+                main_control._vtrx_pressure_beam_disable_latched = True
+
+                if outcome == "rejected":
+                    self._fail_operation(
+                        main_control,
+                        token,
+                        "operation_result",
+                    )
+                elif outcome == "failed":
+                    self._fail_operation(
+                        main_control,
+                        token,
+                        "operation_failed",
+                    )
+                elif outcome == "cancelled":
+                    self._fail_operation(
+                        main_control,
+                        token,
+                        "operation_cancelled",
+                    )
+                elif outcome == "timeout":
+                    main_control._expire_bcon_operation(token, "send")
+                else:
+                    main_control._terminate_pending_bcon_operation(
+                        "test disconnect"
+                    )
+
+                self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_all_off_preemption_keeps_latch_until_final_operation_fails(self):
+        beam_pulse = FakeBeamPulse()
+        main_control = make_main_control(beam_pulse=beam_pulse)
+        self._enable_beam_pressure_guard(main_control)
+        disable_token = self._start_sent_all_off(main_control, "disable_all")
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+        disarm_token = self._start_sent_all_off(main_control, "disarm")
+
+        self.assertNotEqual(disarm_token, disable_token)
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+        self._fail_operation(main_control, disable_token, "operation_failed")
+
+        self.assertEqual(
+            main_control._pending_bcon_operation["token"],
+            disarm_token,
+        )
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+        estop_token = self._start_sent_all_off(main_control, "estop")
+
+        self.assertNotEqual(estop_token, disarm_token)
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+        self._fail_operation(main_control, estop_token, "operation_failed")
+
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+
+        self.assertEqual(beam_pulse.disable_all_calls, 1)
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_failed_estop_poll_still_allows_conservative_pressure_retry(self):
+        beam_pulse = FakeBeamPulse()
+        main_control = make_main_control(beam_pulse=beam_pulse)
+        self._enable_beam_pressure_guard(main_control)
+        token = self._start_sent_all_off(main_control, "estop")
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+        self._fail_operation(main_control, token, "operation_failed")
+        main_control._handle_bcon_operation_event(
+            "operation_poll",
+            {"completed_at": 100.1},
+        )
+
+        self.assertIsNone(main_control._pending_bcon_operation)
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+
+        self.assertEqual(beam_pulse.disable_all_calls, 1)
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_synchronous_all_off_failure_waits_for_timeout_before_retry(self):
+        beam_pulse = FakeBeamPulse(disable_all_result=False)
+        main_control = make_main_control(beam_pulse=beam_pulse)
+        self._enable_beam_pressure_guard(main_control)
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+
+        failed_token = main_control._pending_bcon_operation["token"]
+        self.assertEqual(beam_pulse.disable_all_calls, 1)
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+
+        self.assertEqual(beam_pulse.disable_all_calls, 1)
+        self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control._expire_bcon_operation(failed_token, "send")
+
+        self.assertIsNone(main_control._pending_bcon_operation)
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+        main_control._handle_vtrx_pressure_update(
+            2e-5,
+            pressure_reading_is_fresh=True,
+        )
+
+        self.assertEqual(beam_pulse.disable_all_calls, 2)
+        self.assertFalse(main_control._vtrx_pressure_beam_disable_latched)
+
+    def test_all_unsafe_pressure_sources_share_all_off_retry_behavior(self):
+        unsafe_updates = (
+            (2e-5, True, False),
+            (5e-6, False, False),
+            (5e-6, True, True),
+        )
+        for pressure, fresh, firmware_error in unsafe_updates:
+            with self.subTest(
+                pressure=pressure,
+                fresh=fresh,
+                firmware_error=firmware_error,
+            ):
+                beam_pulse = FakeBeamPulse()
+                main_control = make_main_control(beam_pulse=beam_pulse)
+                self._enable_beam_pressure_guard(main_control)
+                token = self._start_sent_all_off(main_control, "estop")
+
+                main_control._handle_vtrx_pressure_update(
+                    pressure,
+                    pressure_reading_is_fresh=fresh,
+                    firmware_error=firmware_error,
+                )
+                self.assertEqual(beam_pulse.disable_all_calls, 0)
+
+                self._fail_operation(
+                    main_control,
+                    token,
+                    "operation_cancelled",
+                )
+                main_control._handle_vtrx_pressure_update(
+                    pressure,
+                    pressure_reading_is_fresh=fresh,
+                    firmware_error=firmware_error,
+                )
+
+                self.assertEqual(beam_pulse.disable_all_calls, 1)
+                self.assertTrue(main_control._vtrx_pressure_beam_disable_latched)
+
     def test_high_pressure_resets_interlocks_only_after_confirmed_all_off_poll(self):
         beam_pulse = FakeBeamPulse()
         main_control = make_main_control(beam_pulse=beam_pulse)
-        main_control.disable_beams_on_vtrx_pressure_exceeded = True
-        main_control._vtrx_pressure_beam_disable_latched = False
+        self._enable_beam_pressure_guard(main_control)
         main_control._beam_software_interlock_states = [True, True, True]
 
         main_control._handle_vtrx_pressure_update(2e-5, pressure_reading_is_fresh=True)
@@ -735,8 +1091,7 @@ class MainControlVtrxCcsPressureTimerTest(unittest.TestCase):
     def test_vtrx_firmware_error_turns_off_bcon_channels_and_latches_until_clear(self):
         beam_pulse = FakeBeamPulse()
         main_control = make_main_control(beam_pulse=beam_pulse)
-        main_control.disable_beams_on_vtrx_pressure_exceeded = True
-        main_control._vtrx_pressure_beam_disable_latched = False
+        self._enable_beam_pressure_guard(main_control)
 
         main_control._handle_vtrx_pressure_update(
             5e-6,

--- a/citestfiles/beam_energy_warning_limits_test.py
+++ b/citestfiles/beam_energy_warning_limits_test.py
@@ -60,9 +60,22 @@ class FakeVar:
 class FakeBeamEnergyForMainControl:
     def __init__(self):
         self.raw_values = []
+        self.callback = None
 
-    def set_beams_estop_current_limit_ma(self, value_ma):
+    def set_beams_disable_current_limit_ma(self, value_ma):
         self.raw_values.append(value_ma)
+        return True
+
+    def set_beams_disable_callback(self, callback):
+        self.callback = callback
+
+
+class FakeBeamPulseForDisarm:
+    def __init__(self):
+        self.disarm_calls = []
+
+    def disarm_beams(self, operation_token=None, defer_ui=False):
+        self.disarm_calls.append((operation_token, defer_ui))
         return True
 
 
@@ -77,7 +90,7 @@ def make_beam_energy():
         supply_key: dict(limits)
         for supply_key, limits in DEFAULT_WARNING_LIMITS.items()
     }
-    beam_energy.beams_estop_current_limit_ma = None
+    beam_energy.beams_disable_current_limit_ma = None
     beam_energy.refresh_warning_indicators = lambda _index: None
     beam_energy.latest_actual_voltage_values = [None for _ in SUPPLY_KEYS]
     beam_energy.latest_actual_current_values = [None for _ in SUPPLY_KEYS]
@@ -86,8 +99,8 @@ def make_beam_energy():
     beam_energy._radiation_indicator_last_valid_state = None
     beam_energy._radiation_indicator_sent = None
     beam_energy._radiation_indicator_missing_callback_state = None
-    beam_energy.beams_estop_callback = None
-    beam_energy.beams_estop_current_limit_enabled = True
+    beam_energy.beams_disable_callback = None
+    beam_energy.beams_disable_current_limit_enabled = True
     return beam_energy
 
 
@@ -98,10 +111,10 @@ class BeamEnergyWarningLimitConfigTest(unittest.TestCase):
 
             limits = load_beam_energy_warning_limits(config_path)
 
-            self.assertNotIn("beams_estop_current_ma", limits[POS20KV_SUPPLY_KEY])
+            self.assertNotIn("beams_disable_current_ma", limits[POS20KV_SUPPLY_KEY])
             with open(config_path, "r") as file:
                 saved = json.load(file)
-            self.assertNotIn("beams_estop_current_ma", saved[POS20KV_SUPPLY_KEY])
+            self.assertNotIn("beams_disable_current_ma", saved[POS20KV_SUPPLY_KEY])
 
     def test_pos20kv_current_warning_limit_normalizes(self):
         for max_current in (0.0, 0.5, 1.0):
@@ -121,24 +134,24 @@ class BeamEnergyWarningLimitConfigTest(unittest.TestCase):
 
 
 class BeamEnergyWarningLimitSetterTest(unittest.TestCase):
-    def test_beams_estop_limit_stores_value_sent_by_main_control(self):
+    def test_beams_disable_limit_stores_value_sent_by_main_control(self):
         beam_energy = make_beam_energy()
         pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
         refreshed_indexes = []
         beam_energy.refresh_warning_indicators = refreshed_indexes.append
 
-        result = beam_energy.set_beams_estop_current_limit_ma(0.5)
+        result = beam_energy.set_beams_disable_current_limit_ma(0.5)
 
         self.assertTrue(result)
-        self.assertEqual(beam_energy.beams_estop_current_limit_ma, 0.5)
+        self.assertEqual(beam_energy.beams_disable_current_limit_ma, 0.5)
         self.assertEqual(refreshed_indexes, [pos20kv_index])
 
-    def test_pos20kv_current_estop_uses_main_control_limit(self):
+    def test_pos20kv_current_beams_disable_uses_main_control_limit(self):
         beam_energy = make_beam_energy()
         pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
         triggered = []
-        beam_energy.beams_estop_callback = lambda: triggered.append(True)
-        beam_energy.set_beams_estop_current_limit_ma(0.5)
+        beam_energy.beams_disable_callback = lambda: triggered.append(True)
+        beam_energy.set_beams_disable_current_limit_ma(0.5)
 
         beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.49)
         self.assertEqual(triggered, [])
@@ -146,30 +159,30 @@ class BeamEnergyWarningLimitSetterTest(unittest.TestCase):
         beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.5)
         self.assertEqual(triggered, [True])
 
-    def test_pos20kv_current_estop_can_be_disabled(self):
+    def test_pos20kv_current_beams_disable_can_be_disabled(self):
         beam_energy = make_beam_energy()
         pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
         refreshed_indexes = []
         triggered = []
         beam_energy.refresh_warning_indicators = refreshed_indexes.append
-        beam_energy.beams_estop_callback = lambda: triggered.append(True)
-        beam_energy.set_beams_estop_current_limit_ma(0.5)
+        beam_energy.beams_disable_callback = lambda: triggered.append(True)
+        beam_energy.set_beams_disable_current_limit_ma(0.5)
 
-        result = beam_energy.set_beams_estop_current_limit_enabled(False)
+        result = beam_energy.set_beams_disable_current_limit_enabled(False)
         beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.5)
 
         self.assertTrue(result)
-        self.assertFalse(beam_energy.beams_estop_current_limit_enabled)
+        self.assertFalse(beam_energy.beams_disable_current_limit_enabled)
         self.assertEqual(triggered, [])
         self.assertEqual(refreshed_indexes, [pos20kv_index, pos20kv_index])
 
-    def test_pos20kv_max_current_warning_accepts_values_above_or_below_estop(self):
+    def test_pos20kv_max_current_warning_accepts_values_above_or_below_beams_disable(self):
         pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
 
-        for max_current, estop_current in ((1.0, 0.25), (0.25, 1.0)):
-            with self.subTest(max_current=max_current, estop_current=estop_current):
+        for max_current, beams_disable_current in ((1.0, 0.25), (0.25, 1.0)):
+            with self.subTest(max_current=max_current, beams_disable_current=beams_disable_current):
                 beam_energy = make_beam_energy()
-                beam_energy.beams_estop_current_limit_ma = estop_current
+                beam_energy.beams_disable_current_limit_ma = beams_disable_current
 
                 result = beam_energy._set_warning_limit_from_raw(
                     pos20kv_index,
@@ -253,44 +266,90 @@ class BeamEnergyRadiationIndicatorTest(unittest.TestCase):
         self.assertEqual(sent_states, [True])
 
 
-class MainControlBeamsEstopLimitUiTest(unittest.TestCase):
-    def test_main_control_formats_beams_estop_limit_display(self):
+class MainControlBeamsDisableLimitUiTest(unittest.TestCase):
+    def test_main_control_formats_beams_disable_limit_display(self):
         main_control = MainControlPanel.__new__(MainControlPanel)
 
         self.assertEqual(
-            main_control._format_beams_estop_current_limit_ma(0.5),
+            main_control._format_beams_disable_current_limit_ma(0.5),
             "0.5",
         )
         self.assertEqual(
-            main_control._format_beams_estop_current_limit_ma(None),
+            main_control._format_beams_disable_current_limit_ma(None),
             "--",
         )
 
-    @patch("subsystem.main_control.main_control.save_beams_estop_current_limit_ma")
-    def test_main_control_logs_successful_beams_estop_limit_update(self, save_mock):
+    def test_beam_energy_threshold_uses_disarm_beams_path(self):
+        main_control = MainControlPanel.__new__(MainControlPanel)
+        beam_energy = FakeBeamEnergyForMainControl()
+        disarm_causes = []
+        main_control.subsystems = {"Beam Energy": beam_energy}
+        main_control.beams_disable_current_limit_ma = 0.7
+        main_control.beams_disable_current_limit_enabled = True
+        main_control._request_disarm_beams = (
+            lambda cause=None: disarm_causes.append(cause) or True
+        )
+        main_control.refresh_beams_disable_current_limit_display = lambda: None
+        main_control._apply_logging_suppression_settings = lambda: None
+
+        main_control.wire_beam_energy(beam_energy)
+        beam_energy.callback()
+
+        self.assertEqual(
+            disarm_causes,
+            ["Disable Beams if 20kV Bertan exceeds 0.7mA"],
+        )
+
+    def test_request_disarm_beams_calls_beam_pulse_disarm(self):
+        main_control = MainControlPanel.__new__(MainControlPanel)
+        beam_pulse = FakeBeamPulseForDisarm()
+        operations = []
+        main_control.subsystems = {"Beam Pulse": beam_pulse}
+
+        def start_operation(action, channels, expected="poll", kind="normal", cause=None):
+            operations.append((action, tuple(channels), expected, kind, cause))
+            return "bcon-1"
+
+        main_control._start_bcon_operation = start_operation
+
+        self.assertTrue(main_control._request_disarm_beams(cause="20kV threshold"))
+        self.assertEqual(
+            operations,
+            [(
+                "Disarm Beams command: all channels mode=OFF",
+                (0, 1, 2),
+                "all_off",
+                "disarm",
+                "20kV threshold",
+            )],
+        )
+        self.assertEqual(beam_pulse.disarm_calls, [("bcon-1", True)])
+
+    @patch("subsystem.main_control.main_control.save_beams_disable_current_limit_ma")
+    def test_main_control_logs_successful_beams_disable_limit_update(self, save_mock):
         save_mock.return_value = True
         main_control = MainControlPanel.__new__(MainControlPanel)
         beam_energy = FakeBeamEnergyForMainControl()
         logger = FakeMainControlLogger()
         main_control.subsystems = {"Beam Energy": beam_energy}
         main_control.logger = logger
-        main_control.beams_estop_current_limit_ma = 0.7
-        main_control.beams_estop_current_entry_var = FakeVar("0.5")
-        main_control.beams_estop_current_value_var = FakeVar()
+        main_control.beams_disable_current_limit_ma = 0.7
+        main_control.beams_disable_current_entry_var = FakeVar("0.5")
+        main_control.beams_disable_current_value_var = FakeVar()
 
-        main_control.set_beams_estop_current_limit()
+        main_control.set_beams_disable_current_limit()
 
         self.assertEqual(beam_energy.raw_values, [0.5])
-        self.assertEqual(main_control.beams_estop_current_entry_var.get(), "")
+        self.assertEqual(main_control.beams_disable_current_entry_var.get(), "")
         self.assertEqual(
-            main_control.beams_estop_current_value_var.get(),
+            main_control.beams_disable_current_value_var.get(),
             "0.5",
         )
         self.assertEqual(
             logger.info_entries,
             [
                 (
-                    "Trigger E-Stop if 20kV Bertan exceeds 0.5mA: "
+                    "Disable Beams if 20kV Bertan exceeds 0.5mA: "
                     "setting successfully changed.",
                     "Main Control",
                 )
@@ -298,18 +357,18 @@ class MainControlBeamsEstopLimitUiTest(unittest.TestCase):
         )
 
     @patch("subsystem.main_control.main_control.messagebox.showerror")
-    @patch("subsystem.main_control.main_control.save_beams_estop_current_limit_ma")
-    def test_main_control_rejects_beams_estop_limit_above_one_ma(self, save_mock, showerror_mock):
+    @patch("subsystem.main_control.main_control.save_beams_disable_current_limit_ma")
+    def test_main_control_rejects_beams_disable_limit_above_one_ma(self, save_mock, showerror_mock):
         main_control = MainControlPanel.__new__(MainControlPanel)
         main_control.subsystems = {"Beam Energy": FakeBeamEnergyForMainControl()}
         main_control.logger = FakeMainControlLogger()
-        main_control.beams_estop_current_limit_ma = 0.7
-        main_control.beams_estop_current_entry_var = FakeVar("1.1")
-        main_control.beams_estop_current_value_var = FakeVar("0.7")
+        main_control.beams_disable_current_limit_ma = 0.7
+        main_control.beams_disable_current_entry_var = FakeVar("1.1")
+        main_control.beams_disable_current_value_var = FakeVar("0.7")
 
-        main_control.set_beams_estop_current_limit()
+        main_control.set_beams_disable_current_limit()
 
-        self.assertEqual(main_control.beams_estop_current_limit_ma, 0.7)
+        self.assertEqual(main_control.beams_disable_current_limit_ma, 0.7)
         self.assertFalse(save_mock.called)
         showerror_mock.assert_called_once()
 

--- a/citestfiles/beam_energy_warning_limits_test.py
+++ b/citestfiles/beam_energy_warning_limits_test.py
@@ -66,19 +66,6 @@ class FakeBeamEnergyForMainControl:
         self.raw_values.append(value_ma)
         return True
 
-    def set_beams_disable_callback(self, callback):
-        self.callback = callback
-
-
-class FakeBeamPulseForDisarm:
-    def __init__(self):
-        self.disarm_calls = []
-
-    def disarm_beams(self, operation_token=None, defer_ui=False):
-        self.disarm_calls.append((operation_token, defer_ui))
-        return True
-
-
 def make_beam_energy():
     beam_energy = BeamEnergySubsystem.__new__(BeamEnergySubsystem)
     beam_energy.logger = FakeLogger()
@@ -134,47 +121,6 @@ class BeamEnergyWarningLimitConfigTest(unittest.TestCase):
 
 
 class BeamEnergyWarningLimitSetterTest(unittest.TestCase):
-    def test_beams_disable_limit_stores_value_sent_by_main_control(self):
-        beam_energy = make_beam_energy()
-        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
-        refreshed_indexes = []
-        beam_energy.refresh_warning_indicators = refreshed_indexes.append
-
-        result = beam_energy.set_beams_disable_current_limit_ma(0.5)
-
-        self.assertTrue(result)
-        self.assertEqual(beam_energy.beams_disable_current_limit_ma, 0.5)
-        self.assertEqual(refreshed_indexes, [pos20kv_index])
-
-    def test_pos20kv_current_beams_disable_uses_main_control_limit(self):
-        beam_energy = make_beam_energy()
-        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
-        triggered = []
-        beam_energy.beams_disable_callback = lambda: triggered.append(True)
-        beam_energy.set_beams_disable_current_limit_ma(0.5)
-
-        beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.49)
-        self.assertEqual(triggered, [])
-
-        beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.5)
-        self.assertEqual(triggered, [True])
-
-    def test_pos20kv_current_beams_disable_can_be_disabled(self):
-        beam_energy = make_beam_energy()
-        pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
-        refreshed_indexes = []
-        triggered = []
-        beam_energy.refresh_warning_indicators = refreshed_indexes.append
-        beam_energy.beams_disable_callback = lambda: triggered.append(True)
-        beam_energy.set_beams_disable_current_limit_ma(0.5)
-
-        result = beam_energy.set_beams_disable_current_limit_enabled(False)
-        beam_energy.apply_warning_indicators(pos20kv_index, 0, 0.5)
-
-        self.assertTrue(result)
-        self.assertFalse(beam_energy.beams_disable_current_limit_enabled)
-        self.assertEqual(triggered, [])
-        self.assertEqual(refreshed_indexes, [pos20kv_index, pos20kv_index])
 
     def test_pos20kv_max_current_warning_accepts_values_above_or_below_beams_disable(self):
         pos20kv_index = SUPPLY_KEYS.index(POS20KV_SUPPLY_KEY)
@@ -267,6 +213,11 @@ class BeamEnergyRadiationIndicatorTest(unittest.TestCase):
 
 
 class MainControlBeamsDisableLimitUiTest(unittest.TestCase):
+    def test_disarm_bcon_operations_are_critical(self):
+        self.assertTrue(
+            MainControlPanel._is_critical_bcon_operation({"kind": "disarm"})
+        )
+
     def test_main_control_formats_beams_disable_limit_display(self):
         main_control = MainControlPanel.__new__(MainControlPanel)
 
@@ -278,52 +229,6 @@ class MainControlBeamsDisableLimitUiTest(unittest.TestCase):
             main_control._format_beams_disable_current_limit_ma(None),
             "--",
         )
-
-    def test_beam_energy_threshold_uses_disarm_beams_path(self):
-        main_control = MainControlPanel.__new__(MainControlPanel)
-        beam_energy = FakeBeamEnergyForMainControl()
-        disarm_causes = []
-        main_control.subsystems = {"Beam Energy": beam_energy}
-        main_control.beams_disable_current_limit_ma = 0.7
-        main_control.beams_disable_current_limit_enabled = True
-        main_control._request_disarm_beams = (
-            lambda cause=None: disarm_causes.append(cause) or True
-        )
-        main_control.refresh_beams_disable_current_limit_display = lambda: None
-        main_control._apply_logging_suppression_settings = lambda: None
-
-        main_control.wire_beam_energy(beam_energy)
-        beam_energy.callback()
-
-        self.assertEqual(
-            disarm_causes,
-            ["Disable Beams if 20kV Bertan exceeds 0.7mA"],
-        )
-
-    def test_request_disarm_beams_calls_beam_pulse_disarm(self):
-        main_control = MainControlPanel.__new__(MainControlPanel)
-        beam_pulse = FakeBeamPulseForDisarm()
-        operations = []
-        main_control.subsystems = {"Beam Pulse": beam_pulse}
-
-        def start_operation(action, channels, expected="poll", kind="normal", cause=None):
-            operations.append((action, tuple(channels), expected, kind, cause))
-            return "bcon-1"
-
-        main_control._start_bcon_operation = start_operation
-
-        self.assertTrue(main_control._request_disarm_beams(cause="20kV threshold"))
-        self.assertEqual(
-            operations,
-            [(
-                "Disarm Beams command: all channels mode=OFF",
-                (0, 1, 2),
-                "all_off",
-                "disarm",
-                "20kV threshold",
-            )],
-        )
-        self.assertEqual(beam_pulse.disarm_calls, [("bcon-1", True)])
 
     @patch("subsystem.main_control.main_control.save_beams_disable_current_limit_ma")
     def test_main_control_logs_successful_beams_disable_limit_update(self, save_mock):

--- a/citestfiles/beam_energy_warning_limits_test.py
+++ b/citestfiles/beam_energy_warning_limits_test.py
@@ -254,7 +254,7 @@ class MainControlBeamsDisableLimitUiTest(unittest.TestCase):
             logger.info_entries,
             [
                 (
-                    "Disable Beams if 20kV Bertan exceeds 0.5mA: "
+                    "Disable Beams if 20kV Bertan reaches or exceeds 0.5mA: "
                     "setting successfully changed.",
                     "Main Control",
                 )

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -26,7 +26,7 @@ class BeamEnergySubsystem:
     """
 
     displayFont = "Arial"
-    ESTOP_TEXT_COLOR = "red"
+    BEAMS_DISABLE_TEXT_COLOR = "red"
     WARNING_TEXT_COLOR = "#FF8000"
     NORMAL_TEXT_COLOR = "black"
 
@@ -103,7 +103,7 @@ class BeamEnergySubsystem:
         ]
         self.supply_keys = [supply_key for supply_key, _ in self.supply_payload_map]
         self.warning_limits = load_beam_energy_warning_limits(logger=self.logger)
-        self.beams_estop_current_limit_ma = None
+        self.beams_disable_current_limit_ma = None
         # Last numeric readings let limit edits immediately refresh colors/trips without waiting for a new poll.
         self.latest_actual_voltage_values = [None for _ in self.power_supplies]
         self.latest_actual_current_values = [None for _ in self.power_supplies]
@@ -135,9 +135,9 @@ class BeamEnergySubsystem:
         self.ccs_power_on = False
         self.disable_logging_when_hvolt_off = False
         self.hvolt_on_provider = None
-        # Main Control pushes the +20kV current threshold; Dashboard provides the stop handler.
-        self.beams_estop_callback = None
-        self.beams_estop_current_limit_enabled = True
+        # Main Control pushes the +20kV current threshold; Dashboard provides the beam-disable handler.
+        self.beams_disable_callback = None
+        self.beams_disable_current_limit_enabled = True
         # Dashboard wires this to LaserMonitorDriver.set_radiation_indicator().
         # The last-sent value prevents repeated sends during unchanged 500 ms polls.
         self.radiation_indicator_callback = None
@@ -343,7 +343,7 @@ class BeamEnergySubsystem:
                 ttk.Label(
                     frame,
                     text=(
-                        "20kV Bertan Current Limit for Beams E-Stop trigger can "
+                        "20kV Bertan Current Limit for Automatic Beam Disarm can "
                         "be found in the Main Control Config menu"
                     ),
                     font=("Segoe UI", 8, "italic"),
@@ -375,15 +375,15 @@ class BeamEnergySubsystem:
         sign = "-" if supply_key == "neg1kv" and field != "max_current_ma" else ""
         return f"Limit set to: {sign}{value:g}{self._warning_limit_unit(field)}"
 
-    def set_beams_estop_current_limit_ma(self, value_ma):
-        """Receive the +20kV Beams E-STOP current limit from Main Control."""
-        self.beams_estop_current_limit_ma = value_ma
+    def set_beams_disable_current_limit_ma(self, value_ma):
+        """Receive the +20kV automatic beam-disable current limit from Main Control."""
+        self.beams_disable_current_limit_ma = value_ma
         self.refresh_warning_indicators(self._get_pos20kv_index())
         return True
 
-    def set_beams_estop_current_limit_enabled(self, enabled):
-        """Receive whether Main Control's +20kV Beams E-STOP guard is active."""
-        self.beams_estop_current_limit_enabled = bool(enabled)
+    def set_beams_disable_current_limit_enabled(self, enabled):
+        """Receive whether Main Control's +20kV automatic beam-disable guard is active."""
+        self.beams_disable_current_limit_enabled = bool(enabled)
         self.refresh_warning_indicators(self._get_pos20kv_index())
         return True
 
@@ -528,26 +528,26 @@ class BeamEnergySubsystem:
             return None
         return abs(value) if supply_key == "neg1kv" else value
 
-    def _trigger_beams_estop_current(self, current_ma, limit_ma):
+    def _trigger_beams_disable_current(self, current_ma, limit_ma):
         self.log(
-            "+20kV Bertan automatic Beams E-STOP: actual current "
-            f"{current_ma:.3f}mA exceeded E-STOP limit {limit_ma:g}mA.",
+            "+20kV Bertan automatic beam disable: actual current "
+            f"{current_ma:.3f}mA reached beam-disable limit {limit_ma:g}mA.",
             LogLevel.CRITICAL,
         )
 
-        callback = getattr(self, "beams_estop_callback", None)
+        callback = getattr(self, "beams_disable_callback", None)
         if not callable(callback):
-            self.log("Automatic Beams E-STOP callback is not configured.", LogLevel.CRITICAL)
+            self.log("Automatic beam-disable callback is not configured.", LogLevel.CRITICAL)
             return
 
         try:
             callback()
         except Exception as e:
-            self.log(f"Automatic Beams E-STOP callback failed: {e}", LogLevel.CRITICAL)
+            self.log(f"Automatic beam-disable callback failed: {e}", LogLevel.CRITICAL)
 
-    def set_beams_estop_callback(self, callback):
-        """Register the dashboard's Beams E-STOP handler."""
-        self.beams_estop_callback = callback
+    def set_beams_disable_callback(self, callback):
+        """Register the dashboard's automatic beam-disarm handler."""
+        self.beams_disable_callback = callback
         pos20kv_index = self._get_pos20kv_index()
 
         def _recheck():
@@ -673,24 +673,24 @@ class BeamEnergySubsystem:
             current_value is not None
             and current_value >= limits["max_current_ma"]
         )
-        beams_estop_limit_ma = self.beams_estop_current_limit_ma
-        current_estop = (
+        beams_disable_limit_ma = self.beams_disable_current_limit_ma
+        current_beams_disable = (
             supply_key == POS20KV_SUPPLY_KEY
             and current_value is not None
-            and beams_estop_limit_ma is not None
-            and bool(getattr(self, "beams_estop_current_limit_enabled", True))
-            and current_value >= beams_estop_limit_ma
+            and beams_disable_limit_ma is not None
+            and bool(getattr(self, "beams_disable_current_limit_enabled", True))
+            and current_value >= beams_disable_limit_ma
         )
 
         if voltage_warning:
             self._log_warning_breach(index, "voltage", voltage_value)
-        # For 20kV: the E-STOP threshold takes priority over the Max I warning.
-        if current_estop:
-            self._trigger_beams_estop_current(
+        # For 20kV: the automatic beam-disable threshold takes priority over the Max I warning.
+        if current_beams_disable:
+            self._trigger_beams_disable_current(
                 current_value,
-                beams_estop_limit_ma,
+                beams_disable_limit_ma,
             )
-        if current_warning and not current_estop:
+        if current_warning and not current_beams_disable:
             self._log_warning_breach(index, "current", current_value)
 
         voltage_color = (
@@ -698,8 +698,8 @@ class BeamEnergySubsystem:
             if voltage_warning
             else self.NORMAL_TEXT_COLOR
         )
-        if current_estop:
-            current_color = self.ESTOP_TEXT_COLOR
+        if current_beams_disable:
+            current_color = self.BEAMS_DISABLE_TEXT_COLOR
         elif current_warning:
             current_color = self.WARNING_TEXT_COLOR
         else:

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -679,7 +679,7 @@ class BeamEnergySubsystem:
             and current_value is not None
             and beams_disable_limit_ma is not None
             and bool(getattr(self, "beams_disable_current_limit_enabled", True))
-            and current_value >= beams_disable_limit_ma
+            and current_value > beams_disable_limit_ma
         )
 
         if voltage_warning:

--- a/subsystem/beam_energy/beam_energy.py
+++ b/subsystem/beam_energy/beam_energy.py
@@ -679,7 +679,7 @@ class BeamEnergySubsystem:
             and current_value is not None
             and beams_disable_limit_ma is not None
             and bool(getattr(self, "beams_disable_current_limit_enabled", True))
-            and current_value > beams_disable_limit_ma
+            and current_value >= beams_disable_limit_ma
         )
 
         if voltage_warning:

--- a/subsystem/beam_pulse/README.md
+++ b/subsystem/beam_pulse/README.md
@@ -29,7 +29,7 @@ flowchart TD
     BeamPulse -->|"manual disconnect check,<br/>disconnect notification"| MainControl
     MainControl -->|"BCON-connected provider,<br/>guard setting, turn_off_all_beams()"| Cathode
 
-    BeamEnergy -->|"+20kV current E-stop callback"| MainControl
+    BeamEnergy -->|"+20kV current Disarm callback"| MainControl
     MainControl -->|"turn_off_all_beams()"| Cathode
 
     BeamPulse -->|"high-level channel activation/stop calls"| Driver["BCONDriver<br/>instrumentctl/BCON"]

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -53,8 +53,8 @@ Main Control is a two-tab subpanel.
 - Disable CCS Output on BCON Disconnect toggle.
 - Disable CCS Output if pressure exceeds 10^-5 mbar for the configured grace
   period control.
-- Disable Beams if pressure reaches or exceeds 10^-5 mbar toggle.
-- Disable Beams if 20kV Bertan exceeds the configured current limit control.
+- Disable Beams if pressure exceeds 10^-5 mbar toggle.
+- Disable Beams if 20kV Bertan reaches or exceeds the configured current limit control.
 - Do not activate Beams if Predicted Emission Current exceeds the configured
   limit control.
 - F1 keyboard shortcut hint.
@@ -162,12 +162,12 @@ post-command poll confirms all channels OFF.
 
 VTRX reports pressure updates to Main Control. When the high-pressure
 beam-disable guard is enabled, Main Control uses the tokenized Disable All Beams
-flow on the first high, stale, unavailable, or firmware-error reading. A pending
-Disable All, Disarm, or E-stop operation with an all-off expectation covers the
-same requirement without a redundant command. A confirming all-off poll
-satisfies the VTRX shutdown; an unsuccessful terminal outcome releases the
-latch so another unsafe reading retries. Main Control then waits for pressure
-to recover to 1e-5 mbar or below before a new shutdown episode can trigger.
+flow on the first high, stale, unavailable, or firmware-error reading. Any
+healthy pending operation that expects all channels off satisfies the same
+requirement without a redundant command. The global VTRX latch remains set
+after confirmation and clears when pressure recovers to 1e-5 mbar or below. Any
+unsuccessful all-off outcome clears the latch so a later unsafe reading retries;
+a conservative redundant all-off after an uncertain outcome is intentional.
 
 Main Control also uses VTRX pressure to protect CCS output. Stale pressure or
 pressure above 1e-5 mbar starts the configured CCS grace-period timer only when
@@ -256,10 +256,12 @@ Dashboard callbacks.
   block cathode output enable requests.
 - Disable Beams if pressure exceeds 10^-5 mbar is a runtime Main Control
   setting. When enabled, an unsafe or stale VTRX reading invalidates any pending
-  operator action and requests tokenized BCON all-off. An already-pending
-  all-off Disable All, Disarm, or E-stop covers that request; confirmation keeps
-  the VTRX episode latched, while failure releases it for retry. Dashboard
-  interlocks clear only after a post-command poll confirms all channels OFF.
+  operator action and requests tokenized BCON all-off unless a healthy pending
+  operation already expects all channels off. Confirmation keeps the global
+  VTRX episode latched, while any failure, rejection, cancellation, timeout, or
+  termination makes the next unsafe update eligible to retry. Dashboard
+  interlocks clear only after a post-command poll confirms all channels OFF;
+  operations do not carry or transfer VTRX-specific coverage state.
 - Disable CCS Output after the configured grace period above 10^-5 mbar applies
   when CCS output is active. The grace-period duration is persisted in Main
   Control config, defaults to 30 seconds, blocks new CCS output enables while

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -53,7 +53,7 @@ Main Control is a two-tab subpanel.
 - Disable CCS Output on BCON Disconnect toggle.
 - Disable CCS Output if pressure exceeds 10^-5 mbar for the configured grace
   period control.
-- Disable Beams if pressure exceeds 10^-5 mbar toggle.
+- Disable Beams if pressure reaches or exceeds 10^-5 mbar toggle.
 - Disable Beams if 20kV Bertan exceeds the configured current limit control.
 - Do not activate Beams if Predicted Emission Current exceeds the configured
   limit control.
@@ -162,10 +162,12 @@ post-command poll confirms all channels OFF.
 
 VTRX reports pressure updates to Main Control. When the high-pressure
 beam-disable guard is enabled, Main Control uses the tokenized Disable All Beams
-flow on the first high, stale, unavailable, or firmware-error reading. It
-clears dashboard software interlocks only after the post-command BCON poll
-confirms every channel OFF, then waits for pressure to recover to 1e-5 mbar or
-below before it can trigger again.
+flow on the first high, stale, unavailable, or firmware-error reading. A pending
+Disable All, Disarm, or E-stop operation with an all-off expectation covers the
+same requirement without a redundant command. A confirming all-off poll
+satisfies the VTRX shutdown; an unsuccessful terminal outcome releases the
+latch so another unsafe reading retries. Main Control then waits for pressure
+to recover to 1e-5 mbar or below before a new shutdown episode can trigger.
 
 Main Control also uses VTRX pressure to protect CCS output. Stale pressure or
 pressure above 1e-5 mbar starts the configured CCS grace-period timer only when
@@ -254,9 +256,10 @@ Dashboard callbacks.
   block cathode output enable requests.
 - Disable Beams if pressure exceeds 10^-5 mbar is a runtime Main Control
   setting. When enabled, an unsafe or stale VTRX reading invalidates any pending
-  operator action, logs a critical message, requests tokenized BCON all-off, and
-  clears dashboard interlocks only after a post-command poll confirms all
-  channels OFF. It triggers once until pressure recovers to 1e-5 mbar or below.
+  operator action and requests tokenized BCON all-off. An already-pending
+  all-off Disable All, Disarm, or E-stop covers that request; confirmation keeps
+  the VTRX episode latched, while failure releases it for retry. Dashboard
+  interlocks clear only after a post-command poll confirms all channels OFF.
 - Disable CCS Output after the configured grace period above 10^-5 mbar applies
   when CCS output is active. The grace-period duration is persisted in Main
   Control config, defaults to 30 seconds, blocks new CCS output enables while

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -194,11 +194,13 @@ Dashboard callbacks.
   poll state (`poll`, `off`, or `all_off`), operation kind, lifecycle state,
   timestamps, optional safety cause, and timeout handles. The token is only a
   correlation ID; it is not sent to BCON firmware.
-- A normal action is rejected while another operation is pending. Disarm and
-  safety actions can invalidate/preempt an earlier operator action; a repeated
-  E-stop reuses the pending E-stop token. Sending has a 1.5 s deadline. Once
-  the terminal command is sent, firmware acknowledgement and an eligible full
-  BCON poll share a 1 s deadline.
+- Pending operations follow this priority: E-stop > Disarm > Disable All >
+  normal/interlock actions. Only a higher-priority request can preempt a healthy
+  pending operation; a failed E-stop confirmation remains replaceable for
+  recovery. Repeated disarm requests are coalesced, and a repeated E-stop reuses
+  the pending E-stop token. Sending has a 1.5 s deadline. Once the terminal
+  command is sent, firmware acknowledgement and an eligible full BCON poll
+  share a 1 s deadline.
 - Driver `command_sent`, result, failure, and cancellation events are accepted
   only when their token matches the pending operation. A full poll is
   intentionally un-tokenized: it is eligible only when it completed after the

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -51,11 +51,12 @@ Main Control is a two-tab subpanel.
 - Launch Log Post-processor button.
 - UI log-level and file log-level dropdowns.
 - Disable CCS Output on BCON Disconnect toggle.
+- Disable CCS Output if pressure exceeds 10^-5 mbar for the configured grace
+  period control.
 - Disable Beams if pressure exceeds 10^-5 mbar toggle.
-- Disable CCS Output after the configured grace period above 10^-5 mbar
-  control.
-- Total Max Emission Current control.
-- 20kV Bertan Current Limit for E-Stop Trigger control.
+- Disable Beams if 20kV Bertan exceeds the configured current limit control.
+- Do not activate Beams if Predicted Emission Current exceeds the configured
+  limit control.
 - F1 keyboard shortcut hint.
 
 ## Code Structure
@@ -69,7 +70,7 @@ Main Control is a two-tab subpanel.
   Pulse output/action status updates, gives Beam Pulse the emission-limit, VTRX
   pressure, and dashboard-software-interlock providers, and wires BCON
   disconnect notifications into Cathode Heating.
-- `wire_beam_energy()` registers the Beam Energy +20 kV current E-stop callback.
+- `wire_beam_energy()` registers the Beam Energy +20 kV current beam-disable callback.
 - `wire_vtrx()` registers the VTRX pressure callback used by the high-pressure
   beam-disable guard.
 - `create_com_port_frame()`, `apply_com_port_changes()`, and related helpers
@@ -78,9 +79,9 @@ Main Control is a two-tab subpanel.
   limit through `usr/main_control_config.py`.
 - `set_vtrx_ccs_disable_grace_period()` validates and persists the VTRX
   high-pressure CCS shutdown grace period through `usr/main_control_config.py`.
-- `set_beams_estop_current_limit()` validates the operator-entered +20 kV
-  E-stop current limit, persists it through `usr/main_control_config.py`, and
-  applies the runtime value to Beam Energy.
+- `set_beams_disable_current_limit()` validates the operator-entered +20 kV
+  automatic beam-disable current limit, persists it through
+  `usr/main_control_config.py`, and applies the runtime value to Beam Energy.
 - `toggle_disable_ccs_output_on_bcon_disconnect()` updates the runtime
   BCON/CCS guard setting and propagates it to Cathode Heating.
 
@@ -149,11 +150,13 @@ Main Control uses Cathode Heating in several ways:
 ### Beam Energy
 
 Beam Energy owns Knob Box monitoring and warning thresholds. Main Control owns
-the 20kV Bertan Current Limit for E-Stop Trigger setting: it validates and
+the 20kV Bertan automatic beam-disarm current-limit setting: it validates and
 persists the entry, sends the numeric value to Beam Energy, and registers a
-callback with Beam Energy through `set_beams_estop_callback()`. Beam Energy uses
+callback with Beam Energy through `set_beams_disable_callback()`. Beam Energy uses
 the Main Control-provided value during each Knob Box poll; when +20 kV current
-reaches that value, it calls Main Control's `E-STOP: BEAMS & CCS` path.
+reaches that value, it calls Main Control's tokenized beam-disarm path. This
+stops active sequences, sends BCON all-off, and clears the armed state after the
+post-command poll confirms all channels OFF.
 
 ### VTRX
 

--- a/subsystem/main_control/README.md
+++ b/subsystem/main_control/README.md
@@ -206,9 +206,9 @@ Dashboard callbacks.
   channel state. Late events from an older token are ignored.
 - A normal-action timeout releases the pending-operation slot, logs the token,
   action, channels, elapsed time, and unknown firmware outcome, and leaves
-  hardware presentation to later polls. Disable-all and E-stop failures/timeouts
-  are logged as CRITICAL, except firmware rejection due to `UNSAFE_INTERLOCK`,
-  which is logged as ERROR.
+  hardware presentation to later polls. Disable-all, disarm, and E-stop
+  failures/timeouts are logged as CRITICAL, except firmware rejection due to
+  `UNSAFE_INTERLOCK`, which is logged as ERROR.
 - An E-STOP confirmation timeout leaves the Beam Pulse arming state unchanged
   and BCON output state unknown. It is logged as CRITICAL, but Main Control
   keeps BCON controls available for an operator recovery attempt.

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -821,7 +821,7 @@ class MainControlPanel:
 
     @staticmethod
     def _is_critical_bcon_operation(op):
-        return op["kind"] in ("disable_all", "estop")
+        return op["kind"] in ("disable_all", "disarm", "estop")
 
     def _start_bcon_operation(self, action, channels, expected="poll", kind="normal",
                               cause=None):
@@ -898,7 +898,7 @@ class MainControlPanel:
     def _invalidate_pending_user_bcon_operation(self, reason):
         """Invalidate an operator action before an automatic safety ALL_OFF."""
         op = getattr(self, "_pending_bcon_operation", None)
-        if not op or self._is_critical_bcon_operation(op) or op["kind"] == "disarm":
+        if not op or self._is_critical_bcon_operation(op):
             return
         self._finish_bcon_operation(op["token"])
         message = f"BCON operation invalidated by {reason}: {self._bcon_operation_details(op)}"

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -456,12 +456,6 @@ class MainControlPanel:
             "disable_ccs_output_on_bcon_disconnect",
             self.toggle_disable_ccs_output_on_bcon_disconnect,
         )
-        self._create_setting_checkbutton(
-            beam_cathode_frame,
-            f"Disable Beams if pressure exceeds {VTRX_BEAM_DISABLE_PRESSURE_LIMIT_MBAR} mbar",
-            "disable_beams_on_vtrx_pressure_exceeded",
-            self.toggle_disable_beams_on_vtrx_pressure_exceeded,
-        )
         self._create_value_setting_controls(
             beam_cathode_frame,
             title_var=self.vtrx_ccs_disable_grace_period_title_var,
@@ -473,16 +467,11 @@ class MainControlPanel:
             enable_setting_attr="vtrx_ccs_pressure_shutdown_enabled",
             enable_command=lambda: self._toggle_value_setting_enabled("vtrx_ccs_pressure_shutdown_enabled"),
         )
-        self._create_value_setting_controls(
+        self._create_setting_checkbutton(
             beam_cathode_frame,
-            title_var=self.total_max_emission_current_title_var,
-            label_text="Max Emission I:",
-            entry_var=self.total_max_emission_current_entry_var,
-            unit_text="mA",
-            command=self.set_total_max_emission_current_limit,
-            value_var=self.total_max_emission_current_value_var,
-            enable_setting_attr="total_max_emission_current_limit_enabled",
-            enable_command=lambda: self._toggle_value_setting_enabled("total_max_emission_current_limit_enabled"),
+            f"Disable Beams if pressure exceeds {VTRX_BEAM_DISABLE_PRESSURE_LIMIT_MBAR} mbar",
+            "disable_beams_on_vtrx_pressure_exceeded",
+            self.toggle_disable_beams_on_vtrx_pressure_exceeded,
         )
         self._create_value_setting_controls(
             beam_cathode_frame,
@@ -494,6 +483,17 @@ class MainControlPanel:
             value_var=self.beams_estop_current_value_var,
             enable_setting_attr="beams_estop_current_limit_enabled",
             enable_command=lambda: self._toggle_value_setting_enabled("beams_estop_current_limit_enabled"),
+        )
+        self._create_value_setting_controls(
+            beam_cathode_frame,
+            title_var=self.total_max_emission_current_title_var,
+            label_text="Max Emission I:",
+            entry_var=self.total_max_emission_current_entry_var,
+            unit_text="mA",
+            command=self.set_total_max_emission_current_limit,
+            value_var=self.total_max_emission_current_value_var,
+            enable_setting_attr="total_max_emission_current_limit_enabled",
+            enable_command=lambda: self._toggle_value_setting_enabled("total_max_emission_current_limit_enabled"),
         )
 
         # Add F1 help hint

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -9,13 +9,13 @@ from tkinter import messagebox, ttk
 import serial.tools.list_ports
 
 from usr.main_control_config import (
-    BEAMS_ESTOP_CURRENT_LIMIT_MAX_MA,
-    BEAMS_ESTOP_CURRENT_LIMIT_MIN_MA,
+    BEAMS_DISABLE_CURRENT_LIMIT_MAX_MA,
+    BEAMS_DISABLE_CURRENT_LIMIT_MIN_MA,
     DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
-    load_beams_estop_current_limit_ma,
+    load_beams_disable_current_limit_ma,
     load_total_max_emission_current,
     load_vtrx_ccs_disable_grace_period_s,
-    save_beams_estop_current_limit_ma,
+    save_beams_disable_current_limit_ma,
     save_total_max_emission_current,
     save_vtrx_ccs_disable_grace_period_s,
 )
@@ -103,20 +103,20 @@ class MainControlPanel:
         self._value_setting_controls = {}
         self.vtrx_ccs_pressure_shutdown_enabled = True
         self.total_max_emission_current_limit_enabled = True
-        self.beams_estop_current_limit_enabled = True
+        self.beams_disable_current_limit_enabled = True
 
         self.total_max_emission_current_ma = load_total_max_emission_current(logger=self.logger)
         self.total_max_emission_current_entry_var = tk.StringVar(value="")
         self.total_max_emission_current_value_var = tk.StringVar(
             value=f"{self.total_max_emission_current_ma:g}"
         )
-        self.beams_estop_current_limit_ma = load_beams_estop_current_limit_ma(logger=self.logger)
-        self.beams_estop_current_entry_var = tk.StringVar(value="")
-        self.beams_estop_current_value_var = tk.StringVar(
-            value=f"{self.beams_estop_current_limit_ma:g}"
+        self.beams_disable_current_limit_ma = load_beams_disable_current_limit_ma(logger=self.logger)
+        self.beams_disable_current_entry_var = tk.StringVar(value="")
+        self.beams_disable_current_value_var = tk.StringVar(
+            value=f"{self.beams_disable_current_limit_ma:g}"
         )
         self.total_max_emission_current_title_var = tk.StringVar(value="")
-        self.beams_estop_current_limit_title_var = tk.StringVar(value="")
+        self.beams_disable_current_limit_title_var = tk.StringVar(value="")
         self.vtrx_ccs_disable_grace_period_entry_var = tk.StringVar(value="")
         self.vtrx_ccs_disable_grace_period_title_var = tk.StringVar(value="")
         self.vtrx_ccs_disable_grace_period_value_var = tk.StringVar(
@@ -156,15 +156,15 @@ class MainControlPanel:
             self.update_com_ports_callback(new_com_ports)
 
     def wire_beam_energy(self, beam_energy):
-        """Register the Beam Energy +20kV current E-stop callback."""
-        if beam_energy is not None and hasattr(beam_energy, "set_beams_estop_callback"):
-            beam_energy.set_beams_estop_callback(
-                lambda: self.handle_beams_off(
-                    "20kV E-Stop Current Limit exceeded: All Beams Disabled"
+        """Register the Beam Energy +20kV current beam-disable callback."""
+        if beam_energy is not None and hasattr(beam_energy, "set_beams_disable_callback"):
+            beam_energy.set_beams_disable_callback(
+                lambda: self._request_disarm_beams(
+                    cause=self._beams_disable_title()
                 )
             )
-        self._apply_beams_estop_current_limit_to_beam_energy(beam_energy)
-        self.refresh_beams_estop_current_limit_display()
+        self._apply_beams_disable_current_limit_to_beam_energy(beam_energy)
+        self.refresh_beams_disable_current_limit_display()
         self._apply_logging_suppression_settings()
 
     def wire_vtrx(self, vtrx):
@@ -475,14 +475,14 @@ class MainControlPanel:
         )
         self._create_value_setting_controls(
             beam_cathode_frame,
-            title_var=self.beams_estop_current_limit_title_var,
+            title_var=self.beams_disable_current_limit_title_var,
             label_text="Max 20kV I:",
-            entry_var=self.beams_estop_current_entry_var,
+            entry_var=self.beams_disable_current_entry_var,
             unit_text="mA",
-            command=self.set_beams_estop_current_limit,
-            value_var=self.beams_estop_current_value_var,
-            enable_setting_attr="beams_estop_current_limit_enabled",
-            enable_command=lambda: self._toggle_value_setting_enabled("beams_estop_current_limit_enabled"),
+            command=self.set_beams_disable_current_limit,
+            value_var=self.beams_disable_current_value_var,
+            enable_setting_attr="beams_disable_current_limit_enabled",
+            enable_command=lambda: self._toggle_value_setting_enabled("beams_disable_current_limit_enabled"),
         )
         self._create_value_setting_controls(
             beam_cathode_frame,
@@ -725,13 +725,8 @@ class MainControlPanel:
         outcome_key = str(outcome).strip().lower()
         message_text = str(message or "")
         is_failure = outcome_key in ("failure", "error")
-        is_20kv_estop = (
-            outcome_key == "estop"
-            and "20kv" in message_text.lower()
-            and "current limit" in message_text.lower()
-        )
         prefix = "FAILURE: " if is_failure else ""
-        color = BEAM_ACTION_FAILURE_COLOR if is_20kv_estop else BEAM_ACTION_NEUTRAL_COLOR
+        color = BEAM_ACTION_NEUTRAL_COLOR
 
         self._beam_action_status_prefix_text = prefix
         self._beam_action_status_text = message_text
@@ -1205,7 +1200,7 @@ class MainControlPanel:
 
         return duration_s
 
-    def _format_beams_estop_current_limit_ma(self, value):
+    def _format_beams_disable_current_limit_ma(self, value):
         try:
             limit_ma = float(value)
         except (TypeError, ValueError):
@@ -1216,28 +1211,28 @@ class MainControlPanel:
 
         return f"{limit_ma:g}"
 
-    def _apply_beams_estop_current_limit_to_beam_energy(self, beam_energy=None):
+    def _apply_beams_disable_current_limit_to_beam_energy(self, beam_energy=None):
         if beam_energy is None:
             beam_energy = getattr(self, "subsystems", {}).get("Beam Energy")
-        setter = getattr(beam_energy, "set_beams_estop_current_limit_ma", None)
+        setter = getattr(beam_energy, "set_beams_disable_current_limit_ma", None)
         if not callable(setter):
             return False
 
         try:
-            setter(self.beams_estop_current_limit_ma)
+            setter(self.beams_disable_current_limit_ma)
         except Exception as e:
-            self._log_warning(
-                f"20kV Bertan Current Limit for E-Stop Trigger: Beam Energy update failed ({e})."
+            self._log_critical(
+                f"20kV Bertan Current Limit for Automatic Beam Disarm: Beam Energy update failed ({e})."
             )
             return False
 
-        enabled_setter = getattr(beam_energy, "set_beams_estop_current_limit_enabled", None)
+        enabled_setter = getattr(beam_energy, "set_beams_disable_current_limit_enabled", None)
         if callable(enabled_setter):
             try:
-                enabled_setter(bool(getattr(self, "beams_estop_current_limit_enabled", True)))
+                enabled_setter(bool(getattr(self, "beams_disable_current_limit_enabled", True)))
             except Exception as e:
-                self._log_warning(
-                    f"20kV Bertan Current Limit for E-Stop Trigger: Beam Energy enable update failed ({e})."
+                self._log_critical(
+                    f"20kV Bertan Current Limit for Automatic Beam Disarm: Beam Energy enable update failed ({e})."
                 )
         return True
 
@@ -1250,11 +1245,11 @@ class MainControlPanel:
         grace_period_s = self._coerce_vtrx_ccs_disable_grace_period_s(
             getattr(self, "vtrx_ccs_disable_grace_period_s", None)
         )
-        total_emission_ma = self._format_beams_estop_current_limit_ma(
+        total_emission_ma = self._format_beams_disable_current_limit_ma(
             getattr(self, "total_max_emission_current_ma", None)
         )
-        beams_estop_ma = self._format_beams_estop_current_limit_ma(
-            getattr(self, "beams_estop_current_limit_ma", None)
+        beams_disable_ma = self._format_beams_disable_current_limit_ma(
+            getattr(self, "beams_disable_current_limit_ma", None)
         )
 
         _set_var("vtrx_ccs_disable_grace_period_title_var", self._vtrx_ccs_shutdown_title())
@@ -1267,13 +1262,13 @@ class MainControlPanel:
             "total_max_emission_current_value_var",
             total_emission_ma,
         )
-        _set_var("beams_estop_current_limit_title_var", self._beams_estop_title())
+        _set_var("beams_disable_current_limit_title_var", self._beams_disable_title())
         _set_var(
-            "beams_estop_current_value_var",
-            beams_estop_ma,
+            "beams_disable_current_value_var",
+            beams_disable_ma,
         )
 
-    def refresh_beams_estop_current_limit_display(self):
+    def refresh_beams_disable_current_limit_display(self):
         self.refresh_value_setting_displays()
 
     def _vtrx_ccs_shutdown_title(self):
@@ -1286,24 +1281,24 @@ class MainControlPanel:
         )
 
     def _emission_activation_title(self):
-        limit_ma = self._format_beams_estop_current_limit_ma(
+        limit_ma = self._format_beams_disable_current_limit_ma(
             getattr(self, "total_max_emission_current_ma", None)
         )
         return f"Do not activate Beams if Predicted Emission Current exceeds {limit_ma}mA"
 
-    def _beams_estop_title(self):
-        limit_ma = self._format_beams_estop_current_limit_ma(
-            getattr(self, "beams_estop_current_limit_ma", None)
+    def _beams_disable_title(self):
+        limit_ma = self._format_beams_disable_current_limit_ma(
+            getattr(self, "beams_disable_current_limit_ma", None)
         )
-        return f"Trigger E-Stop if 20kV Bertan exceeds {limit_ma}mA"
+        return f"Disable Beams if 20kV Bertan exceeds {limit_ma}mA"
 
     def _value_setting_title(self, setting_attr):
         if setting_attr == "vtrx_ccs_pressure_shutdown_enabled":
             return self._vtrx_ccs_shutdown_title()
         if setting_attr == "total_max_emission_current_limit_enabled":
             return self._emission_activation_title()
-        if setting_attr == "beams_estop_current_limit_enabled":
-            return self._beams_estop_title()
+        if setting_attr == "beams_disable_current_limit_enabled":
+            return self._beams_disable_title()
         return str(setting_attr)
 
     def _create_setting_checkbutton(self, parent_frame, label, setting_attr, command):
@@ -1373,8 +1368,8 @@ class MainControlPanel:
         if setting_attr == "vtrx_ccs_pressure_shutdown_enabled" and not enabled:
             self._clear_vtrx_ccs_disable_timer()
         self._refresh_value_setting_control_state(setting_attr)
-        if setting_attr == "beams_estop_current_limit_enabled":
-            self._apply_beams_estop_current_limit_to_beam_energy()
+        if setting_attr == "beams_disable_current_limit_enabled":
+            self._apply_beams_disable_current_limit_to_beam_energy()
         state = "enabled" if enabled else "disabled"
         self._log_info(f"{self._value_setting_title(setting_attr)} {state}")
 
@@ -1529,11 +1524,11 @@ class MainControlPanel:
                 f"{self._vtrx_ccs_shutdown_title()}: setting successfully changed."
             )
 
-    def set_beams_estop_current_limit(self):
-        """UI callback for committing the Beam Energy +20kV Beams E-STOP current limit."""
-        context = "Trigger E-Stop if 20kV Bertan exceeds"
+    def set_beams_disable_current_limit(self):
+        """UI callback for committing the Beam Energy +20kV beam-disable current limit."""
+        context = "Disable Beams if 20kV Bertan exceeds"
         new_value = self._read_non_negative_setting_value(
-            self.beams_estop_current_entry_var,
+            self.beams_disable_current_entry_var,
             context,
             "limit",
             "mA",
@@ -1541,21 +1536,21 @@ class MainControlPanel:
         if new_value is None:
             return
 
-        if not BEAMS_ESTOP_CURRENT_LIMIT_MIN_MA <= new_value <= BEAMS_ESTOP_CURRENT_LIMIT_MAX_MA:
+        if not BEAMS_DISABLE_CURRENT_LIMIT_MIN_MA <= new_value <= BEAMS_DISABLE_CURRENT_LIMIT_MAX_MA:
             message = (
-                f"{context}: value must be between {BEAMS_ESTOP_CURRENT_LIMIT_MIN_MA:g}mA "
-                f"and {BEAMS_ESTOP_CURRENT_LIMIT_MAX_MA:g}mA."
+                f"{context}: value must be between {BEAMS_DISABLE_CURRENT_LIMIT_MIN_MA:g}mA "
+                f"and {BEAMS_DISABLE_CURRENT_LIMIT_MAX_MA:g}mA."
             )
             self._log_warning(message)
             messagebox.showerror("Invalid Input", message)
             return
 
-        self.beams_estop_current_limit_ma = new_value
-        self.beams_estop_current_entry_var.set("")
+        self.beams_disable_current_limit_ma = new_value
+        self.beams_disable_current_entry_var.set("")
         self.refresh_value_setting_displays()
-        beam_energy_updated = self._apply_beams_estop_current_limit_to_beam_energy()
+        beam_energy_updated = self._apply_beams_disable_current_limit_to_beam_energy()
 
-        if not save_beams_estop_current_limit_ma(new_value, logger=self.logger):
+        if not save_beams_disable_current_limit_ma(new_value, logger=self.logger):
             message = f"{context}: value was updated for this session but could not be saved."
             self._log_warning(message)
             messagebox.showwarning("Save Failed", message)
@@ -1566,7 +1561,7 @@ class MainControlPanel:
             return
 
         self._log_info(
-            f"{self._beams_estop_title()}: setting successfully changed."
+            f"{self._beams_disable_title()}: setting successfully changed."
         )
 
     def create_post_processor_button(self, parent_frame):
@@ -1941,6 +1936,29 @@ class MainControlPanel:
         if not token:
             return False
         return bool(disable_all_beams(operation_token=token, defer_ui=True))
+
+    def _request_disarm_beams(self, cause=None):
+        """Request tokenized beam disarm without depending on the ARM button toggle."""
+        beam_pulse = self._get_beam_pulse_or_fail("disarm beams")
+        if beam_pulse is None:
+            return False
+        disarm_beams = getattr(beam_pulse, "disarm_beams", None)
+        if not callable(disarm_beams):
+            self._set_beam_action_status(
+                "Failed to disarm beams, Beam Pulse API not available",
+                "failure",
+            )
+            return False
+        token = self._start_bcon_operation(
+            "Disarm Beams command: all channels mode=OFF",
+            range(3),
+            expected="all_off",
+            kind="disarm",
+            cause=cause,
+        )
+        if not token:
+            return False
+        return bool(disarm_beams(operation_token=token, defer_ui=True))
 
     def handle_disable_all_beams(self):
         self._request_disable_all_beams()

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -1302,7 +1302,7 @@ class MainControlPanel:
         limit_ma = self._format_beams_disable_current_limit_ma(
             getattr(self, "beams_disable_current_limit_ma", None)
         )
-        return f"Disable Beams if 20kV Bertan exceeds {limit_ma}mA"
+        return f"Disable Beams if 20kV Bertan reaches or exceeds {limit_ma}mA"
 
     def _value_setting_title(self, setting_attr):
         if setting_attr == "vtrx_ccs_pressure_shutdown_enabled":

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -34,6 +34,11 @@ VTRX_CCS_DISABLE_PRESSURE_LIMIT_MBAR = 1e-5
 VTRX_CCS_DISABLE_WARNING_INTERVAL_S = 10.0
 BCON_SEND_TIMEOUT_MS = 1500
 BCON_ACK_POLL_TIMEOUT_MS = 1000
+BCON_OPERATION_PRIORITY = {
+    "disable_all": 1,
+    "disarm": 2,
+    "estop": 3,
+}
 
 
 def channel_label(index: int) -> str:
@@ -820,33 +825,40 @@ class MainControlPanel:
         return f"token={op['token']}, action={op['action']}, channels={channels}"
 
     @staticmethod
+    def _bcon_operation_priority(kind):
+        return BCON_OPERATION_PRIORITY.get(kind, 0)
+
+    @staticmethod
     def _is_critical_bcon_operation(op):
-        return op["kind"] in ("disable_all", "disarm", "estop")
+        return MainControlPanel._bcon_operation_priority(op["kind"]) > 0
 
     def _start_bcon_operation(self, action, channels, expected="poll", kind="normal",
                               cause=None):
         """Create the one dashboard operation allowed to await a BCON result."""
         self._initialize_main_control_beam_status_state()
         pending = self._pending_bcon_operation
-        if pending and pending["kind"] == "estop":
-            if kind == "estop":
-                return pending["token"]
-            if not pending.get("safety_failed"):
-                self._log_warning(
-                    f"Failed to send {action}, Dashboard is waiting for E-STOP confirmation.")
-                return None
-            self._finish_bcon_operation(pending["token"])
-            self._log_warning(
-                f"{action} is proceeding after failed E-STOP confirmation "
-                f"({self._bcon_operation_details(pending)}).")
-            pending = None
-        if pending and kind == "normal":
-            self._log_warning(
-                f"Failed to send {action}, Dashboard waiting for firmware response from the previous command.")
-            return None
         if pending:
-            self._finish_bcon_operation(pending["token"])
-            self._log_warning(f"{action} interrupted pending BCON operation {pending['token']}")
+            pending_kind = pending["kind"]
+            if pending_kind == "estop" and kind == "estop":
+                return pending["token"]
+            if pending_kind == "estop" and pending.get("safety_failed"):
+                self._finish_bcon_operation(pending["token"])
+                self._log_warning(
+                    f"{action} is proceeding after failed E-STOP confirmation "
+                    f"({self._bcon_operation_details(pending)}).")
+            elif (
+                self._bcon_operation_priority(pending_kind)
+                >= self._bcon_operation_priority(kind)
+            ):
+                self._log_warning(
+                    f"Failed to send {action}, Dashboard is waiting for "
+                    f"{pending['action']} confirmation.")
+                return None
+            else:
+                self._finish_bcon_operation(pending["token"])
+                self._log_warning(
+                    f"{action} preempted lower-priority BCON operation "
+                    f"{pending['token']}.")
         self._bcon_operation_counter += 1
         token = f"bcon-{self._bcon_operation_counter}"
         op = {
@@ -1939,6 +1951,9 @@ class MainControlPanel:
 
     def _request_disarm_beams(self, cause=None):
         """Request tokenized beam disarm without depending on the ARM button toggle."""
+        pending = getattr(self, "_pending_bcon_operation", None)
+        if pending and pending["kind"] == "disarm":
+            return True
         beam_pulse = self._get_beam_pulse_or_fail("disarm beams")
         if beam_pulse is None:
             return False
@@ -1974,21 +1989,7 @@ class MainControlPanel:
             is_armed = bool(get_armed()) if callable(get_armed) else False
 
             if is_armed:
-                disarm_beams = getattr(beam_pulse, "disarm_beams", None)
-                if not callable(disarm_beams):
-                    self._log_error("Failed to disarm beams: Beam Pulse disarm API is unavailable")
-                    self._set_beam_action_status(
-                        "Failed to disarm beams: Beam Pulse disarm API is unavailable",
-                        "failure",
-                    )
-                    return
-                token = self._start_bcon_operation(
-                    "Disarm Beams command: all channels mode=OFF", range(3),
-                    expected="all_off", kind="disarm")
-                if not token:
-                    return
-                if not disarm_beams(operation_token=token, defer_ui=True):
-                    return
+                self._request_disarm_beams()
             else:
                 arm_beams = getattr(beam_pulse, "arm_beams", None)
                 if callable(arm_beams) and arm_beams():

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -837,9 +837,6 @@ class MainControlPanel:
         """Create the one dashboard operation allowed to await a BCON result."""
         self._initialize_main_control_beam_status_state()
         pending = self._pending_bcon_operation
-        covers_vtrx_beam_disable = bool(
-            pending and pending.get("covers_vtrx_beam_disable")
-        )
         if pending:
             pending_kind = pending["kind"]
             if pending_kind == "estop" and kind == "estop":
@@ -862,13 +859,6 @@ class MainControlPanel:
                 self._log_warning(
                     f"{action} preempted lower-priority BCON operation "
                     f"{pending['token']}.")
-        replacement_covers_vtrx = (
-            covers_vtrx_beam_disable
-            and kind in BCON_OPERATION_PRIORITY
-            and expected == "all_off"
-        )
-        if covers_vtrx_beam_disable and not replacement_covers_vtrx:
-            self._release_vtrx_beam_disable_coverage(pending)
         self._bcon_operation_counter += 1
         token = f"bcon-{self._bcon_operation_counter}"
         op = {
@@ -876,7 +866,6 @@ class MainControlPanel:
             "expected": expected, "kind": kind, "state": "awaiting_send",
             "created_at": time.monotonic(), "sent_at": None,
             "cause": str(cause or ""),
-            "covers_vtrx_beam_disable": replacement_covers_vtrx,
             "safety_failed": False, "safety_failure_logged": False,
             "send_after": None, "ack_after": None,
         }
@@ -918,8 +907,9 @@ class MainControlPanel:
         self._pending_bcon_operation = None
         return op
 
-    def _release_vtrx_beam_disable_coverage(self, op):
-        if op.get("covers_vtrx_beam_disable"):
+    def _release_vtrx_latch_after_all_off_failure(self, op):
+        """Allow unsafe VTRX pressure to retry an unsuccessful all-off."""
+        if op.get("expected") == "all_off":
             self._vtrx_pressure_beam_disable_latched = False
 
     def _invalidate_pending_user_bcon_operation(self, reason):
@@ -938,7 +928,7 @@ class MainControlPanel:
         if not op:
             return
         self._finish_bcon_operation(op["token"])
-        self._release_vtrx_beam_disable_coverage(op)
+        self._release_vtrx_latch_after_all_off_failure(op)
         message = (
             f"BCON operation terminated by {reason} ({self._bcon_operation_details(op)}); "
             "firmware outcome is unknown"
@@ -950,6 +940,7 @@ class MainControlPanel:
     def _hold_estop_for_poll_after_failure(self, op):
         """Keep E-stop active so a later full poll still drives the UI state."""
         op["safety_failed"] = True
+        self._release_vtrx_latch_after_all_off_failure(op)
         op["state"] = "awaiting_poll"
         self._schedule_bcon_timeout(op, "ack", BCON_ACK_POLL_TIMEOUT_MS)
 
@@ -978,7 +969,7 @@ class MainControlPanel:
                 "firmware outcome is unknown or unconfirmed"
             )
         self._finish_bcon_operation(token)
-        self._release_vtrx_beam_disable_coverage(op)
+        self._release_vtrx_latch_after_all_off_failure(op)
         log = self._log_critical if self._is_critical_bcon_operation(op) else self._log_error
         log(message)
         self._set_beam_action_status(message, "failure")
@@ -1079,7 +1070,7 @@ class MainControlPanel:
                     self._set_beam_action_status(message, "failure")
                     return
                 self._finish_bcon_operation(token)
-                self._release_vtrx_beam_disable_coverage(op)
+                self._release_vtrx_latch_after_all_off_failure(op)
                 log = (
                     self._log_critical
                     if self._is_critical_bcon_operation(op) and not hardware_interlock_rejection
@@ -1113,7 +1104,7 @@ class MainControlPanel:
             self._set_beam_action_status(message, "failure")
             return
         self._finish_bcon_operation(token)
-        self._release_vtrx_beam_disable_coverage(op)
+        self._release_vtrx_latch_after_all_off_failure(op)
         if cancelled:
             log = self._log_warning
         else:
@@ -1880,10 +1871,9 @@ class MainControlPanel:
         pending = getattr(self, "_pending_bcon_operation", None)
         if (
             pending
-            and pending["kind"] in ("disable_all", "disarm", "estop")
             and pending["expected"] == "all_off"
+            and not pending.get("safety_failed")
         ):
-            pending["covers_vtrx_beam_disable"] = True
             return
 
         try:
@@ -1891,10 +1881,6 @@ class MainControlPanel:
             if not self._request_disable_all_beams(cause=cause):
                 self._vtrx_pressure_beam_disable_latched = False
                 self._log_critical("VTRX pressure beam disable failed: BCON all-off was not confirmed")
-            else:
-                pending = getattr(self, "_pending_bcon_operation", None)
-                if pending and pending["kind"] == "disable_all":
-                    pending["covers_vtrx_beam_disable"] = True
         except Exception as e:
             self._vtrx_pressure_beam_disable_latched = False
             self._log_critical(f"VTRX pressure beam disable failed: {e}")

--- a/subsystem/main_control/main_control.py
+++ b/subsystem/main_control/main_control.py
@@ -837,6 +837,9 @@ class MainControlPanel:
         """Create the one dashboard operation allowed to await a BCON result."""
         self._initialize_main_control_beam_status_state()
         pending = self._pending_bcon_operation
+        covers_vtrx_beam_disable = bool(
+            pending and pending.get("covers_vtrx_beam_disable")
+        )
         if pending:
             pending_kind = pending["kind"]
             if pending_kind == "estop" and kind == "estop":
@@ -859,6 +862,13 @@ class MainControlPanel:
                 self._log_warning(
                     f"{action} preempted lower-priority BCON operation "
                     f"{pending['token']}.")
+        replacement_covers_vtrx = (
+            covers_vtrx_beam_disable
+            and kind in BCON_OPERATION_PRIORITY
+            and expected == "all_off"
+        )
+        if covers_vtrx_beam_disable and not replacement_covers_vtrx:
+            self._release_vtrx_beam_disable_coverage(pending)
         self._bcon_operation_counter += 1
         token = f"bcon-{self._bcon_operation_counter}"
         op = {
@@ -866,6 +876,7 @@ class MainControlPanel:
             "expected": expected, "kind": kind, "state": "awaiting_send",
             "created_at": time.monotonic(), "sent_at": None,
             "cause": str(cause or ""),
+            "covers_vtrx_beam_disable": replacement_covers_vtrx,
             "safety_failed": False, "safety_failure_logged": False,
             "send_after": None, "ack_after": None,
         }
@@ -907,6 +918,10 @@ class MainControlPanel:
         self._pending_bcon_operation = None
         return op
 
+    def _release_vtrx_beam_disable_coverage(self, op):
+        if op.get("covers_vtrx_beam_disable"):
+            self._vtrx_pressure_beam_disable_latched = False
+
     def _invalidate_pending_user_bcon_operation(self, reason):
         """Invalidate an operator action before an automatic safety ALL_OFF."""
         op = getattr(self, "_pending_bcon_operation", None)
@@ -923,6 +938,7 @@ class MainControlPanel:
         if not op:
             return
         self._finish_bcon_operation(op["token"])
+        self._release_vtrx_beam_disable_coverage(op)
         message = (
             f"BCON operation terminated by {reason} ({self._bcon_operation_details(op)}); "
             "firmware outcome is unknown"
@@ -962,6 +978,7 @@ class MainControlPanel:
                 "firmware outcome is unknown or unconfirmed"
             )
         self._finish_bcon_operation(token)
+        self._release_vtrx_beam_disable_coverage(op)
         log = self._log_critical if self._is_critical_bcon_operation(op) else self._log_error
         log(message)
         self._set_beam_action_status(message, "failure")
@@ -1062,6 +1079,7 @@ class MainControlPanel:
                     self._set_beam_action_status(message, "failure")
                     return
                 self._finish_bcon_operation(token)
+                self._release_vtrx_beam_disable_coverage(op)
                 log = (
                     self._log_critical
                     if self._is_critical_bcon_operation(op) and not hardware_interlock_rejection
@@ -1095,6 +1113,7 @@ class MainControlPanel:
             self._set_beam_action_status(message, "failure")
             return
         self._finish_bcon_operation(token)
+        self._release_vtrx_beam_disable_coverage(op)
         if cancelled:
             log = self._log_warning
         else:
@@ -1858,11 +1877,26 @@ class MainControlPanel:
             cause = "VTRX pressure reading stale safety shutdown"
             self._log_critical("VTRX pressure reading is stale; disabling all beams.")
 
+        pending = getattr(self, "_pending_bcon_operation", None)
+        if (
+            pending
+            and pending["kind"] in ("disable_all", "disarm", "estop")
+            and pending["expected"] == "all_off"
+        ):
+            pending["covers_vtrx_beam_disable"] = True
+            return
+
         try:
             self._invalidate_pending_user_bcon_operation("VTRX pressure safety shutdown")
             if not self._request_disable_all_beams(cause=cause):
+                self._vtrx_pressure_beam_disable_latched = False
                 self._log_critical("VTRX pressure beam disable failed: BCON all-off was not confirmed")
+            else:
+                pending = getattr(self, "_pending_bcon_operation", None)
+                if pending and pending["kind"] == "disable_all":
+                    pending["covers_vtrx_beam_disable"] = True
         except Exception as e:
+            self._vtrx_pressure_beam_disable_latched = False
             self._log_critical(f"VTRX pressure beam disable failed: {e}")
 
     def _handle_vtrx_pressure_update(self, pressure_mbar, pressure_reading_is_fresh=False, firmware_error=False):

--- a/usr/main_control_config.py
+++ b/usr/main_control_config.py
@@ -6,22 +6,22 @@ import os
 CONFIG_FILE = "usr/usr_data/main_control_config.json"
 DEFAULT_TOTAL_MAX_EMISSION_CURRENT_MA = 6.0
 DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S = 30.0
-DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA = 0.7
-BEAMS_ESTOP_CURRENT_LIMIT_MIN_MA = 0.0
-BEAMS_ESTOP_CURRENT_LIMIT_MAX_MA = 1.0
+DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA = 0.7
+BEAMS_DISABLE_CURRENT_LIMIT_MIN_MA = 0.0
+BEAMS_DISABLE_CURRENT_LIMIT_MAX_MA = 1.0
 TOTAL_MAX_EMISSION_CURRENT_FIELD = "total_max_emission_current_ma"
 VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD = "vtrx_ccs_disable_grace_period_s"
-BEAMS_ESTOP_CURRENT_LIMIT_FIELD = "beams_estop_current_limit_ma"
+BEAMS_DISABLE_CURRENT_LIMIT_FIELD = "beams_disable_current_limit_ma"
 
 _DEFAULTS = {
     TOTAL_MAX_EMISSION_CURRENT_FIELD: DEFAULT_TOTAL_MAX_EMISSION_CURRENT_MA,
     VTRX_CCS_DISABLE_GRACE_PERIOD_FIELD: DEFAULT_VTRX_CCS_DISABLE_GRACE_PERIOD_S,
-    BEAMS_ESTOP_CURRENT_LIMIT_FIELD: DEFAULT_BEAMS_ESTOP_CURRENT_LIMIT_MA,
+    BEAMS_DISABLE_CURRENT_LIMIT_FIELD: DEFAULT_BEAMS_DISABLE_CURRENT_LIMIT_MA,
 }
 _FIELD_RANGES = {
-    BEAMS_ESTOP_CURRENT_LIMIT_FIELD: (
-        BEAMS_ESTOP_CURRENT_LIMIT_MIN_MA,
-        BEAMS_ESTOP_CURRENT_LIMIT_MAX_MA,
+    BEAMS_DISABLE_CURRENT_LIMIT_FIELD: (
+        BEAMS_DISABLE_CURRENT_LIMIT_MIN_MA,
+        BEAMS_DISABLE_CURRENT_LIMIT_MAX_MA,
     ),
 }
 
@@ -81,8 +81,12 @@ def _read_config(filepath, logger=None):
 
 
 def _normalize_config(config, logger=None):
-    normalized = dict(config)
-    changed = False
+    normalized = {
+        field: config[field]
+        for field in _DEFAULTS
+        if field in config
+    }
+    changed = len(normalized) != len(config)
     for field, default_value in _DEFAULTS.items():
         value = _as_field_value(field, normalized.get(field))
         if value is None:
@@ -161,15 +165,15 @@ def save_vtrx_ccs_disable_grace_period_s(value, filepath=CONFIG_FILE, logger=Non
     )
 
 
-def load_beams_estop_current_limit_ma(filepath=CONFIG_FILE, logger=None):
-    """Load the persisted +20kV Beams E-STOP current limit."""
-    return _load_field(BEAMS_ESTOP_CURRENT_LIMIT_FIELD, filepath=filepath, logger=logger)
+def load_beams_disable_current_limit_ma(filepath=CONFIG_FILE, logger=None):
+    """Load the persisted +20kV automatic beam-disable current limit."""
+    return _load_field(BEAMS_DISABLE_CURRENT_LIMIT_FIELD, filepath=filepath, logger=logger)
 
 
-def save_beams_estop_current_limit_ma(value, filepath=CONFIG_FILE, logger=None):
-    """Persist the +20kV Beams E-STOP current limit."""
+def save_beams_disable_current_limit_ma(value, filepath=CONFIG_FILE, logger=None):
+    """Persist the +20kV automatic beam-disable current limit."""
     return _save_field(
-        BEAMS_ESTOP_CURRENT_LIMIT_FIELD,
+        BEAMS_DISABLE_CURRENT_LIMIT_FIELD,
         value,
         filepath=filepath,
         logger=logger,


### PR DESCRIPTION
PR Summary:

1. Reorder and Rename some of the Main Control Config settings to be clearer, and grouped together
<img width="383" height="225" alt="image" src="https://github.com/user-attachments/assets/b363e118-50ea-40dd-94dc-ae2fb70dc9ae" />

2. Change 20kV Current automatic shutoff to disable and disarm beams instead of calling the E-STOP. This is because the E-Stop essentially does the same thing that Knob Box does right now, except much, much slower. The initial intention behind this setting was to only shut off Beams by turning grids negative, while keeping CCS on, acting as a soft shutoff. The dashboard previously had multiple things called E-Stop, this lead to some confusion about which automatic responses call which E-Stops. There is now only 1 E-stop which shuts off CCS output and Beams. Most of this PR is removing any 'E-stop' language from the disable beams since it does not call the E-Stop.
3. VTRX pressure automatic beams shutdown now uses the existing global pressure latch. A healthy pending all-off operation suppresses a redundant request; any unsuccessful all-off outcome releases the latch so unsafe pressure can retry beams off.

This PR looks quite large, but around 250 lines are simply being renamed, and 400 lines of tests were added. So the line diff looks disproportionately large for the actually quite subtle code changes. 

