### PR TITLE
Bugfix: CCS Overtemp Log Rate Limit

### DIFF
--- a/subsystem/cathode_heating/README.md
+++ b/subsystem/cathode_heating/README.md
@@ -301,7 +301,7 @@ Important nuances:
 When the measured temperature is above the configured limit:
 
 - The measured clamp-temperature box turns orange.
-- A critical log entry is emitted: `Cathode X OVERTEMP!`.
+- A critical log entry is emitted immediately and then at most once every 10 seconds per cathode while the condition persists: `Cathode X OVERTEMP!`.
 
 When temperature returns below the limit, the measured temperature box returns to the normal measured-output background and status returns to `Normal`. If temperature is unavailable, status becomes `N/A` and the box is also returned to normal.
 

--- a/subsystem/cathode_heating/cathode_heating.py
+++ b/subsystem/cathode_heating/cathode_heating.py
@@ -51,6 +51,7 @@ class CathodeHeatingSubsystem:
     TEMPERATURE_GRAPHS_ENABLED = False  # Flip to True to restore the CCS temperature graphs.
     MAX_POINTS = 60  # Maximum number of points to display on the plot
     OVERTEMP_THRESHOLD = 200.0 # Overtemperature threshold in C
+    OVERTEMP_LOG_INTERVAL_SECONDS = 10.0
     POLL_ERROR_LOG_INTERVAL_SECONDS = 10.0
     WORKER_LOG_QUEUE_MAXSIZE = 1000
     DEFAULT_VOLTAGE_DIFF_WARNING_PERCENT = 10.0
@@ -207,6 +208,7 @@ class CathodeHeatingSubsystem:
         self.toggle_states = [False for _ in range(3)]
         self._latest_clamp_temperatures = [None for _ in range(3)]
         self._overtemp_limit_values = [self.OVERTEMP_THRESHOLD for _ in range(3)]
+        self._overtemp_last_log_times = [None for _ in range(3)]
         self.power_supply_poll_interval = 0.5
         self.power_supply_poll_thread = None
         self.power_supply_poll_stop_event = threading.Event()
@@ -2666,18 +2668,32 @@ class CathodeHeatingSubsystem:
             if temperature is not None:
                 if temperature > self.overtemp_limit_vars[i].get():
                     self.overtemp_status_vars[i].set("OVERTEMP!")
-                    self.log(f"Cathode {['A', 'B', 'C'][i]} OVERTEMP!", LogLevel.CRITICAL)
+                    self._log_overtemp_rate_limited(i)
                     self._set_measured_temperature_warning_box(i, True)
                 else:
+                    self._overtemp_last_log_times[i] = None
                     self.overtemp_status_vars[i].set('Normal')
                     self._set_measured_temperature_warning_box(i, False)
             else:
+                self._overtemp_last_log_times[i] = None
                 self.overtemp_status_vars[i].set('N/A')
                 self._set_measured_temperature_warning_box(i, False)
 
             # Update the plot for current cathode
             if plot_this_cycle:  # Ensure plots are updated only when new data is plotted
                 self.update_plot(i)
+
+    def _log_overtemp_rate_limited(self, index):
+        now = time.monotonic()
+        last_logged = self._overtemp_last_log_times[index]
+        if (
+            last_logged is not None
+            and now - last_logged < self.OVERTEMP_LOG_INTERVAL_SECONDS
+        ):
+            return
+
+        self._overtemp_last_log_times[index] = now
+        self.log(f"Cathode {['A', 'B', 'C'][index]} OVERTEMP!", LogLevel.CRITICAL)
 
     def cancel_updates(self):
         '''Cancel after() scheduled updates, to be called by dashboard when app is quit.'''

--- a/test_procedures/CCS_test_plan.md
+++ b/test_procedures/CCS_test_plan.md
@@ -1786,10 +1786,10 @@ limit configured; outputs OFF.
 
 | Test steps | Expected results | Notes |
 |---|---|---|
-| 1. Raise temperature above the limit and hold for 5 s. | One breach transition is logged at CRITICAL and UI remains orange/OVERTEMP; duplicate CRITICAL records do not appear every refresh. | |
-| 2. Continue holding for another 10 s. | No additional CRITICAL transition is emitted for the same continuous breach; UI remains OVERTEMP/orange. | |
+| 1. Raise temperature above the limit and hold for 5 s. | One breach transition is logged at CRITICAL and UI remains orange/OVERTEMP. | |
+| 2. Continue holding for another 5 s. | No additional CRITICAL transition is emitted for the same continuous breach; UI remains OVERTEMP/orange. | |
 | 3. Allow temperature below the limit. | One recovery transition is recorded and highlight clears. | |
-| 4. Raise it above again after full recovery. | A new breach produces one new CRITICAL transition. | |
+| 4. Raise it above again after full recovery. | A new breach produces one new CRITICAL transition every 10s. | |
 | 5. Restore 200 C. | Baseline returns Normal. | |
 
 ### CCS-11.8 - Invalid-data telemetry hygiene


### PR DESCRIPTION
This PR adds a 10 second rate limit to CCS overtemp logs, which were previously posted every 0.5 seconds. 